### PR TITLE
fix(cli): align scaffolded state metadata with workflow mode

### DIFF
--- a/.oat/templates/state.md
+++ b/.oat/templates/state.md
@@ -3,13 +3,13 @@ oat_current_task: null
 oat_last_commit: null
 oat_blockers: []
 associated_issues: [] # [{type: backlog|project|jira|linear, ref: "identifier"}]
-oat_hill_checkpoints: ['discovery', 'spec', 'design'] # Configured: which phases require human-in-the-loop lifecycle approval
+oat_hill_checkpoints: { OAT_HILL_CHECKPOINTS } # Configured: which phases require human-in-the-loop lifecycle approval
 oat_hill_completed: [] # Progress: which HiLL checkpoints have been completed
 oat_parallel_execution: false
-oat_phase: discovery # Current phase: discovery | spec | design | plan | implement
+oat_phase: { OAT_PHASE } # Current phase: discovery | spec | design | plan | implement
 oat_phase_status: in_progress # Status: in_progress | complete
 oat_execution_mode: single-thread # single-thread | subagent-driven
-oat_workflow_mode: spec-driven # spec-driven | quick | import
+oat_workflow_mode: { OAT_WORKFLOW_MODE } # spec-driven | quick | import
 oat_workflow_origin: native # native | imported
 oat_docs_updated: null # null | skipped | complete — documentation sync status
 oat_project_created: null # ISO 8601 UTC timestamp — set once at project creation
@@ -22,26 +22,21 @@ oat_template_name: state
 
 # Project State: {Project Name}
 
-**Status:** Discovery
+**Status:** {OAT_STATUS}
 **Started:** YYYY-MM-DD
 **Last Updated:** YYYY-MM-DD
 
 ## Current Phase
 
-Discovery - Gathering requirements and understanding the problem space
+{OAT_CURRENT_PHASE}
 
 ## Artifacts
 
-- **Discovery:** `discovery.md` (in_progress)
-- **Spec:** Not yet created
-- **Design:** Not yet created
-- **Plan:** Not yet created
-- **Implementation:** Not yet created
+{OAT_ARTIFACTS}
 
 ## Progress
 
-- ✓ Discovery started
-- ⧗ Awaiting user input
+{OAT_PROGRESS}
 
 ## Blockers
 
@@ -49,4 +44,4 @@ None
 
 ## Next Milestone
 
-Complete discovery and move to specification phase
+{OAT_NEXT_MILESTONE}

--- a/packages/cli/assets/templates/state.md
+++ b/packages/cli/assets/templates/state.md
@@ -3,13 +3,13 @@ oat_current_task: null
 oat_last_commit: null
 oat_blockers: []
 associated_issues: [] # [{type: backlog|project|jira|linear, ref: "identifier"}]
-oat_hill_checkpoints: ['discovery', 'spec', 'design'] # Configured: which phases require human-in-the-loop lifecycle approval
+oat_hill_checkpoints: { OAT_HILL_CHECKPOINTS } # Configured: which phases require human-in-the-loop lifecycle approval
 oat_hill_completed: [] # Progress: which HiLL checkpoints have been completed
 oat_parallel_execution: false
-oat_phase: discovery # Current phase: discovery | spec | design | plan | implement
+oat_phase: { OAT_PHASE } # Current phase: discovery | spec | design | plan | implement
 oat_phase_status: in_progress # Status: in_progress | complete
 oat_execution_mode: single-thread # single-thread | subagent-driven
-oat_workflow_mode: spec-driven # spec-driven | quick | import
+oat_workflow_mode: { OAT_WORKFLOW_MODE } # spec-driven | quick | import
 oat_workflow_origin: native # native | imported
 oat_docs_updated: null # null | skipped | complete — documentation sync status
 oat_project_created: null # ISO 8601 UTC timestamp — set once at project creation
@@ -22,26 +22,21 @@ oat_template_name: state
 
 # Project State: {Project Name}
 
-**Status:** Discovery
+**Status:** {OAT_STATUS}
 **Started:** YYYY-MM-DD
 **Last Updated:** YYYY-MM-DD
 
 ## Current Phase
 
-Discovery - Gathering requirements and understanding the problem space
+{OAT_CURRENT_PHASE}
 
 ## Artifacts
 
-- **Discovery:** `discovery.md` (in_progress)
-- **Spec:** Not yet created
-- **Design:** Not yet created
-- **Plan:** Not yet created
-- **Implementation:** Not yet created
+{OAT_ARTIFACTS}
 
 ## Progress
 
-- ✓ Discovery started
-- ⧗ Awaiting user input
+{OAT_PROGRESS}
 
 ## Blockers
 
@@ -49,4 +44,4 @@ None
 
 ## Next Milestone
 
-Complete discovery and move to specification phase
+{OAT_NEXT_MILESTONE}

--- a/packages/cli/src/commands/commands.integration.test.ts
+++ b/packages/cli/src/commands/commands.integration.test.ts
@@ -137,19 +137,50 @@ async function seedProjectTemplates(root: string): Promise<void> {
     'implementation.md',
     'project-index.md',
   ]) {
-    await writeFile(
-      join(root, '.oat', 'templates', template),
-      [
-        '---',
-        'oat_template: true',
-        `oat_template_name: ${template.replace('.md', '')}`,
-        '---',
-        '',
-        `# {Project Name} ${template}`,
-        'Date: YYYY-MM-DD',
-      ].join('\n'),
-      'utf8',
-    );
+    const content =
+      template === 'state.md'
+        ? [
+            '---',
+            'oat_template: true',
+            'oat_template_name: state',
+            'oat_hill_checkpoints: {OAT_HILL_CHECKPOINTS}',
+            'oat_phase: {OAT_PHASE}',
+            'oat_phase_status: in_progress',
+            'oat_workflow_mode: {OAT_WORKFLOW_MODE}',
+            '---',
+            '',
+            '# Project State: {Project Name}',
+            '',
+            '**Status:** {OAT_STATUS}',
+            '**Started:** YYYY-MM-DD',
+            '**Last Updated:** YYYY-MM-DD',
+            '',
+            '## Current Phase',
+            '',
+            '{OAT_CURRENT_PHASE}',
+            '',
+            '## Artifacts',
+            '',
+            '{OAT_ARTIFACTS}',
+            '',
+            '## Progress',
+            '',
+            '{OAT_PROGRESS}',
+            '',
+            '## Next Milestone',
+            '',
+            '{OAT_NEXT_MILESTONE}',
+          ].join('\n')
+        : [
+            '---',
+            'oat_template: true',
+            `oat_template_name: ${template.replace('.md', '')}`,
+            '---',
+            '',
+            `# {Project Name} ${template}`,
+            'Date: YYYY-MM-DD',
+          ].join('\n');
+    await writeFile(join(root, '.oat', 'templates', template), content, 'utf8');
   }
 }
 
@@ -371,6 +402,16 @@ describe('CLI command integration', () => {
         ),
       ).rejects.toThrow();
     }
+
+    const state = await readFile(
+      join(root, '.oat', 'projects', 'shared', 'quick-smoke', 'state.md'),
+      'utf8',
+    );
+    expect(state).toContain('oat_workflow_mode: quick');
+    expect(state).toContain('- **Spec:** N/A (quick mode)');
+    expect(state).toContain(
+      'Complete discovery and generate a quick implementation plan',
+    );
   });
 
   it('cleanup subcommands parse successfully', async () => {

--- a/packages/cli/src/commands/project/new/scaffold.test.ts
+++ b/packages/cli/src/commands/project/new/scaffold.test.ts
@@ -21,19 +21,53 @@ async function seedTemplates(repoRoot: string): Promise<void> {
   ];
 
   for (const name of templateNames) {
-    await writeFile(
-      join(templatesDir, name),
-      [
-        '---',
-        'oat_template: true',
-        `oat_template_name: ${name.replace('.md', '')}`,
-        '---',
-        '',
-        `# {Project Name} ${name}`,
-        'Date: YYYY-MM-DD',
-      ].join('\n'),
-      'utf8',
-    );
+    const content =
+      name === 'state.md'
+        ? [
+            '---',
+            'oat_template: true',
+            'oat_template_name: state',
+            'oat_hill_checkpoints: {OAT_HILL_CHECKPOINTS}',
+            'oat_phase: {OAT_PHASE}',
+            'oat_phase_status: in_progress',
+            'oat_workflow_mode: {OAT_WORKFLOW_MODE}',
+            'oat_project_created: null',
+            'oat_project_completed: null',
+            'oat_project_state_updated: null',
+            '---',
+            '',
+            '# Project State: {Project Name}',
+            '',
+            '**Status:** {OAT_STATUS}',
+            '**Started:** YYYY-MM-DD',
+            '**Last Updated:** YYYY-MM-DD',
+            '',
+            '## Current Phase',
+            '',
+            '{OAT_CURRENT_PHASE}',
+            '',
+            '## Artifacts',
+            '',
+            '{OAT_ARTIFACTS}',
+            '',
+            '## Progress',
+            '',
+            '{OAT_PROGRESS}',
+            '',
+            '## Next Milestone',
+            '',
+            '{OAT_NEXT_MILESTONE}',
+          ].join('\n')
+        : [
+            '---',
+            'oat_template: true',
+            `oat_template_name: ${name.replace('.md', '')}`,
+            '---',
+            '',
+            `# {Project Name} ${name}`,
+            'Date: YYYY-MM-DD',
+          ].join('\n');
+    await writeFile(join(templatesDir, name), content, 'utf8');
   }
 }
 
@@ -261,7 +295,6 @@ describe('scaffoldProject', () => {
     });
 
     for (const file of [
-      'state.md',
       'discovery.md',
       'spec.md',
       'design.md',
@@ -291,11 +324,45 @@ describe('scaffoldProject', () => {
           'projects',
           'shared',
           'spec-driven-mode',
+          'state.md',
+        ),
+        'utf8',
+      ),
+    ).resolves.toContain('# Project State: spec-driven-mode');
+
+    await expect(
+      readFile(
+        join(
+          repoRoot,
+          '.oat',
+          'projects',
+          'shared',
+          'spec-driven-mode',
           'project-index.md',
         ),
         'utf8',
       ),
     ).rejects.toThrow();
+
+    const state = await readFile(
+      join(
+        repoRoot,
+        '.oat',
+        'projects',
+        'shared',
+        'spec-driven-mode',
+        'state.md',
+      ),
+      'utf8',
+    );
+    expect(state).toContain('oat_workflow_mode: spec-driven');
+    expect(state).toContain('oat_phase: discovery');
+    expect(state).toContain(
+      '- **Spec:** `spec.md` (scaffolded template — not started)',
+    );
+    expect(state).toContain(
+      '- **Implementation:** `implementation.md` (scaffolded template — not started)',
+    );
   });
 
   it('creates quick mode artifacts only', async () => {
@@ -333,6 +400,21 @@ describe('scaffoldProject', () => {
         ),
       ).rejects.toThrow();
     }
+
+    const state = await readFile(
+      join(repoRoot, '.oat', 'projects', 'shared', 'quick-mode', 'state.md'),
+      'utf8',
+    );
+    expect(state).toContain('oat_workflow_mode: quick');
+    expect(state).toContain('oat_hill_checkpoints: []');
+    expect(state).toContain('**Status:** Discovery');
+    expect(state).toContain('- **Spec:** N/A (quick mode)');
+    expect(state).toContain(
+      '- **Design:** N/A (quick mode unless lightweight design is needed)',
+    );
+    expect(state).toContain(
+      'Complete discovery and generate a quick implementation plan',
+    );
   });
 
   it('creates import mode artifacts only and sets references dir', async () => {
@@ -380,6 +462,22 @@ describe('scaffoldProject', () => {
         'utf8',
       ),
     ).resolves.toBe('');
+
+    const state = await readFile(
+      join(repoRoot, '.oat', 'projects', 'shared', 'import-mode', 'state.md'),
+      'utf8',
+    );
+    expect(state).toContain('oat_workflow_mode: import');
+    expect(state).toContain('oat_hill_checkpoints: []');
+    expect(state).toContain('oat_phase: plan');
+    expect(state).toContain('**Status:** Plan Import');
+    expect(state).toContain('- **Discovery:** N/A (import mode)');
+    expect(state).toContain(
+      '- **Plan:** `plan.md` (scaffolded template — awaiting imported content)',
+    );
+    expect(state).toContain(
+      'Run `oat-project-import-plan` to normalize the external plan',
+    );
   });
 
   it('does not reject when refreshDashboardCallback throws', async () => {

--- a/packages/cli/src/commands/project/new/scaffold.ts
+++ b/packages/cli/src/commands/project/new/scaffold.ts
@@ -44,6 +44,84 @@ const TEMPLATES_BY_MODE: Record<ProjectScaffoldMode, string[]> = {
   import: ['state.md', 'plan.md', 'implementation.md'],
 };
 
+interface StateTemplateContent {
+  hillCheckpoints: string;
+  phase: string;
+  status: string;
+  currentPhase: string;
+  artifacts: string[];
+  progress: string[];
+  nextMilestone: string;
+}
+
+const STATE_TEMPLATE_BY_MODE: Record<
+  ProjectScaffoldMode,
+  StateTemplateContent
+> = {
+  'spec-driven': {
+    hillCheckpoints: "['discovery', 'spec', 'design']",
+    phase: 'discovery',
+    status: 'Discovery',
+    currentPhase:
+      'Discovery - Gathering requirements and understanding the problem space',
+    artifacts: [
+      '- **Discovery:** `discovery.md` (in_progress)',
+      '- **Spec:** `spec.md` (scaffolded template — not started)',
+      '- **Design:** `design.md` (scaffolded template — not started)',
+      '- **Plan:** `plan.md` (scaffolded template — not started)',
+      '- **Implementation:** `implementation.md` (scaffolded template — not started)',
+    ],
+    progress: [
+      '- ✓ Discovery started',
+      '- ✓ Downstream lifecycle files scaffolded',
+      '- ⧗ Awaiting user input',
+    ],
+    nextMilestone: 'Complete discovery and move to specification phase',
+  },
+  quick: {
+    hillCheckpoints: '[]',
+    phase: 'discovery',
+    status: 'Discovery',
+    currentPhase:
+      'Discovery - Gathering requirements for a quick workflow before planning',
+    artifacts: [
+      '- **Discovery:** `discovery.md` (in_progress)',
+      '- **Spec:** N/A (quick mode)',
+      '- **Design:** N/A (quick mode unless lightweight design is needed)',
+      '- **Plan:** `plan.md` (scaffolded template — not started)',
+      '- **Implementation:** `implementation.md` (scaffolded template — not started)',
+    ],
+    progress: [
+      '- ✓ Discovery started',
+      '- ✓ Execution artifacts scaffolded',
+      '- ⧗ Awaiting user input',
+    ],
+    nextMilestone:
+      'Complete discovery and generate a quick implementation plan',
+  },
+  import: {
+    hillCheckpoints: '[]',
+    phase: 'plan',
+    status: 'Plan Import',
+    currentPhase:
+      'Plan import - Waiting to normalize an external plan into OAT format',
+    artifacts: [
+      '- **Discovery:** N/A (import mode)',
+      '- **Spec:** N/A (import mode)',
+      '- **Design:** N/A (import mode)',
+      '- **Plan:** `plan.md` (scaffolded template — awaiting imported content)',
+      '- **Implementation:** `implementation.md` (scaffolded template — awaiting imported plan)',
+    ],
+    progress: [
+      '- ✓ Import-mode project scaffolded',
+      '- ✓ Execution artifacts scaffolded',
+      '- ⧗ Awaiting external plan import',
+    ],
+    nextMilestone:
+      'Run `oat-project-import-plan` to normalize the external plan',
+  },
+};
+
 function validateProjectName(name: string): void {
   if (name.startsWith('-')) {
     throw new Error(
@@ -62,10 +140,20 @@ function applyTemplateReplacements(
   projectName: string,
   today: string,
   nowUtc: string,
+  mode: ProjectScaffoldMode,
 ): string {
+  const stateContent = STATE_TEMPLATE_BY_MODE[mode];
   return template
     .replaceAll('{Project Name}', projectName)
     .replaceAll('YYYY-MM-DD', today)
+    .replaceAll('{OAT_HILL_CHECKPOINTS}', stateContent.hillCheckpoints)
+    .replaceAll('{OAT_WORKFLOW_MODE}', mode)
+    .replaceAll('{OAT_PHASE}', stateContent.phase)
+    .replaceAll('{OAT_STATUS}', stateContent.status)
+    .replaceAll('{OAT_CURRENT_PHASE}', stateContent.currentPhase)
+    .replaceAll('{OAT_ARTIFACTS}', stateContent.artifacts.join('\n'))
+    .replaceAll('{OAT_PROGRESS}', stateContent.progress.join('\n'))
+    .replaceAll('{OAT_NEXT_MILESTONE}', stateContent.nextMilestone)
     .replaceAll(
       /oat_project_created:\s*null/gi,
       `oat_project_created: "${nowUtc}"`,
@@ -109,6 +197,7 @@ async function scaffoldModeTemplates(
       projectName,
       today,
       nowUtc,
+      mode,
     );
     await writeFile(dest, rendered, 'utf8');
     createdFiles.push(templateFile);


### PR DESCRIPTION
## Purpose

Fix the OAT project scaffolder so newly created projects start with `state.md` content that matches the workflow mode and the files actually written to disk.

The bug was that `oat project new` scaffolded downstream artifacts up front, but the rendered `state.md` still used hardcoded spec-driven text such as "Not yet created". That created false bookkeeping drift for agents and confused routing, especially for `quick` and `import` projects.

## Changes

- [x] Make `state.md` scaffold output mode-aware in [`packages/cli/src/commands/project/new/scaffold.ts`](https://github.com/voxmedia/open-agent-toolkit/blob/fix/scaffold-state-workflow-metadata/packages/cli/src/commands/project/new/scaffold.ts)
- [x] Replace hardcoded `state.md` template values with scaffold-time placeholders in [`.oat/templates/state.md`](https://github.com/voxmedia/open-agent-toolkit/blob/fix/scaffold-state-workflow-metadata/.oat/templates/state.md) and [`packages/cli/assets/templates/state.md`](https://github.com/voxmedia/open-agent-toolkit/blob/fix/scaffold-state-workflow-metadata/packages/cli/assets/templates/state.md)
- [x] Add regression coverage for `spec-driven`, `quick`, and `import` scaffolds in [`packages/cli/src/commands/project/new/scaffold.test.ts`](https://github.com/voxmedia/open-agent-toolkit/blob/fix/scaffold-state-workflow-metadata/packages/cli/src/commands/project/new/scaffold.test.ts)
- [x] Extend CLI integration coverage to assert the generated quick-mode `state.md` content in [`packages/cli/src/commands/commands.integration.test.ts`](https://github.com/voxmedia/open-agent-toolkit/blob/fix/scaffold-state-workflow-metadata/packages/cli/src/commands/commands.integration.test.ts)

## Testing

- [x] `pnpm --filter @oat/cli exec vitest run src/commands/project/new/scaffold.test.ts`
- [x] `pnpm --filter @oat/cli exec vitest run src/commands/commands.integration.test.ts`
- [x] `pnpm --filter @oat/cli type-check`

## Notes

### What was wrong

Before this change, the scaffold path created mode-specific files but treated `state.md` as a static document:

- `spec-driven` projects wrote `spec.md`, `design.md`, `plan.md`, and `implementation.md`, but `state.md` still said those files were not yet created.
- `quick` projects were scaffolded with only discovery/plan/implementation artifacts, but the initial `state.md` still identified the project as `spec-driven` and implied spec/design phase gates.
- `import` projects were scaffolded for plan import, but the initial `state.md` still looked like an early discovery-phase project.

That mismatch made lifecycle inspection look broken even when the filesystem was correct, and it created unnecessary confusion for any agent or command relying on `state.md` as the project summary.

### Implementation details

The scaffolder now computes a small mode-specific `state.md` content bundle at render time, including:

- `oat_hill_checkpoints`
- `oat_workflow_mode`
- `oat_phase`
- status headline and current-phase text
- artifact inventory text
- progress bullets
- next milestone text

This keeps the scaffolder as the source of truth for the initial workflow posture instead of requiring later skills to repair an inconsistent starting state.

### Why this shape

This fix is intentionally narrow:

- It does not change downstream routing logic.
- It does not introduce new lifecycle semantics.
- It fixes the inconsistency at the point where it is created: project scaffolding.

That keeps the change low-risk while addressing the actual source of the false mismatch.

### Reviewer focus

The highest-signal review points are:

- whether the mode-specific `state.md` defaults in `scaffold.ts` match current OAT workflow expectations
- whether the template placeholders in both template copies stay in sync
- whether the tests cover the specific regression conditions that caused the drift
