### PR TITLE
chore(oat): scaffold docs artifact bundle quick project

### DIFF
--- a/.oat/projects/shared/docs-artifact-bundle/design.md
+++ b/.oat/projects/shared/docs-artifact-bundle/design.md
@@ -1,0 +1,173 @@
+---
+oat_status: complete
+oat_ready_for: null
+oat_blockers: []
+oat_last_updated: 2026-03-21
+oat_generated: false
+oat_template: false
+---
+
+# Design: docs-artifact-bundle
+
+## Overview
+
+This project adapts the artifact-bundle idea from the agent-instructions workflow to the docs
+analyze/apply pair, but with a lighter contract. The current docs workflow already has a usable
+review artifact, and many recommendations are simple enough that they do not need a second machine-
+oriented bundle. The design therefore keeps the markdown analysis artifact as the canonical review
+surface while adding stable recommendation IDs and optional per-recommendation packs for the
+recommendation types most likely to lose nuance between analysis and apply.
+
+The main design goal is to preserve recommendation-scoped detail only where docs apply actually
+needs it: large creates, splits, complex content opportunities, and recommendations with nuanced
+disclosure or workflow constraints. Simple updates should remain inline in the main artifact so the
+docs workflow stays lighter than the agent-instructions workflow.
+
+## Architecture
+
+### System Context
+
+This work changes the contract between `oat-docs-analyze` and `oat-docs-apply` without merging
+them. Analyze remains responsible for discovery, evidence gathering, and recommendation shaping.
+Apply remains responsible for turning approved recommendations into docs edits and nav updates. The
+new contract introduces optional recommendation packs that sit beside the existing markdown analysis
+artifact when a recommendation needs more execution context than the inline artifact can carry
+comfortably.
+
+**Key Components:**
+
+- **Docs Analysis Artifact:** Reviewer-facing markdown artifact with stable recommendation IDs and
+  the complete ordered recommendation set.
+- **Recommendation Pack Contract:** Optional per-recommendation detail documents used only for
+  complex docs changes.
+- **Docs Apply Intake Layer:** Validation and planning logic that reads the markdown artifact first
+  and loads packs only when referenced.
+- **Regression Coverage:** Contract tests or fixtures that prove recommendation metadata and
+  optional-pack behavior survive the analyze -> apply handoff.
+
+### Component Diagram
+
+```text
+repo docs surface
+    |
+    v
+oat-docs-analyze
+    |-- docs-<timestamp>.md
+    `-- optional packs/<recommendation-id>.md
+                    |
+                    v
+             oat-docs-apply
+                    |
+                    v
+         updated docs files / nav changes
+```
+
+### Data Flow
+
+Analyze produces one markdown artifact for every run. Each recommendation gets a stable ID. Most
+recommendations remain fully represented in the markdown artifact. When a recommendation crosses a
+complexity threshold, analyze also emits a companion pack keyed by the same recommendation ID.
+Apply builds its recommendation plan from the markdown artifact, then loads a matching pack only
+when the artifact says one exists.
+
+```text
+1. analyze inventories docs surface and evidence
+2. analyze writes markdown artifact with recommendation IDs
+3. analyze emits optional packs for complex recommendations
+4. user approves recommendations
+5. apply reads the markdown artifact and recommendation IDs
+6. apply loads optional packs where referenced
+7. apply edits docs and runs nav / docs verification
+```
+
+## Component Design
+
+### Docs Analysis Artifact
+
+**Purpose:** Remain the canonical reviewer-facing artifact and primary recommendation index.
+
+**Responsibilities:**
+
+- Preserve the complete ordered findings and recommendations list.
+- Assign a stable ID to every recommendation.
+- Record whether each recommendation is inline-only or backed by a companion pack.
+- Continue to carry evidence, confidence, disclosure, and link-target decisions for all
+  recommendations.
+
+**Dependencies:**
+
+- Existing docs analysis artifact template.
+- Existing docs quality, coverage, and claim-verification workflow.
+
+**Design Decisions:**
+
+- The markdown artifact remains mandatory for every run.
+- Recommendation IDs are required for all recommendations, even when no pack exists.
+- Optional-pack references are additive metadata, not a replacement for the reviewer-facing artifact.
+
+### Recommendation Pack Contract
+
+**Purpose:** Preserve richer execution context for recommendations that are too dense or nuanced to
+fit cleanly inline in the main docs artifact.
+
+**Responsibilities:**
+
+- Capture structured content guidance for complex docs changes.
+- Preserve disclosure nuances, anti-patterns, or workflow notes when those materially affect apply.
+- Keep recommendation-scoped evidence grouped with the affected docs change instead of forcing apply
+  to re-synthesize it from a large artifact section.
+
+**Dependencies:**
+
+- Recommendation IDs from the main artifact.
+- A complexity threshold defined by docs analyze.
+
+**Design Decisions:**
+
+- Packs are optional and recommendation-scoped.
+- Packs should be emitted only for complex recommendations such as `CREATE`, `SPLIT`, or large
+  content-opportunity updates.
+- The pack shape should be simpler than the agent-instructions version because docs apply edits prose
+  rather than generating multiple provider formats.
+
+### Docs Apply Intake Layer
+
+**Purpose:** Consume the markdown artifact as the baseline plan source and augment it with pack data
+only when a recommendation references a pack.
+
+**Responsibilities:**
+
+- Validate recommendation IDs and pack references.
+- Build the recommendation plan from the markdown artifact without rediscovering docs conventions.
+- Load pack content only for recommendations that reference one.
+- Refuse to infer pack-only detail when the pack is missing or stale.
+
+**Dependencies:**
+
+- `oat-docs-apply` analysis-artifact intake.
+- Apply plan template and docs editing flow.
+
+**Design Decisions:**
+
+- Apply should always be able to operate on simple recommendations without a pack.
+- If a recommendation references a pack and the pack is missing, apply should stop rather than guess.
+- Pack presence should tighten the contract for that recommendation, not globally force all
+  recommendations into bundle mode.
+
+## Testing Strategy
+
+### Contract and Fixture Coverage
+
+- Add at least one simple docs recommendation fixture that remains inline-only.
+- Add at least one complex recommendation fixture that requires a pack.
+- Verify that docs apply can build a plan from mixed runs where some recommendations have packs and
+  others do not.
+- Verify that a missing referenced pack fails clearly instead of degrading into guesswork.
+
+### Key Scenarios
+
+- Simple `UPDATE` recommendation with only inline artifact data.
+- Large `CREATE` recommendation with a companion pack carrying content guidance.
+- `SPLIT` recommendation where apply needs pack-level migration notes.
+- Content-opportunity recommendation with `link_only` or `ask_user` nuance preserved across the
+  handoff.

--- a/.oat/projects/shared/docs-artifact-bundle/discovery.md
+++ b/.oat/projects/shared/docs-artifact-bundle/discovery.md
@@ -1,0 +1,193 @@
+---
+oat_status: complete
+oat_ready_for: null
+oat_blockers: []
+oat_last_updated: 2026-03-21
+oat_generated: false
+---
+
+# Discovery: docs-artifact-bundle
+
+## Phase Guardrails (Discovery)
+
+Discovery is for requirements and decisions, not implementation details.
+
+- Prefer outcomes and constraints over concrete deliverables (no specific scripts, file paths, or function names).
+- If an implementation detail comes up, capture it as an **Open Question** for design (or a constraint), not as a deliverable list.
+
+## Initial Request
+
+Turn the discussion about applying the agent-instructions artifact-bundle strategy to `oat-docs-analyze` and
+`oat-docs-apply` into a quick project.
+
+## Clarifying Questions
+
+### Question 1: Scope of change
+
+**Q:** Should the same bundling strategy used for agent instructions be applied to docs analyze/apply?
+**A:** Probably yes in concept, but not as a 1:1 copy. The likely fit is a lighter hybrid contract rather than a
+full mandatory bundle for every docs recommendation.
+**Decision:** This project should evaluate and likely plan a docs-specific bundle strategy, not blindly mirror the
+agent-instructions design.
+
+## Solution Space
+
+This request is exploratory because there are multiple viable ways to reduce analyze -> apply loss in docs, and the
+right answer depends on how much complexity the docs workflow should absorb.
+
+### Approach 1: Full Bundle Mirror
+
+**Description:** Copy the agent-instructions model directly: reviewer-facing markdown artifact plus a mandatory
+companion bundle with a manifest and per-recommendation packs for every docs analysis run.
+**When this is the right choice:** Best if docs analyze/apply already shows repeated loss of recommendation-scoped
+behavior, workflow nuance, and evidence handoff across many recommendation types.
+**Tradeoffs:** Highest consistency and machine-readability, but also the most complexity. It risks overfitting the
+docs workflow to a problem that may only affect a subset of recommendation types.
+
+### Approach 2: Hybrid Optional Packs _(Recommended)_
+
+**Description:** Keep the markdown docs analysis artifact as the primary review document, add stable recommendation
+IDs, and introduce optional per-recommendation packs only for complex recommendations such as large `CREATE`,
+`SPLIT`, or high-context content-opportunity work.
+**When this is the right choice:** Best when simple docs fixes still fit cleanly in one artifact, but a subset of
+recommendations need richer handoff detail.
+**Tradeoffs:** Better balance of fidelity and complexity, but it introduces a mixed contract that apply must handle
+carefully.
+
+### Approach 3: Enrich the Single Artifact Only
+
+**Description:** Keep one markdown artifact and continue adding richer fields, structure, and evidence expectations to
+it without introducing a companion bundle.
+**When this is the right choice:** Best if the current docs artifact is only missing a few fields and does not
+regularly lose detail at apply time.
+**Tradeoffs:** Lowest implementation cost, but it keeps all detail compressed into one reviewer-oriented document and
+may recreate the same ceiling the agent-instructions workflow hit.
+
+### Chosen Direction
+
+**Approach:** Hybrid optional packs
+**Rationale:** It preserves the simpler docs workflow where possible, while still giving apply a richer contract for
+the recommendation types most likely to lose nuance.
+**User validated:** Yes
+
+## Options Considered
+
+{Specific implementation options within the chosen approach. More granular than Solution Space — captures decisions about libraries, patterns, data formats, etc.}
+
+### Option A: Reuse the agent-instructions bundle shape as-is
+
+**Description:** Use the same manifest + summary + pack structure and field names across docs and instructions.
+
+**Pros:**
+
+- Consistent mental model across skill families
+- Reuses a pattern already proven useful in the repo
+
+**Cons:**
+
+- Docs recommendations are often simpler and more prose-oriented than instruction-file generation
+- Could force unnecessary pack overhead on routine docs fixes
+
+**Chosen:** Neither
+
+### Option B: Use a docs-specific lighter contract
+
+**Description:** Keep the same high-level idea but tailor the contract to docs workflows, likely with optional packs
+and fewer mandatory fields for simple updates.
+
+**Pros:**
+
+- Better fit for mixed docs recommendation complexity
+- Reduces bundle overhead for low-risk fixes
+
+**Cons:**
+
+- Less symmetry across the two skill families
+- Requires a fresh contract design instead of a direct port
+
+**Chosen:** B
+
+**Summary:** Reuse the bundle idea, but not the full agent-instructions contract verbatim. A docs-specific lighter
+variant is the leading direction.
+
+## Key Decisions
+
+1. **Workflow stance:** Keep separate `oat-docs-analyze` and `oat-docs-apply` steps instead of merging them.
+2. **Contract stance:** Prefer a hybrid docs-specific bundle strategy over a mandatory full bundle for every docs
+   recommendation.
+3. **Evidence boundary:** Apply should remain constrained by the analysis contract and cited evidence, not rediscover
+   new recommendations on its own.
+
+## Constraints
+
+- Preserve the current reviewer-friendly markdown artifact for docs analysis.
+- Avoid adding bundle overhead to simple docs fixes unless there is clear value.
+- Keep docs apply from inventing unsupported docs conventions.
+- Stay compatible with the existing OAT docs analyze/apply workflow shape unless the project deliberately changes it.
+
+## Success Criteria
+
+- A quick-mode plan exists for evaluating or implementing a docs-specific bundle handoff.
+- The plan makes an explicit decision between full mirror, hybrid optional packs, or single-artifact enrichment.
+- The project captures when docs recommendations should stay inline versus when they need richer pack-style context.
+
+## Out of Scope
+
+- Reworking unrelated docs-analysis quality criteria that are not part of the analyze/apply handoff.
+- Merging docs analyze and docs apply into one skill.
+- Blindly copying the entire agent-instructions bundle contract without docs-specific evaluation.
+
+## Deferred Ideas
+
+{Ideas that came up during discovery but are intentionally out of scope for now}
+
+- Add runtime parsing/validation for docs bundles in the CLI - deferred until the docs contract is chosen
+- Unify docs and agent-instructions bundle schemas completely - deferred until both workflows prove they need the same
+  shape
+
+## Open Questions
+
+- **Recommendation threshold:** Which docs recommendation types are complex enough to require packs?
+- **Contract shape:** Should docs packs be optional per recommendation, or should bundle presence imply packs for all
+  recommendations in a run?
+- **Apply behavior:** How should docs apply treat mixed runs where some recommendations have packs and others stay
+  inline in the main artifact?
+
+## Assumptions
+
+- Docs analyze/apply currently has a lower fidelity-loss risk than agent instructions because many docs changes are
+  simpler and prose-oriented.
+- Some docs recommendation classes are still complex enough to benefit from a richer handoff.
+
+## Risks
+
+- **Over-engineering:** The docs workflow could inherit unnecessary contract complexity from the agent-instructions
+  solution.
+  - **Likelihood:** Low / Medium / High
+  - **Impact:** Medium
+  - **Mitigation Ideas:** Start with a hybrid design and define explicit thresholds for when packs are needed.
+
+- **Insufficient fidelity:** A lighter docs contract could still leave apply starved of recommendation-scoped context
+  for complex docs work.
+  - **Likelihood:** Medium
+  - **Impact:** High
+  - **Mitigation Ideas:** Add regression scenarios for complex `CREATE`, `SPLIT`, and content-opportunity
+    recommendations.
+
+- **Contract inconsistency:** A docs-specific variant may diverge too far from the agent-instructions pattern and
+  become harder to maintain.
+  - **Likelihood:** Medium
+  - **Impact:** Medium
+  - **Mitigation Ideas:** Reuse stable concepts like recommendation IDs and per-recommendation context packs even if
+    the exact schema differs.
+
+## Next Steps
+
+Use this discovery artifact to drive the next workflow step:
+
+- **Quick mode → straight to plan:** proceed directly to `plan.md` when scope is clear and no architecture decisions remain.
+- **Quick mode → optional lightweight design:** produce a focused `design.md` (architecture, components, data flow, testing) before planning. Choose this when discovery surfaced architecture choices or component boundaries.
+- **Quick mode → promote:** escalate to spec-driven if discovery revealed the scope is larger or more complex than expected.
+- **Spec-driven mode:** continue to `oat-project-spec` (after HiLL approval if configured).
+
+This project chose the quick-mode lightweight design path and is ready for planning.

--- a/.oat/projects/shared/docs-artifact-bundle/implementation.md
+++ b/.oat/projects/shared/docs-artifact-bundle/implementation.md
@@ -1,0 +1,207 @@
+---
+oat_status: in_progress
+oat_ready_for: null
+oat_blockers: []
+oat_last_updated: 2026-03-23
+oat_current_task_id: p01-t01
+oat_generated: false
+---
+
+# Implementation: docs-artifact-bundle
+
+**Started:** 2026-03-21
+**Last Updated:** 2026-03-23
+
+> This document is used to resume interrupted implementation sessions.
+>
+> Conventions:
+>
+> - `oat_current_task_id` always points at the **next plan task to do** (not the last completed task).
+> - When all plan tasks are complete, set `oat_current_task_id: null`.
+> - Reviews are **not** plan tasks. Track review status in `plan.md` under `## Reviews` (e.g., `| final | code | passed | ... |`).
+> - Keep phase/task statuses consistent with the Progress Overview table so restarts resume correctly.
+> - Before running the `oat-project-pr-final` skill, ensure `## Final Summary (for PR/docs)` is filled with what was actually implemented.
+
+## Progress Overview
+
+| Phase   | Status  | Tasks | Completed |
+| ------- | ------- | ----- | --------- |
+| Phase 1 | pending | 2     | 0/2       |
+| Phase 2 | pending | 2     | 0/2       |
+
+**Total:** 0/4 tasks completed
+
+---
+
+## Phase 1: Define Hybrid Docs Contract
+
+**Status:** pending
+**Started:** -
+
+### Phase Summary (fill when phase is complete)
+
+**Outcome (what changed):**
+
+- Pending implementation
+
+**Key files touched:**
+
+- Pending implementation
+
+**Verification:**
+
+- Run: `pnpm format && pnpm lint`
+- Result: pending
+
+**Notes / Decisions:**
+
+- Quick-mode project initialized from lightweight design
+
+### Task p01-t01: Add stable recommendation IDs and optional-pack metadata to docs analysis
+
+**Status:** pending
+**Commit:** -
+
+**Outcome (required when completed):**
+
+- Pending implementation
+
+**Files changed:**
+
+- `.agents/skills/oat-docs-analyze/SKILL.md` - define recommendation IDs and optional-pack metadata
+- `.agents/skills/oat-docs-analyze/references/analysis-artifact-template.md` - add recommendation-scoped metadata
+- `.agents/skills/oat-docs-apply/SKILL.md` - align intake and planning with optional packs
+- `.agents/skills/oat-docs-apply/references/apply-plan-template.md` - carry IDs and pack references into plan review
+
+**Verification:**
+
+- Run: `pnpm format && pnpm lint`
+- Result: pending
+
+**Notes / Decisions:**
+
+- Keep the docs contract hybrid; do not force packs for simple recommendations
+
+**Issues Encountered:**
+
+- -
+
+---
+
+### Task p01-t02: Add docs recommendation-pack template and apply-side validation rules
+
+**Status:** pending
+**Commit:** -
+
+**Notes:**
+
+- Add a lighter docs-specific pack template and blocking validation for missing referenced packs
+
+---
+
+## Phase 2: Add Mixed-Mode Verification Coverage
+
+**Status:** pending
+**Started:** -
+
+### Task p02-t01: Add contract fixtures for inline-only and pack-backed docs recommendations
+
+**Status:** pending
+**Commit:** -
+
+**Notes:**
+
+- Cover simple inline-only, complex pack-backed, and mixed recommendation runs
+
+---
+
+## Orchestration Runs
+
+> This section is used by `oat-project-subagent-implement` to log parallel execution runs.
+> Each run appends a new subsection — never overwrite prior entries.
+> For single-thread execution (via `oat-project-implement`), this section remains empty.
+
+<!-- orchestration-runs-start -->
+<!-- orchestration-runs-end -->
+
+---
+
+## Implementation Log
+
+Chronological log of implementation progress.
+
+### 2026-03-23
+
+**Session Start:** planning
+
+- [x] Quick project scaffolded and discovery backfilled
+- [x] Lightweight design drafted and validated
+- [ ] Implementation not started
+
+**What changed (high level):**
+
+- Defined the likely hybrid contract direction for docs analyze/apply
+- Prepared a 4-task quick-mode plan for implementation
+
+**Decisions:**
+
+- Use optional recommendation packs for complex docs recommendations instead of a mandatory full bundle for every run
+
+**Follow-ups / TODO:**
+
+- Decide the exact threshold for when a docs recommendation requires a pack during implementation
+
+**Blockers:**
+
+- None
+
+**Session End:** planning complete
+
+---
+
+---
+
+## Deviations from Plan
+
+Document any deviations from the original plan.
+
+| Task | Planned | Actual | Reason |
+| ---- | ------- | ------ | ------ |
+| -    | -       | -      | -      |
+
+## Test Results
+
+Track test execution during implementation.
+
+| Phase | Tests Run | Passed | Failed | Coverage |
+| ----- | --------- | ------ | ------ | -------- |
+| 1     | -         | -      | -      | -        |
+| 2     | -         | -      | -      | -        |
+
+## Final Summary (for PR/docs)
+
+**What shipped:**
+
+- Pending implementation
+
+**Behavioral changes (user-facing):**
+
+- Pending implementation
+
+**Key files / modules:**
+
+- Pending implementation
+
+**Verification performed:**
+
+- Pending implementation
+
+**Design deltas (if any):**
+
+- Pending implementation
+
+## References
+
+- Plan: `plan.md`
+- Design: `design.md`
+- Spec: `spec.md`

--- a/.oat/projects/shared/docs-artifact-bundle/plan.md
+++ b/.oat/projects/shared/docs-artifact-bundle/plan.md
@@ -1,0 +1,230 @@
+---
+oat_status: complete
+oat_ready_for: oat-project-implement
+oat_blockers: []
+oat_last_updated: 2026-03-23
+oat_phase: plan
+oat_phase_status: complete
+oat_plan_hill_phases: ['p02'] # phases to pause AFTER completing (empty = every phase)
+oat_plan_source: quick # spec-driven | quick | imported
+oat_import_reference: null # e.g., references/imported-plan.md
+oat_import_source_path: null # original source path provided by user
+oat_import_provider: null # codex | cursor | claude | null
+oat_generated: false
+---
+
+# Implementation Plan: docs-artifact-bundle
+
+> Execute this plan using `oat-project-implement` (sequential) or `oat-project-subagent-implement` (parallel), with phase checkpoints and review gates.
+
+**Goal:** Add a docs-specific analyze/apply handoff contract that preserves recommendation-scoped detail for complex docs work without forcing a full bundle for every docs analysis run.
+
+**Architecture:** Keep the markdown docs analysis artifact as the canonical review surface, add stable recommendation IDs, and introduce optional per-recommendation packs only for complex docs recommendations. `oat-docs-apply` should plan from the markdown artifact first and load packs only when a recommendation references one.
+
+**Tech Stack:** Markdown skill docs, OAT project artifacts, optional recommendation-pack contract, docs-analysis/apply templates, contract/fixture tests in `packages/cli`
+
+**Commit Convention:** `{type}({scope}): {description}` - e.g., `feat(p01-t01): add user auth endpoint`
+
+## Planning Checklist
+
+- [x] Confirmed HiLL checkpoints with user
+- [x] Set `oat_plan_hill_phases` in frontmatter
+
+---
+
+## Phase 1: Define Hybrid Docs Contract
+
+### Task p01-t01: Add stable recommendation IDs and optional-pack metadata to docs analysis
+
+**Files:**
+
+- Modify: `.agents/skills/oat-docs-analyze/SKILL.md`
+- Modify: `.agents/skills/oat-docs-analyze/references/analysis-artifact-template.md`
+- Modify: `.agents/skills/oat-docs-apply/SKILL.md`
+- Modify: `.agents/skills/oat-docs-apply/references/apply-plan-template.md`
+
+**Step 1: Define the metadata contract**
+
+- Add stable recommendation IDs to the docs analysis artifact contract.
+- Define how a recommendation advertises that it has an optional companion pack.
+- Update docs apply intake rules so it can distinguish inline-only recommendations from pack-backed ones.
+
+**Step 2: Update planning guidance**
+
+- Ensure the apply plan template carries recommendation IDs and optional pack references.
+- Keep simple recommendations first-class in the markdown artifact so apply is not forced into pack mode globally.
+
+**Step 3: Refactor**
+
+- Align wording between docs analyze and docs apply so the hybrid contract is explicit and consistent.
+- Remove any wording that implies a pack is required for every recommendation.
+
+**Step 4: Verify**
+
+Run: `pnpm format && pnpm lint`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add .agents/skills/oat-docs-analyze .agents/skills/oat-docs-apply
+git commit -m "feat(p01-t01): add docs recommendation pack metadata"
+```
+
+---
+
+### Task p01-t02: Add docs recommendation-pack template and apply-side validation rules
+
+**Files:**
+
+- Create or modify docs contract references under `.agents/skills/oat-docs-analyze/references/`
+- Modify `.agents/skills/oat-docs-apply/SKILL.md`
+- Modify `.agents/skills/oat-docs-apply/references/apply-plan-template.md`
+
+**Step 1: Add pack template**
+
+- Add a docs-specific recommendation-pack template for complex recommendations.
+- Keep the pack shape lighter than the agent-instructions version and focused on docs editing needs.
+
+**Step 2: Tighten apply validation**
+
+- Define which recommendations require a pack and what apply must do when a referenced pack is missing.
+- Make missing referenced packs a blocking condition instead of a soft fallback.
+
+**Step 3: Refactor**
+
+- Align terminology across the markdown artifact, pack template, and apply plan template.
+- Ensure optional packs are described as additive context, not a replacement for the main artifact.
+
+**Step 4: Verify**
+
+Run: `pnpm format && pnpm lint`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add .agents/skills/oat-docs-analyze .agents/skills/oat-docs-apply
+git commit -m "feat(p01-t02): add docs recommendation pack template"
+```
+
+---
+
+## Phase 2: Add Mixed-Mode Verification Coverage
+
+### Task p02-t01: Add contract fixtures for inline-only and pack-backed docs recommendations
+
+**Files:**
+
+- Modify: `packages/cli/src/**` test or fixture coverage relevant to docs analyze/apply contracts
+- Modify: `.agents/skills/oat-docs-analyze/references/*` and `.agents/skills/oat-docs-apply/references/*` only as needed to support testable contract markers
+
+**Step 1: Define fixture scenarios**
+
+- Add one simple inline-only docs recommendation scenario.
+- Add one complex pack-backed docs recommendation scenario.
+- Add one mixed scenario where some recommendations have packs and others stay inline.
+
+**Step 2: Implement expectations**
+
+- Ensure the expected contract preserves recommendation IDs and optional-pack references.
+- Ensure the mixed scenario proves that simple recommendations remain valid without packs.
+
+**Step 3: Refactor**
+
+- Keep the fixture expectations structural and stable rather than tightly coupling them to incidental prose.
+
+**Step 4: Verify**
+
+Run: `pnpm test`
+Expected: Relevant contract tests pass
+
+**Step 5: Commit**
+
+```bash
+git add packages/cli .agents/skills/oat-docs-analyze .agents/skills/oat-docs-apply
+git commit -m "test(p02-t01): add docs hybrid bundle fixtures"
+```
+
+---
+
+### Task p02-t02: Wire docs apply to optional pack loading and blocking failures
+
+**Files:**
+
+- Modify: `.agents/skills/oat-docs-apply/SKILL.md`
+- Modify: `.agents/skills/oat-docs-apply/references/apply-plan-template.md`
+- Modify: `packages/cli/src/**` tests that exercise docs apply contract consumption
+
+**Step 1: Update apply flow**
+
+- Make docs apply read the markdown artifact first and load packs only when a recommendation references one.
+- Ensure inline-only recommendations still plan and apply cleanly.
+
+**Step 2: Add blocking-failure coverage**
+
+- Verify that a missing referenced pack stops apply cleanly.
+- Verify that mixed runs do not degrade into all-pack or no-pack behavior.
+
+**Step 3: Refactor**
+
+- Remove stale wording that implies docs apply is either markdown-only forever or full-bundle-only.
+
+**Step 4: Verify**
+
+Run: `pnpm test && pnpm type-check`
+Expected: All relevant checks pass
+
+**Step 5: Commit**
+
+```bash
+git add packages/cli .agents/skills/oat-docs-apply
+git commit -m "feat(p02-t02): wire docs apply to optional packs"
+```
+
+---
+
+## Reviews
+
+{Track reviews here after running the oat-project-review-provide and oat-project-review-receive skills.}
+
+{Keep both code + artifact rows below. Add additional code rows (p03, p04, etc.) as needed, but do not delete `spec`/`design`.}
+
+| Scope  | Type     | Status  | Date | Artifact |
+| ------ | -------- | ------- | ---- | -------- |
+| p01    | code     | pending | -    | -        |
+| p02    | code     | pending | -    | -        |
+| final  | code     | pending | -    | -        |
+| spec   | artifact | pending | -    | -        |
+| design | artifact | pending | -    | -        |
+
+**Status values:** `pending` → `received` → `fixes_added` → `fixes_completed` → `passed`
+
+**Meaning:**
+
+- `received`: review artifact exists (not yet converted into fix tasks)
+- `fixes_added`: fix tasks were added to the plan (work queued)
+- `fixes_completed`: fix tasks implemented, awaiting re-review
+- `passed`: re-review run and recorded as passing (no Critical/Important)
+
+---
+
+## Implementation Complete
+
+**Summary:**
+
+- Phase 1: 2 tasks - define the hybrid docs analyze/apply contract
+- Phase 2: 2 tasks - add mixed-mode contract coverage and apply consumption rules
+
+**Total: 4 tasks**
+
+Ready for code review and merge.
+
+---
+
+## References
+
+- Design: `design.md` (required in spec-driven mode; optional in quick/import mode)
+- Spec: `spec.md` (required in spec-driven mode; optional in quick/import mode)
+- Discovery: `discovery.md`
+- Imported Source: `references/imported-plan.md` (when `oat_plan_source: imported`)

--- a/.oat/projects/shared/docs-artifact-bundle/state.md
+++ b/.oat/projects/shared/docs-artifact-bundle/state.md
@@ -1,0 +1,52 @@
+---
+oat_current_task: null
+oat_last_commit: null
+oat_blockers: []
+associated_issues: [] # [{type: backlog|project|jira|linear, ref: "identifier"}]
+oat_hill_checkpoints: [] # Configured: which phases require human-in-the-loop lifecycle approval
+oat_hill_completed: [] # Progress: which HiLL checkpoints have been completed
+oat_parallel_execution: false
+oat_phase: plan # Current phase: discovery | spec | design | plan | implement
+oat_phase_status: complete # Status: in_progress | complete
+oat_execution_mode: single-thread # single-thread | subagent-driven
+oat_workflow_mode: quick # spec-driven | quick | import
+oat_workflow_origin: native # native | imported
+oat_docs_updated: null # null | skipped | complete — documentation sync status
+oat_project_created: '2026-03-21T23:58:31.737Z' # ISO 8601 UTC timestamp — set once at project creation
+oat_project_completed: null # ISO 8601 UTC timestamp — set when project is completed/archived
+oat_project_state_updated: '2026-03-23T00:00:00Z' # ISO 8601 UTC timestamp — updated on every state.md mutation
+oat_generated: false
+---
+
+# Project State: docs-artifact-bundle
+
+**Status:** Plan Ready
+**Started:** 2026-03-21
+**Last Updated:** 2026-03-21
+
+## Current Phase
+
+Plan complete; ready for implementation.
+
+## Artifacts
+
+- **Discovery:** `discovery.md` (complete)
+- **Spec:** Not yet created
+- **Design:** `design.md` (complete)
+- **Plan:** `plan.md` (complete)
+- **Implementation:** `implementation.md` (in_progress)
+
+## Progress
+
+- ✓ Discovery completed
+- ✓ Lightweight design completed
+- ✓ Plan generated
+- ⧗ Ready for implementation
+
+## Blockers
+
+None
+
+## Next Milestone
+
+Run `oat-project-implement` (or `oat-project-subagent-implement`)


### PR DESCRIPTION
## Summary
- scaffold a quick OAT project to evaluate applying a docs-specific artifact bundle strategy to `oat-docs-analyze` and `oat-docs-apply`
- capture discovery, lightweight design, and an execution-ready plan
- keep the proposed direction intentionally hybrid: stable recommendation IDs for all docs recommendations, with optional packs only for complex docs changes

## What changed
- added a new quick project under `.oat/projects/shared/docs-artifact-bundle/`
- documented the solution space and chosen direction in `discovery.md`
- drafted a lightweight architecture in `design.md`
- generated a 2-phase / 4-task implementation plan in `plan.md`
- initialized resumable tracking in `implementation.md`

## Notes
- this PR contains planning artifacts only; no docs-analyze/docs-apply behavior changed yet
- the plan is ready for `oat-project-implement`
