### PR TITLE
Add backlog item for autonomous lifecycle follow-through

### DIFF
--- a/.oat/repo/reference/backlog/index.md
+++ b/.oat/repo/reference/backlog/index.md
@@ -5,7 +5,7 @@
 ## Curated Overview
 
 - `bl-42f9` tracks the only in-progress backlog item and is currently being delivered through the active `local-project-management` project.
-- Inbox work is concentrated on workflow operations: project-completion hardening (`bl-0ace`, `bl-ea64`) and a Jira-oriented backlog refinement flow.
+- Inbox work is concentrated on workflow operations: project-completion hardening (`bl-0ace`, `bl-ea64`), configurable lifecycle follow-through (`bl-fb3f`), and a Jira-oriented backlog refinement flow.
 - Planned follow-on investments cluster around provider ergonomics (`bl-cbdd`), review collaboration (`bl-9fb8`), dependency analysis (`bl-3327`), and ideas-to-project promotion (`bl-b3f7`).
 - Longer-horizon backlog work now includes explicit entries for freshness hardening (`bl-f9bd`) and memory/provider-enhancement work (`bl-71a1`).
 
@@ -14,6 +14,7 @@
 | ID      | Title                                                                                           | Status      | Priority | Scope      | Estimate |
 | ------- | ----------------------------------------------------------------------------------------------- | ----------- | -------- | ---------- | -------- |
 | bl-42f9 | Add first-class OAT project/repo management workflow family (oat-pjm-_ or oat-repo-reference-_) | in_progress | high     | initiative | XL       |
+| bl-fb3f | Add configurable autonomous project lifecycle follow-through                                    | open        | medium   | feature    | L        |
 | bl-3327 | Add dependency intelligence skill family                                                        | open        | medium   | feature    | L        |
 | bl-b3f7 | Add idea promotion and auto-discovery flow to oat-project-new                                   | open        | medium   | feature    | L        |
 | bl-9fb8 | Add PR review follow-on skill set (provide-remote, respond-remote, summarize-remote)            | open        | medium   | feature    | L        |

--- a/.oat/repo/reference/backlog/items/configurable-autonomous-project-lifecycle-follow-through.md
+++ b/.oat/repo/reference/backlog/items/configurable-autonomous-project-lifecycle-follow-through.md
@@ -1,0 +1,36 @@
+---
+id: bl-fb3f
+title: 'Add configurable autonomous project lifecycle follow-through'
+status: open
+priority: medium
+scope: feature
+scope_estimate: L
+labels: ['automation', 'workflow', 'project-management']
+assignee: null
+created: '2026-03-22T00:27:02Z'
+updated: '2026-03-22T00:27:02Z'
+associated_issues:
+  - type: project
+    ref: 'local-project-management'
+---
+
+## Description
+
+Several OAT lifecycle flows still stop at intermediate handoff points even when the next step is deterministic. This item tracks configurable autonomous follow-through for project execution so workflows can continue without requiring a new manual trigger after each successful phase boundary.
+
+The initial target cases are:
+
+- After converting review findings into fix tasks, automatically continue into `oat-project-implement`.
+- After a final review passes, automatically create the final PR.
+- Decide whether project documentation should become an explicit final phase or a configurable required step before final completion.
+- Support configurable completion ordering, such as opening the final PR before marking the project complete, and optionally marking the project complete automatically after PR creation.
+
+This should be implemented as explicit lifecycle policy rather than ad hoc chaining so teams can choose which follow-on actions run automatically and in what order.
+
+## Acceptance Criteria
+
+- OAT supports configured follow-on execution after review-to-fix conversion, including automatically invoking `oat-project-implement` when policy allows.
+- OAT supports configured follow-on execution after a passing final review, including automatically generating the final PR when policy allows.
+- The lifecycle model defines how project documentation participates in finalization, either as an explicit phase or a configurable required step, and the chosen behavior is documented.
+- OAT configuration can express terminal lifecycle ordering for actions such as documentation, final PR creation, and project completion.
+- Lifecycle commands respect the configured automation policy and remain safe when a required prerequisite fails or needs human input.


### PR DESCRIPTION
## Purpose
Add a backlog item for configurable autonomous project lifecycle follow-through.

## Changes
- add backlog item `bl-fb3f` for configurable autonomous lifecycle follow-through
- capture acceptance criteria around post-review execution, final PR creation, documentation participation, and configurable completion ordering
- refresh the backlog index and curated overview to include the new workflow-operations item

## Testing
- `pnpm run cli -- backlog regenerate-index`