### PR TITLE
Fix backlog index marker repair guidance

### DIFF
--- a/.agents/skills/oat-pjm-add-backlog-item/SKILL.md
+++ b/.agents/skills/oat-pjm-add-backlog-item/SKILL.md
@@ -47,7 +47,24 @@ Collect the item details from the user or surrounding context:
 If the title is missing, ask the user.
 If the description is missing, ask for 1-3 sentences of context.
 
-### Step 2: Prepare Paths and Filename
+### Step 2: Ensure Backlog Scaffold
+
+Before generating IDs or editing backlog files, run:
+
+```bash
+oat backlog init
+```
+
+This command is idempotent. Use it even in existing repos so the canonical backlog scaffold and exact managed index markers are present before `oat backlog regenerate-index` runs.
+
+Do not hand-create the managed marker block in `backlog/index.md`. The scaffold writes the exact markers required by the CLI:
+
+```md
+<!-- OAT BACKLOG-INDEX -->
+<!-- END OAT BACKLOG-INDEX -->
+```
+
+### Step 3: Prepare Paths and Filename
 
 1. Derive a kebab-case slug from the title.
 2. Set the output path:
@@ -58,7 +75,7 @@ ITEM_PATH=".oat/repo/reference/backlog/items/{slug}.md"
 
 3. If the file already exists, ask the user whether to overwrite it or pick a different slug.
 
-### Step 3: Generate ID
+### Step 4: Generate ID
 
 Run:
 
@@ -70,7 +87,7 @@ Use the returned `bl-XXXX` value as the backlog item ID.
 
 If the initial hash collides with an existing backlog item ID, the CLI should retry with a disambiguated seed until it returns an unused ID. If the command reports a duplicate or collision issue, do not continue writing the item until the generated ID is unique across `backlog/items/*.md`.
 
-### Step 4: Copy Template and Fill Frontmatter
+### Step 5: Copy Template and Fill Frontmatter
 
 1. Use `.oat/templates/backlog-item.md` as the source template.
 2. Fill:
@@ -89,7 +106,7 @@ If the initial hash collides with an existing backlog item ID, the CLI should re
    - `## Description`
    - `## Acceptance Criteria`
 
-### Step 5: Write the Backlog Item
+### Step 6: Write the Backlog Item
 
 Write the completed file to:
 
@@ -99,7 +116,7 @@ Write the completed file to:
 
 Use the template field order from `.oat/templates/backlog-item.md`.
 
-### Step 6: Regenerate Managed Index
+### Step 7: Regenerate Managed Index
 
 Run:
 
@@ -109,7 +126,7 @@ oat backlog regenerate-index
 
 This refreshes the managed table inside `.oat/repo/reference/backlog/index.md`.
 
-### Step 7: Update Curated Overview
+### Step 8: Update Curated Overview
 
 Read `.oat/repo/reference/backlog/index.md` and update the `## Curated Overview` section with a brief human-written note when helpful, for example:
 
@@ -119,7 +136,7 @@ Read `.oat/repo/reference/backlog/index.md` and update the `## Curated Overview`
 
 Do not edit inside the managed marker section.
 
-### Step 8: Summarize to the User
+### Step 9: Summarize to the User
 
 Report:
 

--- a/.agents/skills/oat-pjm-update-repo-reference/SKILL.md
+++ b/.agents/skills/oat-pjm-update-repo-reference/SKILL.md
@@ -45,7 +45,24 @@ Write down a 1-3 bullet summary of the implementation change:
 - Repo-reference behavior changes
 - File moves, renames, or retirements
 
-### Step 2: Mine Project Artifacts for Deferred Work and Decisions
+### Step 2: Ensure Backlog Scaffold
+
+Before editing any backlog files or running backlog regeneration, run:
+
+```bash
+oat backlog init
+```
+
+This command is idempotent and ensures `.oat/repo/reference/backlog/index.md` exists with the exact managed markers required by the CLI:
+
+```md
+<!-- OAT BACKLOG-INDEX -->
+<!-- END OAT BACKLOG-INDEX -->
+```
+
+Do not hand-author or rename those managed markers.
+
+### Step 3: Mine Project Artifacts for Deferred Work and Decisions
 
 For recently completed or in-progress projects, read `discovery.md`, `spec.md`, `design.md`, and `implementation.md` as applicable.
 
@@ -56,7 +73,7 @@ Promote notable findings into one of:
 - Decision record entries in `.oat/repo/reference/decision-record.md`
 - Roadmap updates in `.oat/repo/reference/roadmap.md`
 
-### Step 3: Update Canonical Reference Docs
+### Step 4: Update Canonical Reference Docs
 
 Update these files as applicable:
 
@@ -80,7 +97,7 @@ If you modify backlog item files or the completed archive structure, run:
 oat backlog regenerate-index
 ```
 
-### Step 4: Sanity Checks
+### Step 5: Sanity Checks
 
 Use the `Grep` tool for focused searches:
 
@@ -94,7 +111,7 @@ Confirm that:
 - Completed summaries live in `backlog/completed.md`
 - Roadmap wording matches the current `Now / Next / Later` structure
 
-### Step 5: Output
+### Step 6: Output
 
 Provide:
 

--- a/packages/cli/src/commands/backlog/regenerate-index.test.ts
+++ b/packages/cli/src/commands/backlog/regenerate-index.test.ts
@@ -219,4 +219,34 @@ describe('regenerateBacklogIndex', () => {
       regenerateBacklogIndex(clonedBacklogRoot),
     ).resolves.toBeUndefined();
   });
+
+  it('reports the exact marker pair required when the index was hand-authored incorrectly', async () => {
+    const backlogRoot = await mkdtemp(join(tmpdir(), 'oat-backlog-markers-'));
+    tempDirs.push(backlogRoot);
+
+    await mkdir(join(backlogRoot, 'items'), { recursive: true });
+    await writeFile(
+      join(backlogRoot, 'index.md'),
+      [
+        '# Backlog Index',
+        '',
+        '## Curated Overview',
+        '',
+        'Hand-authored content.',
+        '',
+        '<!-- oat:managed:start -->',
+        '| stale | stale |',
+        '<!-- oat:managed:end -->',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    await expect(regenerateBacklogIndex(backlogRoot)).rejects.toThrow(
+      /Expected the exact marker pair:\n<!-- OAT BACKLOG-INDEX -->\n<!-- END OAT BACKLOG-INDEX -->/,
+    );
+    await expect(regenerateBacklogIndex(backlogRoot)).rejects.toThrow(
+      /Run `oat backlog init` if the backlog scaffold is missing/,
+    );
+  });
 });

--- a/packages/cli/src/commands/backlog/regenerate-index.ts
+++ b/packages/cli/src/commands/backlog/regenerate-index.ts
@@ -108,7 +108,9 @@ export async function regenerateBacklogIndex(
   const startIndex = content.indexOf(INDEX_START);
   const endIndex = content.indexOf(INDEX_END);
   if (startIndex === -1 || endIndex === -1) {
-    throw new Error(`Managed backlog index markers missing in ${indexPath}.`);
+    throw new Error(
+      `Managed backlog index markers missing in ${indexPath}. Expected the exact marker pair:\n${INDEX_START}\n${INDEX_END}\nRun \`oat backlog init\` if the backlog scaffold is missing, or restore those exact markers in \`backlog/index.md\` before rerunning \`oat backlog regenerate-index\`.`,
+    );
   }
 
   const before = content.slice(0, startIndex);


### PR DESCRIPTION
## Purpose

Prevent recurring `oat backlog regenerate-index` failures when backlog index files are hand-authored with the wrong managed markers or when agent workflows skip backlog scaffold initialization.

## Changes

- [x] Improve [`packages/cli/src/commands/backlog/regenerate-index.ts`](https://github.com/voxmedia/open-agent-toolkit/blob/fix/backlog-index-marker-repair/packages/cli/src/commands/backlog/regenerate-index.ts) to report the exact required marker pair and direct users to `oat backlog init` when the scaffold is missing.
- [x] Add a regression test in [`packages/cli/src/commands/backlog/regenerate-index.test.ts`](https://github.com/voxmedia/open-agent-toolkit/blob/fix/backlog-index-marker-repair/packages/cli/src/commands/backlog/regenerate-index.test.ts) covering hand-authored `index.md` files with non-canonical markers.
- [x] Update [`oat-pjm-add-backlog-item`](https://github.com/voxmedia/open-agent-toolkit/blob/fix/backlog-index-marker-repair/.agents/skills/oat-pjm-add-backlog-item/SKILL.md) and [`oat-pjm-update-repo-reference`](https://github.com/voxmedia/open-agent-toolkit/blob/fix/backlog-index-marker-repair/.agents/skills/oat-pjm-update-repo-reference/SKILL.md) to run `oat backlog init` before backlog edits or regeneration and to document the exact marker pair expected by the CLI.

## Testing

- [x] `pnpm --filter @voxmedia/oat-cli exec vitest run src/commands/backlog/regenerate-index.test.ts src/commands/backlog/init.test.ts src/commands/backlog/index.test.ts`
- [ ] Manual testing

## Notes

- This keeps the CLI strict about the managed marker pair while making the failure mode self-diagnosing.
- The workflow-side skill changes are intended to stop agents from creating invalid backlog index scaffolds in downstream repos.
