### PR TITLE
[codex] Fix auto-review phase range coverage

### DIFF
--- a/.agents/agents/oat-reviewer.md
+++ b/.agents/agents/oat-reviewer.md
@@ -38,7 +38,7 @@ You will be given a "Review Scope" block including:
 
 - **project**: Path to project directory (e.g., `.oat/projects/shared/my-feature/`)
 - **type**: `code` or `artifact`
-- **scope**: What to review (`pNN-tNN` task, `pNN` phase, `final`, `BASE..HEAD` range, or an artifact name like `spec` / `design`)
+- **scope**: What to review (`pNN-tNN` task, `pNN` phase, `pNN-pMM` contiguous phase range, `final`, `BASE..HEAD` range, or an artifact name like `spec` / `design`)
 - **commits/range**: Git commits or SHA range for changed files
 - **files_changed**: List of files modified in scope
 - **workflow_mode**: `spec-driven` | `quick` | `import` (default to `spec-driven` if absent)

--- a/.agents/skills/oat-project-implement/SKILL.md
+++ b/.agents/skills/oat-project-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-implement
-version: 1.2.1
+version: 1.2.2
 description: Use when plan.md is ready for execution. Implements plan tasks sequentially with TDD discipline and state tracking.
 disable-model-invocation: true
 user-invocable: true
@@ -413,9 +413,12 @@ Before pausing at a checkpoint, check if auto-review is enabled:
 1. Read `oat_auto_review_at_checkpoints` from plan.md frontmatter. If not present, fall back to `.oat/config.json` `autoReviewAtCheckpoints` (default: `false`).
 
 2. If enabled and this is a checkpoint phase:
-   a. **Determine review scope:** Find the last checkpoint phase with a **`passed`** row in plan.md Reviews table. Rows with `fixes_added` or `fixes_completed` do NOT count — those reviews didn't pass and should be re-covered. Scope = all phases from (last passed + 1) through current. If this is the final phase, use scope `final`.
-   b. **Spawn subagent review:** `oat-project-review-provide code {scope}` — instruct it to include `oat_review_invocation: auto` in the review artifact frontmatter.
-   c. **Auto-invoke review-receive:** `oat-project-review-receive` — operates in auto-disposition mode when `oat_review_invocation: auto` is present:
+   a. **Determine review scope:** Find the highest completed implementation phase already covered by a **`passed`** code-review row in plan.md Reviews table. Count only whole-phase scopes: `pNN` or `pNN-pMM`. Ignore task scopes (`pNN-tNN`) and rows with `fixes_added` or `fixes_completed` because those reviews did not pass and must be re-covered. Scope = every implementation phase after that passed coverage through the current phase, inclusive. If no earlier passed whole-phase review exists, start from the first implementation phase. Use `pNN-pMM` when the scope spans multiple phases. If this is the final implementation phase checkpoint, use scope `final`.
+   - Example: prior passed row `p01`, current checkpoint `p03` → review `p02-p03`
+   - Example: no prior passed whole-phase review, current checkpoint `p03` → review `p01-p03`
+   - Example: current checkpoint is the last implementation phase → review `final`
+     b. **Spawn subagent review:** `oat-project-review-provide code {scope}` — instruct it to include `oat_review_invocation: auto` in the review artifact frontmatter.
+     c. **Auto-invoke review-receive:** `oat-project-review-receive` — operates in auto-disposition mode when `oat_review_invocation: auto` is present:
    - Critical/Important/Medium: convert to fix tasks (same as manual)
    - Minor: auto-convert to fix tasks unless clearly out of scope
    - No user prompts for disposition

--- a/.agents/skills/oat-project-review-provide/SKILL.md
+++ b/.agents/skills/oat-project-review-provide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-review-provide
-version: 1.2.1
+version: 1.2.3
 description: Use when completed work in an active OAT project needs a quality gate before merge. Performs a lifecycle-scoped review after a task, phase, or full implementation, unlike oat-review-provide.
 disable-model-invocation: true
 user-invocable: true
@@ -61,6 +61,7 @@ When executing this skill, provide lightweight progress feedback so the user can
 
 ```
 oat-project-review-provide code p02          # Code review for phase
+oat-project-review-provide code p02-p03      # Code review for contiguous phase range
 oat-project-review-provide code p02-t03      # Code review for task
 oat-project-review-provide code final        # Final code review
 oat-project-review-provide code base_sha=abc # Review since specific SHA
@@ -148,7 +149,7 @@ If the user confirms (or just presses enter), use the inferred type and scope. I
 
 - Ask: "What type of review? (code / artifact)"
 - Ask: "What scope?"
-  - For code: `pNN-tNN` task / `pNN` phase / `final` / `base_sha=SHA` / `SHA..HEAD` range
+  - For code: `pNN-tNN` task / `pNN` phase / `pNN-pMM` contiguous phase range / `final` / `base_sha=SHA` / `SHA..HEAD` range
   - For artifact: `discovery` / `spec` / `design` (and optionally `plan`)
 
 ### Step 1.5: Resolve Target Branch and Working Directory
@@ -261,7 +262,7 @@ If review type is `code`, use the scope resolution below.
 
 Before resolving scope, check if this is a re-review of fixes from a prior review cycle:
 
-1. Scan `plan.md` for tasks tagged with `(review)` in the scope being reviewed (e.g., `(p02-review)` fix tasks for a `p02` phase review).
+1. Scan `plan.md` for tasks tagged with `(review)` in the scope being reviewed (e.g., `(p02-review)` fix tasks for a `p02` phase review or `(p02-p03-review)` for a contiguous phase-range review).
 2. If `(review)` fix tasks exist **and** their status is `completed`:
    - This is a re-review. Offer the user a narrowed scope:
 
@@ -284,7 +285,14 @@ Before resolving scope, check if this is a re-review of fixes from a prior revie
    - `<sha1>..<sha2>` → exact range review
    - `pNN-tNN` → task scope
    - `pNN` → phase scope
+   - `pNN-pMM` → contiguous inclusive phase-range scope (for example `p02-p03`)
    - `final` → full project review
+
+**Phase-range semantics:**
+
+- `pNN-pMM` scopes are inclusive and must represent contiguous implementation phases.
+- This is the canonical scope format for checkpoint auto-reviews that need to cover multiple previously unpassed phases in one review.
+- When a phase-range token is used, treat it as a range review for artifact naming/storage, but preserve the exact `oat_review_scope` value (for example `p02-p03`) in frontmatter and plan review rows.
 
 2. **Automatic phase detection (if invoked at phase boundary):**
    - Derive current phase from plan.md + implementation.md
@@ -296,6 +304,15 @@ Before resolving scope, check if this is a re-review of fixes from a prior revie
 
      # Phase commits: grep for (pNN-
      git log --oneline --grep="\(p${PHASE}-" HEAD~50..HEAD
+     ```
+
+   - For contiguous phase-range scopes (`pNN-pMM`), aggregate commit matches for each phase in the inclusive range:
+
+     ```bash
+     for PHASE_NUM in $(seq "$START_PHASE_NUM" "$END_PHASE_NUM"); do
+       PHASE_ID=$(printf "p%02d" "$PHASE_NUM")
+       git log --oneline --grep="\\(${PHASE_ID}-" HEAD~50..HEAD
+     done
      ```
 
 3. **Fallback (if commit conventions missing/inconsistent):**
@@ -619,6 +636,7 @@ After review artifact is written, update `plan.md` `## Reviews` table _if plan.m
 Update or add a row matching `{scope}`:
 
 - `Scope`: `{scope}` (examples: `p02`, `final`, `spec`, `design`)
+  - Phase-range examples such as `p02-p03` are valid code-review scopes and should be preserved exactly.
 - `Type`: `code` or `artifact`
 - `Status`: `received` (receive-review will decide `fixes_added` vs `passed`; `passed` now requires no unresolved Critical/Important/Medium and final deferred-medium disposition when applicable)
 - `Date`: `{today}`

--- a/.agents/skills/oat-project-review-receive/SKILL.md
+++ b/.agents/skills/oat-project-review-receive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-review-receive
-version: 1.2.0
+version: 1.2.1
 description: Use when review findings from oat-project-review-provide need closure. Converts review artifacts into actionable plan tasks.
 disable-model-invocation: true
 user-invocable: true
@@ -257,7 +257,8 @@ Applies to `code` reviews only. (`artifact` reviews are handled via Step 2.6, th
 
 1. Check review scope from artifact frontmatter (`oat_review_scope`)
 2. If scope is `pNN` (phase) or `pNN-tNN` (task): add fix tasks to that phase
-3. If scope is `final` or range: add fix tasks to a new "Review Fixes" phase or the last phase
+3. If scope is `pNN-pMM` (contiguous phase range): add fix tasks to the last phase in the range (`pMM`)
+4. If scope is `final` or SHA/range review: add fix tasks to a new "Review Fixes" phase or the last phase
 
 ### Step 4: Determine Next Task IDs
 
@@ -617,7 +618,7 @@ This prevents reviewing already-approved code and focuses the reviewer on just t
 **How it works:**
 
 1. When `oat-project-review-provide` is called after fix tasks exist
-2. It detects `(review)` tasks in plan.md for the scope
+2. It detects `(review)` tasks in plan.md for the scope, including range review tags such as `(p02-p03-review)`
 3. It offers: "Scope to fix tasks only? (Y/n)"
 4. If yes: scope is just the fix task commits
 

--- a/apps/oat-docs/docs/guide/workflow/lifecycle.md
+++ b/apps/oat-docs/docs/guide/workflow/lifecycle.md
@@ -69,7 +69,7 @@ This distinction matters during completion: `oat-project-complete` can skip the 
 
 ### Auto-review at checkpoints
 
-When `autoReviewAtCheckpoints` is enabled (via `.oat/config.json` or `plan.md` frontmatter `oat_auto_review_at_checkpoints`), completing a plan phase checkpoint automatically spawns a subagent code review scoped to phases since the last passed checkpoint. The review uses auto-disposition mode (minors auto-converted to fix tasks, no user prompts). Disabled by default.
+When `autoReviewAtCheckpoints` is enabled (via `.oat/config.json` or `plan.md` frontmatter `oat_auto_review_at_checkpoints`), completing a plan phase checkpoint automatically spawns a subagent code review scoped to every implementation phase not already covered by a passed whole-phase code review, through the just-completed checkpoint. Mid-implementation multi-phase reviews use inclusive phase-range scopes such as `p02-p03`; the final implementation checkpoint uses `code final`. The review uses auto-disposition mode (minors auto-converted to fix tasks, no user prompts). Disabled by default.
 
 ## Implementation modes
 

--- a/apps/oat-docs/docs/guide/workflow/reviews.md
+++ b/apps/oat-docs/docs/guide/workflow/reviews.md
@@ -52,7 +52,7 @@ Status progression in `plan.md` Reviews table:
 
 ## Auto-review at checkpoints
 
-When `autoReviewAtCheckpoints` is enabled (via `oat config set autoReviewAtCheckpoints true` or per-project in `plan.md` frontmatter), completing a plan phase checkpoint automatically spawns a subagent review. The review scope covers all phases since the last passed checkpoint. The final phase checkpoint triggers a `code final` review.
+When `autoReviewAtCheckpoints` is enabled (via `oat config set autoReviewAtCheckpoints true` or per-project in `plan.md` frontmatter), completing a plan phase checkpoint automatically spawns a subagent review. The review scope covers every implementation phase not already covered by a passed whole-phase code review, through the just-completed checkpoint. Mid-implementation multi-phase checkpoint reviews use inclusive phase-range scopes such as `p02-p03`. The final phase checkpoint triggers a `code final` review.
 
 Auto-triggered reviews use `oat_review_invocation: auto` in the review artifact frontmatter. In auto mode, `oat-project-review-receive` auto-converts all findings to fix tasks without user prompts (Minor findings that are clearly out of scope are deferred with a note).
 

--- a/packages/cli/assets/agents/oat-reviewer.md
+++ b/packages/cli/assets/agents/oat-reviewer.md
@@ -38,7 +38,7 @@ You will be given a "Review Scope" block including:
 
 - **project**: Path to project directory (e.g., `.oat/projects/shared/my-feature/`)
 - **type**: `code` or `artifact`
-- **scope**: What to review (`pNN-tNN` task, `pNN` phase, `final`, `BASE..HEAD` range, or an artifact name like `spec` / `design`)
+- **scope**: What to review (`pNN-tNN` task, `pNN` phase, `pNN-pMM` contiguous phase range, `final`, `BASE..HEAD` range, or an artifact name like `spec` / `design`)
 - **commits/range**: Git commits or SHA range for changed files
 - **files_changed**: List of files modified in scope
 - **workflow_mode**: `spec-driven` | `quick` | `import` (default to `spec-driven` if absent)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkstang/oat-cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
+++ b/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
@@ -20,6 +20,44 @@ describe('review skill contracts', () => {
     expect(content).toContain(
       'missing `spec.md` must not be treated as a project review gate failure for `artifact design`',
     );
+    expect(content).toContain('`pNN-pMM` contiguous phase range');
+    expect(content).toContain(
+      'This is the canonical scope format for checkpoint auto-reviews',
+    );
+    expect(content).toContain(
+      'For contiguous phase-range scopes (`pNN-pMM`), aggregate commit matches for each phase in the inclusive range',
+    );
+  });
+
+  it('defines auto-review checkpoint scope from the last passed whole-phase review', () => {
+    const skillPath = repoFilePath(
+      '.agents/skills/oat-project-implement/SKILL.md',
+    );
+    const content = readFileSync(skillPath, 'utf8');
+
+    expect(content).toContain(
+      'Count only whole-phase scopes: `pNN` or `pNN-pMM`',
+    );
+    expect(content).toContain(
+      'Example: prior passed row `p01`, current checkpoint `p03` → review `p02-p03`',
+    );
+    expect(content).toContain(
+      'Example: no prior passed whole-phase review, current checkpoint `p03` → review `p01-p03`',
+    );
+  });
+
+  it('routes phase-range review fixes into the last phase in the range', () => {
+    const skillPath = repoFilePath(
+      '.agents/skills/oat-project-review-receive/SKILL.md',
+    );
+    const content = readFileSync(skillPath, 'utf8');
+
+    expect(content).toContain(
+      'If scope is `pNN-pMM` (contiguous phase range): add fix tasks to the last phase in the range (`pMM`)',
+    );
+    expect(content).toContain(
+      'including range review tags such as `(p02-p03-review)`',
+    );
   });
 
   it('requires project completion to skip PR prompting when an open PR is tracked', () => {


### PR DESCRIPTION
## Purpose

Fix the auto-review checkpoint flow so multi-phase checkpoint reviews cover all implementation phases that have not already been covered by a passed whole-phase code review.

The bug was in the review-scope contract between the implementation, review, and review-receive skills. Auto-review at a later checkpoint could narrow to only the current phase, and the receive side did not explicitly route contiguous phase-range scopes like `p02-p03` back into the implementation plan.

## Changes

- [x] Update `oat-project-implement` to compute checkpoint review scope from the last passed whole-phase code review and emit inclusive phase-range scopes such as `p02-p03` until the final checkpoint, which still uses `final`.
- [x] Extend `oat-project-review-provide` to treat `pNN-pMM` as a first-class scope token, document its semantics, preserve it in plan/review metadata, and describe how to aggregate commit ranges across the covered phases.
- [x] Update `oat-project-review-receive` to route phase-range review findings into the last phase in the range and recognize range-scoped review-fix task tags during re-review.
- [x] Keep reviewer/docs surfaces in sync by updating the reviewer agent copies, workflow docs, and the `@tkstang/oat-cli` package version to `0.0.6`.
- [x] Add contract coverage that locks in phase-range scope support on the produce side and consume side of the review pipeline.

## Testing

- [x] `pnpm --filter @tkstang/oat-cli test -- src/commands/init/tools/shared/review-skill-contracts.test.ts`
- [x] Repo hooks run during commit and push:
  - `turbo run type-check`
  - `turbo run lint`
  - `turbo run format`
- [ ] Manual testing

## Notes

### Root cause

The repo docs already described checkpoint reviews as covering phases since the last passed checkpoint, but the skill contract did not fully express that behavior end to end. `oat-project-review-provide` lacked explicit phase-range scope support and `oat-project-review-receive` did not explicitly route `pNN-pMM` findings, which left the auto-review -> fix-task loop underspecified.

### Reviewer impact

Reviewers can now expect consistent scope tokens across the workflow:

- Mid-implementation checkpoint reviews may use `pNN-pMM`.
- Final implementation checkpoint reviews still use `final`.
- Range-scoped review fixes re-enter the plan in the last covered phase instead of falling through to ambiguous generic range handling.

### Package/release impact

This updates the bundled CLI behavior and bumps `packages/cli` from `0.0.5` to `0.0.6` so the release dry-run sees a new publishable version for the shipped behavior change.
