### PR TITLE
[codex] Repair skip-only sync manifest reconciliation

### DIFF
--- a/.codex/agents/oat-reviewer.toml
+++ b/.codex/agents/oat-reviewer.toml
@@ -34,7 +34,7 @@ You will be given a "Review Scope" block including:
 
 - **project**: Path to project directory (e.g., `.oat/projects/shared/my-feature/`)
 - **type**: `code` or `artifact`
-- **scope**: What to review (`pNN-tNN` task, `pNN` phase, `final`, `BASE..HEAD` range, or an artifact name like `spec` / `design`)
+- **scope**: What to review (`pNN-tNN` task, `pNN` phase, `pNN-pMM` contiguous phase range, `final`, `BASE..HEAD` range, or an artifact name like `spec` / `design`)
 - **commits/range**: Git commits or SHA range for changed files
 - **files_changed**: List of files modified in scope
 - **workflow_mode**: `spec-driven` | `quick` | `import` (default to `spec-driven` if absent)

--- a/packages/cli/src/commands/sync/apply.ts
+++ b/packages/cli/src/commands/sync/apply.ts
@@ -77,6 +77,8 @@ export async function runSyncApply(
   let failed = 0;
 
   for (const scopePlan of scopePlans) {
+    const hasSyncEntries =
+      scopePlan.plan.entries.length > 0 || scopePlan.plan.removals.length > 0;
     const hasSyncPlannedOperations = [
       ...scopePlan.plan.entries,
       ...scopePlan.plan.removals,
@@ -86,11 +88,11 @@ export async function runSyncApply(
         (operation) => operation.action !== 'skip',
       ) ?? false;
 
-    if (!hasSyncPlannedOperations && !hasCodexPlannedOperations) {
+    if (!hasSyncEntries && !hasCodexPlannedOperations) {
       continue;
     }
 
-    if (hasSyncPlannedOperations) {
+    if (hasSyncEntries) {
       const result = await dependencies.executeSyncPlan(
         scopePlan.plan,
         scopePlan.manifest,

--- a/packages/cli/src/commands/sync/apply.ts
+++ b/packages/cli/src/commands/sync/apply.ts
@@ -79,10 +79,6 @@ export async function runSyncApply(
   for (const scopePlan of scopePlans) {
     const hasSyncEntries =
       scopePlan.plan.entries.length > 0 || scopePlan.plan.removals.length > 0;
-    const hasSyncPlannedOperations = [
-      ...scopePlan.plan.entries,
-      ...scopePlan.plan.removals,
-    ].some((entry) => entry.operation !== 'skip');
     const hasCodexPlannedOperations =
       scopePlan.codexExtensionPlan?.operations.some(
         (operation) => operation.action !== 'skip',

--- a/packages/cli/src/commands/sync/index.test.ts
+++ b/packages/cli/src/commands/sync/index.test.ts
@@ -368,6 +368,20 @@ describe('createSyncCommand', () => {
     expect(capture.success).toContain('\nSync applied successfully.');
   });
 
+  it('apply (default): executes skip-only plans to reconcile manifest state', async () => {
+    const { capture, command, executeSyncPlan } = createHarness({
+      plans: [createPlan('skip')],
+      executeResults: [{ applied: 0, failed: 0, skipped: 1 }],
+    });
+
+    await runSyncCommand(command, {
+      globalArgs: ['--scope', 'project'],
+    });
+
+    expect(executeSyncPlan).toHaveBeenCalledTimes(1);
+    expect(capture.info).toContain('\nNo changes required.');
+  });
+
   it('apply (default): executes transformed rule copy plans', async () => {
     const { command, executeSyncPlan } = createHarness({
       adapters: [createAdapter('cursor')],

--- a/packages/cli/src/engine/engine.integration.test.ts
+++ b/packages/cli/src/engine/engine.integration.test.ts
@@ -3,6 +3,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readlink,
   rm,
   writeFile,
 } from 'node:fs/promises';
@@ -10,6 +11,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { DEFAULT_SYNC_CONFIG } from '@config/sync-config';
+import { createSymlink } from '@fs/io';
 import { createEmptyManifest, loadManifest } from '@manifest/manager';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -106,6 +108,65 @@ describe('sync engine integration', () => {
     expect(
       secondPlan.entries.every((entry) => entry.operation === 'skip'),
     ).toBe(true);
+  });
+
+  it('repairs missing manifest entries for pre-existing in-sync symlinks', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-engine-int-'));
+    tempDirs.push(root);
+    const adapter = createTestAdapter();
+    const manifestPath = join(root, '.oat', 'sync', 'manifest.json');
+    await seedCanonical(root);
+
+    const skillCanonical = join(root, '.agents', 'skills', 'skill-one');
+    const agentCanonical = join(root, '.agents', 'agents', 'agent-one');
+    await Promise.all([
+      createSymlink(
+        skillCanonical,
+        join(root, '.claude', 'skills', 'skill-one'),
+        undefined,
+        false,
+      ),
+      createSymlink(
+        agentCanonical,
+        join(root, '.claude', 'agents', 'agent-one'),
+        undefined,
+        false,
+      ),
+    ]);
+
+    const emptyManifest = createEmptyManifest();
+    const canonical = await scanCanonical(root, 'project');
+    const plan = await computeSyncPlan({
+      canonical,
+      adapters: [adapter],
+      manifest: emptyManifest,
+      scope: 'project',
+      config: DEFAULT_SYNC_CONFIG,
+      scopeRoot: root,
+    });
+
+    expect(plan.entries).toHaveLength(2);
+    expect(plan.entries.every((entry) => entry.operation === 'skip')).toBe(
+      true,
+    );
+
+    const result = await executeSyncPlan(plan, emptyManifest, manifestPath);
+    const manifest = await loadManifest(manifestPath);
+
+    expect(result.applied).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.skipped).toBe(2);
+    expect(
+      manifest.entries.map((entry) => [entry.canonicalPath, entry.provider]),
+    ).toEqual(
+      expect.arrayContaining([
+        ['.agents/skills/skill-one', 'claude'],
+        ['.agents/agents/agent-one', 'claude'],
+      ]),
+    );
+    expect(
+      await readlink(join(root, '.claude', 'skills', 'skill-one')),
+    ).toBeDefined();
   });
 
   it('dry-run: computeSyncPlan without execute makes zero fs changes', async () => {


### PR DESCRIPTION
## Summary

This fixes a provider-sync edge case where `oat sync` could leave `.oat/sync/manifest.json` stale even though the provider views were already correct on disk.

The issue showed up after adding bundled pack reconciliation to `oat tools update`: if provider symlinks already existed for a newly added canonical skill, `sync` would classify those entries as `skip` and report success, but the missing manifest rows would never be written. That left `oat status` reporting providers as out of sync.

## Root Cause

`computeSyncPlan()` correctly emits `skip` when a provider path already points at the right canonical target.

`executeSyncPlan()` already contains the repair path for this situation via `ensureSkipEntryManaged()`, which adds missing manifest entries for skip-only rows.

The bug was in `runSyncApply()`: it only executed the sync engine when a scope had at least one non-skip filesystem operation. For skip-only plans, it returned early, so the manifest repair logic never ran.

## Changes

- Execute sync plans whenever a scope has sync entries, even if every entry is `skip`.
- Preserve the existing no-op user-facing output when no filesystem changes are required.
- Add a command-level regression test proving `sync` still invokes execution for skip-only plans.
- Add an engine integration test covering the exact repair path where in-sync provider symlinks exist before corresponding manifest rows.
- Remove dead state from `sync/apply.ts` after the behavior change.

## Impact

- `oat sync` now repairs manifest drift for already-correct provider entries instead of silently leaving the manifest stale.
- `oat tools update` can rely on its follow-up sync to reconcile newly added bundled skills when provider entries already exist.
- `oat status` should stop reporting false out-of-sync conditions for this specific manifest/provider mismatch.

## Validation

Ran locally:

- `pnpm --filter @tkstang/oat-cli test -- --run packages/cli/src/commands/sync/index.test.ts packages/cli/src/engine/engine.integration.test.ts`
- `pnpm --filter @tkstang/oat-cli lint`
- `pnpm --filter @tkstang/oat-cli type-check`

Note: the package test command executed the CLI package suite in this repo configuration, and it passed.

## Follow-up

There is still room to add a higher-level end-to-end regression that drives the original `oat tools update` repro directly, but this change covers the underlying sync behavior that caused the issue.
