### PR TITLE
fix: correct docs scaffold templates and publish flow

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -71,14 +71,15 @@ jobs:
         env:
           NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc.publish
         run: |
-          for pkg_dir in \
-            packages/docs-transforms \
-            packages/docs-config \
-            packages/docs-theme \
-            packages/cli
+          for pkg_name in \
+            @tkstang/oat-docs-transforms \
+            @tkstang/oat-docs-config \
+            @tkstang/oat-docs-theme \
+            @tkstang/oat-cli
           do
-            (
-              cd "$pkg_dir"
-              npm publish --dry-run --access public
-            )
+            pack_dir="$(mktemp -d)"
+            pnpm --filter "$pkg_name" pack --pack-destination "$pack_dir"
+            tarball="$(find "$pack_dir" -maxdepth 1 -name '*.tgz' -print -quit)"
+            npm publish --dry-run --access public "$tarball"
+            rm -rf "$pack_dir"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,16 +62,17 @@ jobs:
         env:
           NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc.publish
         run: |
-          for pkg_dir in \
-            packages/docs-transforms \
-            packages/docs-config \
-            packages/docs-theme \
-            packages/cli
+          for pkg_name in \
+            @tkstang/oat-docs-transforms \
+            @tkstang/oat-docs-config \
+            @tkstang/oat-docs-theme \
+            @tkstang/oat-cli
           do
-            (
-              cd "$pkg_dir"
-              npm publish --access public
-            )
+            pack_dir="$(mktemp -d)"
+            pnpm --filter "$pkg_name" pack --pack-destination "$pack_dir"
+            tarball="$(find "$pack_dir" -maxdepth 1 -name '*.tgz' -print -quit)"
+            npm publish --access public "$tarball"
+            rm -rf "$pack_dir"
           done
 
   create-release:

--- a/.oat/templates/docs-app-fuma/docs/index.md
+++ b/.oat/templates/docs-app-fuma/docs/index.md
@@ -1,11 +1,11 @@
 ---
-title: { { SITE_NAME } }
-description: { { SITE_DESCRIPTION } }
+title: '{{SITE_NAME}}'
+description: '{{SITE_DESCRIPTION}}'
 ---
 
 # {{SITE_NAME}}
 
-Use this site as the central documentation hub for the repository. It is organized to support both human readers and AI agents, with every directory exposing an `index.md` entrypoint.
+Use this file as the map to the repository's central documentation site. The site is organized to support both human readers and AI agents, with every directory exposing an `index.md` entrypoint.
 
 ## Contents
 

--- a/.oat/templates/docs-app-fuma/tsconfig.json
+++ b/.oat/templates/docs-app-fuma/tsconfig.json
@@ -14,6 +14,7 @@
     "jsx": "preserve",
     "incremental": true,
     "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
       "fumadocs-mdx:collections/*": [".source/*"]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkstang/oat-cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/scripts/bundle-assets.sh
+++ b/packages/cli/scripts/bundle-assets.sh
@@ -78,6 +78,29 @@ cp -R "${REPO_ROOT}/.oat/templates/ideas" "${ASSETS}/templates/"
 cp -R "${REPO_ROOT}/.oat/templates/docs-app-mkdocs" "${ASSETS}/templates/"
 cp -R "${REPO_ROOT}/.oat/templates/docs-app-fuma" "${ASSETS}/templates/"
 
+node - "${REPO_ROOT}" "${ASSETS}" <<'EOF'
+const { readFileSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const repoRoot = process.argv[2];
+const assetsRoot = process.argv[3];
+const packageNames = ['docs-config', 'docs-theme', 'docs-transforms'];
+const versions = Object.fromEntries(
+  packageNames.map((name) => {
+    const pkg = JSON.parse(
+      readFileSync(join(repoRoot, 'packages', name, 'package.json'), 'utf8'),
+    );
+    return [name, pkg.version];
+  }),
+);
+
+writeFileSync(
+  join(assetsRoot, 'public-package-versions.json'),
+  `${JSON.stringify(versions, null, 2)}\n`,
+  'utf8',
+);
+EOF
+
 # Bundle OAT documentation for core pack (oat-docs skill)
 if [ -d "${REPO_ROOT}/apps/oat-docs/docs" ]; then
   cp -R "${REPO_ROOT}/apps/oat-docs/docs/." "${ASSETS}/docs/"

--- a/packages/cli/src/app/create-program.ts
+++ b/packages/cli/src/app/create-program.ts
@@ -3,7 +3,7 @@ import { Command, Option } from 'commander';
 const PROGRAM_NAME = 'oat';
 const PROGRAM_DESCRIPTION =
   'Open Agent Toolkit CLI for provider interoperability';
-const PROGRAM_VERSION = '0.0.5';
+const PROGRAM_VERSION = '0.0.7';
 const SCOPE_CHOICES = ['project', 'user', 'all'] as const;
 
 export function createProgram(): Command {

--- a/packages/cli/src/commands/docs/init/integration.test.ts
+++ b/packages/cli/src/commands/docs/init/integration.test.ts
@@ -120,6 +120,26 @@ describe('scaffold integration', () => {
       expect(layout).toContain('Test Docs Documentation');
       expect(layout).toContain('Integration test documentation');
 
+      const tsconfig = JSON.parse(
+        await readFile(join(result.appRoot, 'tsconfig.json'), 'utf8'),
+      ) as {
+        compilerOptions?: {
+          baseUrl?: string;
+          paths?: Record<string, string[]>;
+        };
+      };
+      expect(tsconfig.compilerOptions?.baseUrl).toBe('.');
+      expect(tsconfig.compilerOptions?.paths?.['@/*']).toEqual(['./*']);
+
+      const docsIndex = await readFile(
+        join(result.appRoot, 'docs', 'index.md'),
+        'utf8',
+      );
+      expect(docsIndex).toContain("title: 'Test Docs Documentation'");
+      expect(docsIndex).toContain(
+        "description: 'Integration test documentation'",
+      );
+
       // Verify package.json is valid JSON with OAT workspace deps
       const packageJson = JSON.parse(
         await readFile(join(result.appRoot, 'package.json'), 'utf8'),
@@ -158,10 +178,25 @@ describe('scaffold integration', () => {
       const root = await mkdtemp(join(tmpdir(), 'oat-integration-consuming-'));
       createdRoots.push(root);
 
-      // Seed a CLI package.json adjacent to assetsRoot for version resolution
+      await writeFile(
+        join(assetsRoot, 'public-package-versions.json'),
+        JSON.stringify(
+          {
+            'docs-config': '2.0.0',
+            'docs-theme': '2.1.0',
+            'docs-transforms': '2.2.0',
+          },
+          null,
+          2,
+        ),
+        'utf8',
+      );
+
+      // Seed a CLI package.json adjacent to assetsRoot to verify it is ignored
+      // when bundled public package versions are available.
       await writeFile(
         join(dirname(assetsRoot), 'package.json'),
-        JSON.stringify({ name: '@tkstang/oat-cli', version: '2.0.0' }),
+        JSON.stringify({ name: '@tkstang/oat-cli', version: '9.9.9' }),
         'utf8',
       );
 
@@ -199,10 +234,10 @@ describe('scaffold integration', () => {
         '^2.0.0',
       );
       expect(packageJson.dependencies['@tkstang/oat-docs-theme']).toBe(
-        '^2.0.0',
+        '^2.1.0',
       );
       expect(packageJson.dependencies['@tkstang/oat-docs-transforms']).toBe(
-        '^2.0.0',
+        '^2.2.0',
       );
 
       // Verify oat CLI with app-relative paths

--- a/packages/cli/src/commands/docs/init/scaffold.test.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.test.ts
@@ -40,7 +40,16 @@ const FUMA_TEMPLATE_FILES: Record<string, string> = {
     "const config = {\n  plugins: {\n    '@tailwindcss/postcss': {},\n  },\n};\n\nexport default config;\n",
   'source.config.ts':
     "import { defineConfig } from 'fumadocs-mdx/config';\nexport default defineConfig({});\n",
-  'tsconfig.json': '{ "extends": "next/core-js" }\n',
+  'tsconfig.json': `{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "fumadocs-mdx:collections/*": [".source/*"]
+    }
+  }
+}
+`,
   'package.json.template': `{
   "name": "{{PACKAGE_NAME}}",
   "description": "{{SITE_DESCRIPTION}}",
@@ -72,7 +81,15 @@ const FUMA_TEMPLATE_FILES: Record<string, string> = {
     "import { DocsPage, Mermaid, Tab, Tabs } from '@tkstang/oat-docs-theme';\nimport defaultComponents from 'fumadocs-ui/mdx';\nexport default function Page() { return <div />; }\n",
   'app/api/search/route.ts':
     "import { createFromSource } from 'fumadocs-core/search/server';\nimport { source } from '@/lib/source';\nconst search = createFromSource(source);\nexport const revalidate = false;\nexport const { staticGET: GET } = search;\n",
-  'docs/index.md': '# {{SITE_NAME}}\n\n{{SITE_DESCRIPTION}}\n',
+  'docs/index.md': `---
+title: '{{SITE_NAME}}'
+description: '{{SITE_DESCRIPTION}}'
+---
+
+# {{SITE_NAME}}
+
+{{SITE_DESCRIPTION}}
+`,
   'docs/getting-started.md': '# Getting Started\n',
   'docs/contributing.md': '# Contributing\n',
 };
@@ -229,6 +246,15 @@ describe('scaffoldDocsApp', () => {
     );
     expect(layout).toContain('Project documentation site');
 
+    const docsIndex = await readFile(
+      join(result.appRoot, 'docs', 'index.md'),
+      'utf8',
+    );
+    expect(docsIndex).toContain("title: 'My Docs Documentation'");
+    expect(docsIndex).toContain("description: 'Project documentation site'");
+    expect(docsIndex).not.toContain('{{SITE_NAME}}');
+    expect(docsIndex).not.toContain('{{SITE_DESCRIPTION}}');
+
     const packageJson = JSON.parse(
       await readFile(join(result.appRoot, 'package.json'), 'utf8'),
     ) as {
@@ -253,6 +279,18 @@ describe('scaffoldDocsApp', () => {
     expect(result.createdFiles).toContain(
       join('app', 'api', 'search', 'route.ts'),
     );
+
+    const tsconfig = JSON.parse(
+      await readFile(join(result.appRoot, 'tsconfig.json'), 'utf8'),
+    ) as {
+      compilerOptions?: {
+        baseUrl?: string;
+        paths?: Record<string, string[]>;
+      };
+    };
+    expect(tsconfig.compilerOptions?.baseUrl).toBe('.');
+    expect(tsconfig.compilerOptions?.paths?.['@/*']).toEqual(['./*']);
+
     expect(result.documentationConfig).toEqual({
       root: 'apps/my-docs',
       tooling: 'fumadocs',
@@ -288,7 +326,7 @@ describe('scaffoldDocsApp', () => {
     expect(packageJson.devDependencies['prettier']).toBeUndefined();
   });
 
-  it('uses versioned deps and oat CLI for consuming repos', async () => {
+  it('uses bundled package versions for consuming repos', async () => {
     const root = await mkdtemp(join(tmpdir(), 'oat-docs-consuming-'));
     createdRoots.push(root);
     const assetsRoot = await seedAssets(
@@ -296,11 +334,24 @@ describe('scaffoldDocsApp', () => {
       'docs-app-fuma',
       FUMA_TEMPLATE_FILES,
     );
+    await writeFile(
+      join(assetsRoot, 'public-package-versions.json'),
+      JSON.stringify(
+        {
+          'docs-config': '1.2.3',
+          'docs-theme': '2.3.4',
+          'docs-transforms': '3.4.5',
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
 
-    // Seed a CLI package.json so version resolution finds it
+    // Seed a mismatched CLI package.json to verify the manifest takes precedence.
     await writeFile(
       join(root, 'package.json'),
-      JSON.stringify({ name: '@tkstang/oat-cli', version: '1.2.3' }),
+      JSON.stringify({ name: '@tkstang/oat-cli', version: '9.9.9' }),
       'utf8',
     );
 
@@ -325,9 +376,9 @@ describe('scaffoldDocsApp', () => {
 
     // Should use versioned deps, not workspace:*
     expect(packageJson.dependencies['@tkstang/oat-docs-config']).toBe('^1.2.3');
-    expect(packageJson.dependencies['@tkstang/oat-docs-theme']).toBe('^1.2.3');
+    expect(packageJson.dependencies['@tkstang/oat-docs-theme']).toBe('^2.3.4');
     expect(packageJson.dependencies['@tkstang/oat-docs-transforms']).toBe(
-      '^1.2.3',
+      '^3.4.5',
     );
 
     // Should use oat CLI directly with paths relative to docs app
@@ -336,6 +387,46 @@ describe('scaffoldDocsApp', () => {
     );
     expect(packageJson.scripts['prebuild']).toBe(
       'fumadocs-mdx && oat docs generate-index --docs-dir docs --output index.md',
+    );
+  });
+
+  it('falls back to the CLI version when bundled package versions are missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-docs-consuming-fallback-'));
+    createdRoots.push(root);
+    const assetsRoot = await seedAssets(
+      root,
+      'docs-app-fuma',
+      FUMA_TEMPLATE_FILES,
+    );
+
+    await writeFile(
+      join(root, 'package.json'),
+      JSON.stringify({ name: '@tkstang/oat-cli', version: '1.2.3' }),
+      'utf8',
+    );
+
+    const result = await scaffoldDocsApp({
+      assetsRoot,
+      repoRoot: root,
+      repoShape: 'single-package',
+      framework: 'fumadocs',
+      appName: 'docs',
+      targetDir: 'docs',
+      siteDescription: 'My project docs',
+      lint: 'none',
+      format: 'none',
+    });
+
+    const packageJson = JSON.parse(
+      await readFile(join(result.appRoot, 'package.json'), 'utf8'),
+    ) as {
+      dependencies: Record<string, string>;
+    };
+
+    expect(packageJson.dependencies['@tkstang/oat-docs-config']).toBe('^1.2.3');
+    expect(packageJson.dependencies['@tkstang/oat-docs-theme']).toBe('^1.2.3');
+    expect(packageJson.dependencies['@tkstang/oat-docs-transforms']).toBe(
+      '^1.2.3',
     );
   });
 

--- a/packages/cli/src/commands/docs/init/scaffold.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.ts
@@ -103,14 +103,13 @@ export interface OatDepContext {
   oatPackageVersions: Record<string, string>;
 }
 
-// Assumes lockstep versioning: all @tkstang/oat-* packages are published at
-// the same version as @tkstang/oat-cli. If packages are ever versioned
-// independently, version resolution here will need per-package lookups.
 const OAT_DEP_PACKAGES = [
   'docs-config',
   'docs-theme',
   'docs-transforms',
 ] as const;
+const DEFAULT_OAT_PUBLISHED_VERSION = '0.0.5';
+const PUBLIC_PACKAGE_VERSIONS_FILE = 'public-package-versions.json';
 
 export async function detectIsOatRepo(repoRoot: string): Promise<boolean> {
   for (const pkg of OAT_DEP_PACKAGES) {
@@ -126,10 +125,35 @@ async function readCliVersion(assetsRoot: string): Promise<string> {
   try {
     const content = await readFile(join(cliRoot, 'package.json'), 'utf8');
     const pkg = JSON.parse(content) as { version?: string };
-    return pkg.version ?? '0.0.5';
+    return pkg.version ?? DEFAULT_OAT_PUBLISHED_VERSION;
   } catch {
-    return '0.0.5';
+    return DEFAULT_OAT_PUBLISHED_VERSION;
   }
+}
+
+async function readBundledOatPackageVersions(
+  assetsRoot: string,
+): Promise<Record<string, string>> {
+  try {
+    const content = await readFile(
+      join(assetsRoot, PUBLIC_PACKAGE_VERSIONS_FILE),
+      'utf8',
+    );
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return Object.fromEntries(
+      OAT_DEP_PACKAGES.flatMap((name) =>
+        typeof parsed[name] === 'string' ? [[name, parsed[name]]] : [],
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function buildFallbackOatPackageVersions(
+  version: string,
+): Record<string, string> {
+  return Object.fromEntries(OAT_DEP_PACKAGES.map((name) => [name, version]));
 }
 
 export async function resolveOatDepContext(
@@ -141,10 +165,11 @@ export async function resolveOatDepContext(
     return { isOatRepo, oatPackageVersions: {} };
   }
 
-  const version = await readCliVersion(assetsRoot);
-  const oatPackageVersions = Object.fromEntries(
-    OAT_DEP_PACKAGES.map((name) => [name, version]),
-  );
+  const cliVersion = await readCliVersion(assetsRoot);
+  const oatPackageVersions = {
+    ...buildFallbackOatPackageVersions(cliVersion),
+    ...(await readBundledOatPackageVersions(assetsRoot)),
+  };
   return { isOatRepo, oatPackageVersions };
 }
 
@@ -197,7 +222,7 @@ function oatDepVersion(depContext: OatDepContext, packageName: string): string {
   if (depContext.isOatRepo) {
     return 'workspace:*';
   }
-  return `^${depContext.oatPackageVersions[packageName] ?? '0.0.5'}`;
+  return `^${depContext.oatPackageVersions[packageName] ?? DEFAULT_OAT_PUBLISHED_VERSION}`;
 }
 
 function renderTemplate(

--- a/packages/cli/src/manifest/manager.ts
+++ b/packages/cli/src/manifest/manager.ts
@@ -10,7 +10,7 @@ import {
   ManifestSchema,
 } from './manifest.types';
 
-const OAT_VERSION = '0.0.5';
+const OAT_VERSION = '0.0.7';
 
 function formatIssuePath(path: (string | number)[]): string {
   if (path.length === 0) {

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkstang/oat-docs-config",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkstang/oat-docs-theme",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkstang/oat-docs-transforms",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- fix the Fumadocs docs app template so frontmatter placeholders render correctly and the generated tsconfig sets `baseUrl`
- make consuming-repo scaffolds prefer bundled public package versions instead of pinning unpublished CLI versions
- publish public packages from `pnpm pack` tarballs and align the lockstep public package versions to `0.0.7`

## Testing
- pnpm release:validate
- pnpm --filter @tkstang/oat-cli exec vitest run src/app/create-program.test.ts src/manifest/manager.test.ts src/commands/docs/init/scaffold.test.ts src/commands/docs/init/integration.test.ts
- local npm publish --dry-run from a tarball produced by `pnpm --filter @tkstang/oat-docs-config pack`
