### PR TITLE
[codex] Fix docs app scaffold dependencies

### DIFF
--- a/.oat/templates/docs-app-fuma/package.json.template
+++ b/.oat/templates/docs-app-fuma/package.json.template
@@ -26,8 +26,10 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@tkstang/oat-cli": "{{OAT_CLI_DEP}}",
     "@tailwindcss/postcss": "^4.2.1",
     "@types/mdx": "^2.0.13",
+    "@types/node": "^22.10.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "tailwindcss": "^4.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkstang/oat-cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/scripts/bundle-assets.sh
+++ b/packages/cli/scripts/bundle-assets.sh
@@ -84,7 +84,7 @@ const { join } = require('node:path');
 
 const repoRoot = process.argv[2];
 const assetsRoot = process.argv[3];
-const packageNames = ['docs-config', 'docs-theme', 'docs-transforms'];
+const packageNames = ['cli', 'docs-config', 'docs-theme', 'docs-transforms'];
 const versions = Object.fromEntries(
   packageNames.map((name) => {
     const pkg = JSON.parse(

--- a/packages/cli/src/commands/docs/init/integration.test.ts
+++ b/packages/cli/src/commands/docs/init/integration.test.ts
@@ -59,7 +59,12 @@ describe('scaffold integration', () => {
       await mkdir(join(root, 'apps'), { recursive: true });
 
       // Seed OAT package dirs so detectIsOatRepo returns true
-      for (const pkg of ['docs-config', 'docs-theme', 'docs-transforms']) {
+      for (const pkg of [
+        'cli',
+        'docs-config',
+        'docs-theme',
+        'docs-transforms',
+      ]) {
         const pkgDir = join(root, 'packages', pkg);
         await mkdir(pkgDir, { recursive: true });
         await writeFile(
@@ -160,6 +165,7 @@ describe('scaffold integration', () => {
       expect(packageJson.dependencies['@tkstang/oat-docs-transforms']).toBe(
         'workspace:*',
       );
+      expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
       expect(packageJson.devDependencies['markdownlint-cli2']).toBeUndefined();
       expect(packageJson.devDependencies['prettier']).toBeUndefined();
       expect(packageJson.devDependencies['oxfmt']).toBeDefined();
@@ -229,6 +235,7 @@ describe('scaffold integration', () => {
       ) as {
         scripts: Record<string, string>;
         dependencies: Record<string, string>;
+        devDependencies: Record<string, string>;
       };
       expect(packageJson.dependencies['@tkstang/oat-docs-config']).toBe(
         '^2.0.0',
@@ -239,13 +246,15 @@ describe('scaffold integration', () => {
       expect(packageJson.dependencies['@tkstang/oat-docs-transforms']).toBe(
         '^2.2.0',
       );
+      expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
+      expect(packageJson.devDependencies['@tkstang/oat-cli']).toBe('^9.9.9');
 
       // Verify oat CLI with app-relative paths
       expect(packageJson.scripts['predev']).toBe(
-        'fumadocs-mdx && oat docs generate-index --docs-dir docs --output index.md',
+        'fumadocs-mdx && (oat docs generate-index --docs-dir docs --output index.md || true)',
       );
       expect(packageJson.scripts['prebuild']).toBe(
-        'fumadocs-mdx && oat docs generate-index --docs-dir docs --output index.md',
+        'fumadocs-mdx && (oat docs generate-index --docs-dir docs --output index.md || true)',
       );
     },
   );

--- a/packages/cli/src/commands/docs/init/mkdocs-compat.test.ts
+++ b/packages/cli/src/commands/docs/init/mkdocs-compat.test.ts
@@ -109,6 +109,7 @@ describe('MkDocs scaffold compatibility (FR8)', () => {
       expect(packageJson).not.toContain('@tkstang/oat-docs-config');
       expect(packageJson).not.toContain('@tkstang/oat-docs-theme');
       expect(packageJson).not.toContain('@tkstang/oat-docs-transforms');
+      expect(packageJson).not.toContain('@tkstang/oat-cli');
     },
   );
 });

--- a/packages/cli/src/commands/docs/init/scaffold.test.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.test.ts
@@ -68,6 +68,8 @@ const FUMA_TEMPLATE_FILES: Record<string, string> = {
     "@tkstang/oat-docs-transforms": "{{OAT_DOCS_TRANSFORMS_DEP}}"
   },
   "devDependencies": {
+    "@tkstang/oat-cli": "{{OAT_CLI_DEP}}",
+    "@types/node": "^22.10.0",
     "typescript": "^5.8.3"{{FUMA_DEV_DEPENDENCIES}}
   }
 }
@@ -260,11 +262,14 @@ describe('scaffoldDocsApp', () => {
     ) as {
       description: string;
       scripts: Record<string, string>;
+      dependencies: Record<string, string>;
       devDependencies: Record<string, string>;
     };
     expect(packageJson.description).toBe('Project documentation site');
     expect(packageJson.scripts['predev']).toContain('docs generate-index');
     expect(packageJson.scripts['prebuild']).toContain('docs generate-index');
+    expect(packageJson.devDependencies['@tkstang/oat-cli']).toBe('^0.0.8');
+    expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
     expect(packageJson.devDependencies['markdownlint-cli2']).toBeUndefined();
     expect(packageJson.devDependencies['prettier']).toBeUndefined();
 
@@ -322,6 +327,8 @@ describe('scaffoldDocsApp', () => {
     const packageJson = JSON.parse(
       await readFile(join(result.appRoot, 'package.json'), 'utf8'),
     ) as { devDependencies: Record<string, string> };
+    expect(packageJson.devDependencies['@tkstang/oat-cli']).toBe('^0.0.8');
+    expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
     expect(packageJson.devDependencies['markdownlint-cli2']).toBeUndefined();
     expect(packageJson.devDependencies['prettier']).toBeUndefined();
   });
@@ -372,6 +379,7 @@ describe('scaffoldDocsApp', () => {
     ) as {
       scripts: Record<string, string>;
       dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
     };
 
     // Should use versioned deps, not workspace:*
@@ -380,13 +388,15 @@ describe('scaffoldDocsApp', () => {
     expect(packageJson.dependencies['@tkstang/oat-docs-transforms']).toBe(
       '^3.4.5',
     );
+    expect(packageJson.devDependencies['@tkstang/oat-cli']).toBe('^9.9.9');
+    expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
 
     // Should use oat CLI directly with paths relative to docs app
     expect(packageJson.scripts['predev']).toBe(
-      'fumadocs-mdx && oat docs generate-index --docs-dir docs --output index.md',
+      'fumadocs-mdx && (oat docs generate-index --docs-dir docs --output index.md || true)',
     );
     expect(packageJson.scripts['prebuild']).toBe(
-      'fumadocs-mdx && oat docs generate-index --docs-dir docs --output index.md',
+      'fumadocs-mdx && (oat docs generate-index --docs-dir docs --output index.md || true)',
     );
   });
 
@@ -421,6 +431,7 @@ describe('scaffoldDocsApp', () => {
       await readFile(join(result.appRoot, 'package.json'), 'utf8'),
     ) as {
       dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
     };
 
     expect(packageJson.dependencies['@tkstang/oat-docs-config']).toBe('^1.2.3');
@@ -428,6 +439,8 @@ describe('scaffoldDocsApp', () => {
     expect(packageJson.dependencies['@tkstang/oat-docs-transforms']).toBe(
       '^1.2.3',
     );
+    expect(packageJson.devDependencies['@tkstang/oat-cli']).toBe('^1.2.3');
+    expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
   });
 
   it('uses workspace:* deps and pnpm -w run cli for OAT repo', async () => {
@@ -440,7 +453,7 @@ describe('scaffoldDocsApp', () => {
     );
 
     // Seed the OAT package directories so detectIsOatRepo returns true
-    for (const pkg of ['docs-config', 'docs-theme', 'docs-transforms']) {
+    for (const pkg of ['cli', 'docs-config', 'docs-theme', 'docs-transforms']) {
       const pkgDir = join(root, 'packages', pkg);
       await mkdir(pkgDir, { recursive: true });
       await writeFile(
@@ -468,6 +481,7 @@ describe('scaffoldDocsApp', () => {
     ) as {
       scripts: Record<string, string>;
       dependencies: Record<string, string>;
+      devDependencies: Record<string, string>;
     };
 
     // Should use workspace:* for OAT packages
@@ -480,6 +494,8 @@ describe('scaffoldDocsApp', () => {
     expect(packageJson.dependencies['@tkstang/oat-docs-transforms']).toBe(
       'workspace:*',
     );
+    expect(packageJson.devDependencies['@tkstang/oat-cli']).toBe('workspace:*');
+    expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
 
     // Should use pnpm -w run cli with full paths from workspace root
     expect(packageJson.scripts['predev']).toBe(

--- a/packages/cli/src/commands/docs/init/scaffold.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.ts
@@ -104,11 +104,12 @@ export interface OatDepContext {
 }
 
 const OAT_DEP_PACKAGES = [
+  'cli',
   'docs-config',
   'docs-theme',
   'docs-transforms',
 ] as const;
-const DEFAULT_OAT_PUBLISHED_VERSION = '0.0.5';
+const DEFAULT_OAT_PUBLISHED_VERSION = '0.0.8';
 const PUBLIC_PACKAGE_VERSIONS_FILE = 'public-package-versions.json';
 
 export async function detectIsOatRepo(repoRoot: string): Promise<boolean> {
@@ -215,7 +216,7 @@ function buildGenerateIndexCmd(isOatRepo: boolean, targetDir: string): string {
   if (isOatRepo) {
     return `pnpm -w run cli -- docs generate-index --docs-dir ${targetDir}/docs --output ${targetDir}/index.md`;
   }
-  return 'oat docs generate-index --docs-dir docs --output index.md';
+  return '(oat docs generate-index --docs-dir docs --output index.md || true)';
 }
 
 function oatDepVersion(depContext: OatDepContext, packageName: string): string {
@@ -260,6 +261,7 @@ function renderTemplate(
     '{{OAT_DOCS_CONFIG_DEP}}': oatDepVersion(depContext, 'docs-config'),
     '{{OAT_DOCS_THEME_DEP}}': oatDepVersion(depContext, 'docs-theme'),
     '{{OAT_DOCS_TRANSFORMS_DEP}}': oatDepVersion(depContext, 'docs-transforms'),
+    '{{OAT_CLI_DEP}}': oatDepVersion(depContext, 'cli'),
   };
 
   return Object.entries(replacements).reduce(

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkstang/oat-docs-config",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkstang/oat-docs-theme",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tkstang/oat-docs-transforms",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- make Fumadocs scaffolds tolerate missing global `oat` binaries during `predev` and `prebuild`
- add `@tkstang/oat-cli` and `@types/node` to the scaffolded Fumadocs app dev dependencies
- keep bundled version resolution and release metadata in sync for the public docs packages and CLI

## Root cause
Scaffolded Fumadocs apps depended on a globally installed `oat` binary and on hoisted Node type definitions. In single-package repos and CI installs scoped to the docs app directory, those assumptions break and `pnpm build` fails.

## Impact
Single-package consumer repos can install and build scaffolded Fumadocs docs apps without relying on workspace hoisting or a globally installed CLI. OAT monorepos keep using `workspace:*` and the workspace CLI path.

## Validation
- `pnpm --filter @tkstang/oat-cli test -- src/commands/docs/init/scaffold.test.ts src/commands/docs/init/integration.test.ts src/commands/docs/init/mkdocs-compat.test.ts src/release/public-package-contract.test.ts`
- pre-push hooks: `type-check`, `lint`, `format`
