### PR TITLE
fix: docs link rewriting fix and reusable checker

### DIFF
--- a/apps/oat-docs/docs/contributing/documentation.md
+++ b/apps/oat-docs/docs/contributing/documentation.md
@@ -27,13 +27,21 @@ Documentation should ship with the code it explains. This page covers the core d
    pnpm build:docs
    ```
 
-3. Run Markdown linting:
+3. Check rendered links against a local or deployed docs host:
+
+   ```bash
+   pnpm docs:check-links
+   # or target a local docs server explicitly
+   pnpm docs:check-links --url http://127.0.0.1:3000/open-agent-toolkit/
+   ```
+
+4. Run Markdown linting:
 
    ```bash
    pnpm --filter oat-docs docs:lint
    ```
 
-4. Run Markdown formatting:
+5. Run Markdown formatting:
 
    ```bash
    pnpm --filter oat-docs docs:format

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cli": "bash packages/cli/scripts/bundle-assets.sh && tsx --tsconfig packages/cli/tsconfig.json packages/cli/src/index.ts",
     "dev": "turbo run dev",
     "dev:docs": "pnpm --filter oat-docs dev",
+    "docs:check-links": "tsx tools/docs/check-links.ts",
     "format": "turbo run format",
     "format:fix": "turbo run format:fix",
     "hooks:disable-all": "node tools/git-hooks/manage-hooks.js disable-all",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
+    "@playwright/test": "^1.51.1",
     "@types/node": "^22.10.0",
     "lint-staged": "^15.2.11",
     "oxfmt": "^0.36.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",

--- a/packages/docs-transforms/src/remark-links.test.ts
+++ b/packages/docs-transforms/src/remark-links.test.ts
@@ -11,10 +11,15 @@ interface LinkResult {
   text: string;
 }
 
-async function transformLinks(markdown: string): Promise<LinkResult[]> {
+async function transformLinks(
+  markdown: string,
+  filePath = '/repo/docs/index.md',
+): Promise<LinkResult[]> {
   const processor = unified().use(remarkParse).use(remarkLinks);
   const tree = processor.parse(markdown);
-  const result = (await processor.run(tree)) as Root;
+  const result = (await processor.run(tree, {
+    path: filePath,
+  } as never)) as Root;
   const links: LinkResult[] = [];
   visit(result, 'link', (node: Link) => {
     let text = '';
@@ -43,7 +48,10 @@ describe('remarkLinks — URL rewriting', () => {
   });
 
   it('handles parent-relative index links with trailing-slash adjustment', async () => {
-    const links = await transformLinks('[Back](../reference/index.md)');
+    const links = await transformLinks(
+      '[Back](../reference/index.md)',
+      '/repo/docs/guide/concepts.md',
+    );
     expect(urls(links)).toEqual(['../../reference']);
   });
 
@@ -75,8 +83,17 @@ describe('remarkLinks — URL rewriting', () => {
   it('adds extra ../ for deep parent-relative links (trailing-slash compensation)', async () => {
     const links = await transformLinks(
       '[Contract](../../reference/docs-index-contract.md)',
+      '/repo/docs/guide/documentation/index.md',
     );
-    expect(urls(links)).toEqual(['../../../reference/docs-index-contract']);
+    expect(urls(links)).toEqual(['../../reference/docs-index-contract']);
+  });
+
+  it('rewrites source-relative links for non-index pages', async () => {
+    const links = await transformLinks(
+      '[Docs Commands](documentation/commands.md)',
+      '/repo/docs/guide/cli-reference.md',
+    );
+    expect(urls(links)).toEqual(['../documentation/commands']);
   });
 
   it('leaves non-.md links unchanged', async () => {
@@ -107,6 +124,11 @@ describe('remarkLinks — display text cleanup', () => {
   it('preserves human-readable display text unchanged', async () => {
     const links = await transformLinks('[Quickstart](quickstart.md)');
     expect(links[0].text).toBe('Quickstart');
+  });
+
+  it('strips .mdx from inline code display text', async () => {
+    const links = await transformLinks('[`quickstart.mdx`](quickstart.mdx)');
+    expect(links).toEqual([{ url: './quickstart', text: 'quickstart' }]);
   });
 
   it('does not touch inline code that is not a .md path', async () => {

--- a/packages/docs-transforms/src/remark-links.ts
+++ b/packages/docs-transforms/src/remark-links.ts
@@ -1,15 +1,22 @@
+import { posix as path } from 'node:path';
+
 import type { InlineCode, Link, Root } from 'mdast';
 import type { Plugin } from 'unified';
 import { visit } from 'unist-util-visit';
 
 /**
- * Strip `.md` extension and collapse `/index` from a relative path.
- * Returns null if the path is not a `.md` link that should be rewritten.
+ * Strip markdown extension and collapse `/index` from a relative path.
+ * Returns null if the path is not a markdown link that should be rewritten.
  */
 function cleanMdPath(raw: string): string | null {
-  if (!raw.endsWith('.md')) return null;
+  const extension = raw.endsWith('.mdx')
+    ? '.mdx'
+    : raw.endsWith('.md')
+      ? '.md'
+      : null;
+  if (!extension) return null;
 
-  let cleaned = raw.slice(0, -3);
+  let cleaned = raw.slice(0, -extension.length);
 
   if (cleaned.endsWith('/index')) {
     cleaned = cleaned.slice(0, -'/index'.length) || '.';
@@ -21,14 +28,56 @@ function cleanMdPath(raw: string): string | null {
   return cleaned;
 }
 
+function normalizeFsPath(raw: string): string {
+  return raw.replaceAll('\\', '/');
+}
+
+function docsRelativeFilePath(filePath: string): string | null {
+  const normalized = normalizeFsPath(filePath);
+  const marker = '/docs/';
+  const index = normalized.lastIndexOf(marker);
+  if (index === -1) return null;
+
+  return normalized.slice(index + marker.length);
+}
+
+function routePathFromDocsFile(filePath: string): string | null {
+  const cleaned = cleanMdPath(filePath);
+  if (cleaned === null) return null;
+  if (cleaned === '.') return '/';
+
+  return path.normalize(`/${cleaned}`);
+}
+
+function resolveRelativeDocsLink(
+  sourceFilePath: string,
+  targetPath: string,
+): string | null {
+  const sourceDocsFile = docsRelativeFilePath(sourceFilePath);
+  if (!sourceDocsFile) return null;
+
+  const targetDocsFile = path
+    .normalize(path.join('/', path.dirname(sourceDocsFile), targetPath))
+    .slice(1);
+
+  const currentRoute = routePathFromDocsFile(sourceDocsFile);
+  const targetRoute = routePathFromDocsFile(targetDocsFile);
+  if (!currentRoute || !targetRoute) return null;
+
+  const relativeRoute = path.relative(currentRoute, targetRoute) || '.';
+  return relativeRoute.startsWith('.') ? relativeRoute : `./${relativeRoute}`;
+}
+
 /**
- * Remark plugin that rewrites relative `.md` links to extensionless paths
- * for Fumadocs routing.
+ * Remark plugin that rewrites source-relative markdown links to routed,
+ * extensionless URLs that still work once pages are emitted with trailing
+ * slashes.
  *
  * URL rewriting:
- * - `quickstart.md` → `./quickstart`
- * - `cli/index.md` → `./cli`
- * - `../reference/index.md` → `../reference`
+ * - `quickstart.md` from `docs/index.md` → `./quickstart`
+ * - `documentation/commands.md` from `docs/guide/cli-reference.md`
+ *   → `../documentation/commands`
+ * - `../reference/index.md` from `docs/guide/concepts.md` → `../../reference`
  * - Absolute URLs and anchors are left unchanged.
  *
  * Display text cleanup:
@@ -38,7 +87,7 @@ function cleanMdPath(raw: string): string | null {
  *   while rendering clean labels on the web.
  */
 export const remarkLinks: Plugin<[], Root> = function remarkLinks() {
-  return (tree: Root) => {
+  return (tree: Root, file?: { path?: string }) => {
     visit(tree, 'link', (node: Link) => {
       const { url } = node;
 
@@ -55,15 +104,17 @@ export const remarkLinks: Plugin<[], Root> = function remarkLinks() {
       const cleaned = cleanMdPath(path);
       if (cleaned === null) return;
 
-      // With trailingSlash enabled, each page URL has an extra directory level
-      // (e.g., /guide/commands/ instead of /guide/commands), so ../ links need
-      // one additional ../ to reach the correct parent.
-      const adjusted = cleaned.startsWith('..') ? `../${cleaned}` : cleaned;
+      const rewrittenPath =
+        typeof file?.path === 'string'
+          ? (resolveRelativeDocsLink(file.path, path) ?? cleaned)
+          : cleaned;
 
       // Rewrite URL
       const prefix =
-        adjusted.startsWith('.') || adjusted.startsWith('/') ? '' : './';
-      node.url = prefix + adjusted + fragment;
+        rewrittenPath.startsWith('.') || rewrittenPath.startsWith('/')
+          ? ''
+          : './';
+      node.url = prefix + rewrittenPath + fragment;
 
       // Clean display text when it's a single inlineCode child with a .md path
       const firstChild = node.children[0];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.8.1
         version: 19.8.1
+      '@playwright/test':
+        specifier: ^1.51.1
+        version: 1.59.1
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.7
@@ -52,16 +55,16 @@ importers:
         version: link:../../packages/docs-transforms
       fumadocs-core:
         specifier: ^16.6.13
-        version: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: ^14.2.9
-        version: 14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       fumadocs-ui:
         specifier: ^16.6.13
-        version: 16.6.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
+        version: 16.6.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
       next:
         specifier: ^16.1.6
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -160,13 +163,13 @@ importers:
         version: 22.19.7
       fumadocs-core:
         specifier: ^16.6.13
-        version: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: ^14.2.9
-        version: 14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       next:
         specifier: ^16.1.6
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -200,13 +203,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       fumadocs-core:
         specifier: ^16.6.13
-        version: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-ui:
         specifier: ^16.6.13
-        version: 16.6.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
+        version: 16.6.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
       next:
         specifier: ^16.1.6
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -1286,6 +1289,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2688,6 +2696,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3595,6 +3608,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plimit-lit@1.6.1:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
@@ -5015,6 +5038,10 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.52.0':
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
@@ -6424,10 +6451,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
+  fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.1
       '@orama/orama': 3.1.18
@@ -6460,21 +6490,21 @@ snapshots:
       '@types/react': 19.2.14
       flexsearch: 0.8.212
       lucide-react: 0.577.0(react@19.2.4)
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
+  fumadocs-mdx@14.2.9(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.3
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -6491,13 +6521,13 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       vite: 7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.6.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
+  fumadocs-ui@16.6.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1):
     dependencies:
       '@fumadocs/tailwind': 0.0.3(tailwindcss@4.2.1)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6511,7 +6541,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.6.13(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(flexsearch@0.8.212)(lucide-react@0.577.0(react@19.2.4))(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       lucide-react: 0.577.0(react@19.2.4)
       motion: 12.35.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6525,7 +6555,7 @@ snapshots:
       unist-util-visit: 5.1.0
     optionalDependencies:
       '@types/react': 19.2.14
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react-dom'
@@ -7484,7 +7514,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -7503,6 +7533,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -7655,6 +7686,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.1
       pathe: 2.0.3
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plimit-lit@1.6.1:
     dependencies:

--- a/tools/docs/check-links.ts
+++ b/tools/docs/check-links.ts
@@ -1,0 +1,401 @@
+import { writeFile } from 'node:fs/promises';
+
+import { chromium } from '@playwright/test';
+
+interface LinkSource {
+  source: string;
+  text: string;
+}
+
+interface LinkRecord {
+  url: string;
+  sources: LinkSource[];
+}
+
+interface PageRecord {
+  finalUrl: string | null;
+  fragments: Set<string>;
+  status: number | null;
+  url: string;
+}
+
+interface CheckResult {
+  finalUrl: string | null;
+  ok: boolean;
+  reason: string | null;
+  status: number | null;
+}
+
+interface BrokenLink {
+  reason: string | null;
+  sources: LinkSource[];
+  status: number | null;
+  type:
+    | 'external'
+    | 'internal-fragment'
+    | 'internal-page'
+    | 'internal-resource';
+  url: string;
+}
+
+interface LinkCheckReport {
+  broken: BrokenLink[];
+  brokenCount: number;
+  crawledPages: number;
+  discoveredLinks: number;
+  startUrl: string;
+}
+
+interface CliOptions {
+  checkExternal: boolean;
+  json: boolean;
+  maxPages: number;
+  output?: string;
+  timeoutMs: number;
+  url: string;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    checkExternal: true,
+    json: false,
+    maxPages: 400,
+    timeoutMs: 20_000,
+    url: 'https://voxmedia.github.io/open-agent-toolkit/',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (arg === '--no-external') {
+      options.checkExternal = false;
+      continue;
+    }
+    if (arg === '--url') {
+      options.url = argv[index + 1] ?? options.url;
+      index += 1;
+      continue;
+    }
+    if (arg === '--output') {
+      options.output = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--max-pages') {
+      options.maxPages =
+        Number.parseInt(argv[index + 1] ?? '', 10) || options.maxPages;
+      index += 1;
+      continue;
+    }
+    if (arg === '--timeout-ms') {
+      options.timeoutMs =
+        Number.parseInt(argv[index + 1] ?? '', 10) || options.timeoutMs;
+      index += 1;
+      continue;
+    }
+    if (!arg.startsWith('--')) {
+      options.url = arg;
+    }
+  }
+
+  return options;
+}
+
+function normalizeNoHash(raw: string, base?: string): string {
+  const url = new URL(raw, base);
+  url.hash = '';
+  return url.href;
+}
+
+function isHttp(url: URL): boolean {
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+function isInternalDocsPage(url: URL, start: URL, prefix: string): boolean {
+  if (!isHttp(url)) return false;
+  if (url.origin !== start.origin) return false;
+  if (!url.pathname.startsWith(prefix)) return false;
+
+  const last = url.pathname.split('/').pop() ?? '';
+  return !/\.[a-zA-Z0-9]+$/.test(last);
+}
+
+function addLink(
+  links: Map<string, LinkRecord>,
+  targetUrl: URL,
+  sourceUrl: string,
+  text: string,
+): void {
+  const existing = links.get(targetUrl.href) ?? {
+    url: targetUrl.href,
+    sources: [],
+  };
+  if (existing.sources.length < 10) {
+    existing.sources.push({
+      source: sourceUrl,
+      text: text.slice(0, 120),
+    });
+  }
+  links.set(targetUrl.href, existing);
+}
+
+async function run(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const start = new URL(options.url);
+  const prefix = start.pathname.endsWith('/')
+    ? start.pathname
+    : `${start.pathname}/`;
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const crawlQueue = [start.href];
+  const queued = new Set([start.href]);
+  const crawled = new Set<string>();
+  const pageData = new Map<string, PageRecord>();
+  const links = new Map<string, LinkRecord>();
+  const fetchCache = new Map<string, CheckResult>();
+
+  async function crawlOne(url: string): Promise<void> {
+    let response;
+    try {
+      response = await page.goto(url, {
+        timeout: options.timeoutMs,
+        waitUntil: 'domcontentloaded',
+      });
+    } catch {
+      pageData.set(url, {
+        finalUrl: null,
+        fragments: new Set(),
+        status: null,
+        url,
+      });
+      return;
+    }
+
+    const finalUrl = page.url();
+    const status = response?.status() ?? null;
+    const fragments = await page
+      .locator('[id], a[name]')
+      .evaluateAll((nodes) => {
+        const values = new Set<string>();
+        for (const node of nodes) {
+          const id = node.getAttribute('id');
+          const name = node.getAttribute('name');
+          if (id) values.add(id);
+          if (name) values.add(name);
+        }
+        return [...values];
+      });
+
+    const pageKey = normalizeNoHash(finalUrl);
+    pageData.set(pageKey, {
+      finalUrl,
+      fragments: new Set(fragments),
+      status,
+      url: pageKey,
+    });
+
+    const anchors = await page.locator('a[href]').evaluateAll((nodes) =>
+      nodes.map((node) => ({
+        href: node.getAttribute('href') || '',
+        text: (node.textContent || '')
+          .trim()
+          .replace(/\s+/g, ' ')
+          .slice(0, 120),
+      })),
+    );
+
+    for (const anchor of anchors) {
+      const href = anchor.href.trim();
+      if (
+        !href ||
+        href.startsWith('data:') ||
+        href.startsWith('javascript:') ||
+        href.startsWith('mailto:') ||
+        href.startsWith('tel:')
+      ) {
+        continue;
+      }
+
+      let target;
+      try {
+        target = new URL(href, finalUrl);
+      } catch {
+        continue;
+      }
+
+      if (!isHttp(target)) continue;
+      addLink(links, target, pageKey, anchor.text);
+
+      const targetPage = new URL(target.href);
+      targetPage.hash = '';
+      if (
+        isInternalDocsPage(targetPage, start, prefix) &&
+        !queued.has(targetPage.href) &&
+        !crawled.has(targetPage.href) &&
+        queued.size < options.maxPages
+      ) {
+        queued.add(targetPage.href);
+        crawlQueue.push(targetPage.href);
+      }
+    }
+  }
+
+  async function fetchCheck(url: URL): Promise<CheckResult> {
+    const key = url.href;
+    const cached = fetchCache.get(key);
+    if (cached) return cached;
+
+    let result: CheckResult;
+    try {
+      let response = await fetch(key, {
+        headers: { 'user-agent': 'oat-link-checker/1.0' },
+        method: 'HEAD',
+        redirect: 'follow',
+      });
+      if (response.status === 403 || response.status === 405) {
+        response = await fetch(key, {
+          headers: { 'user-agent': 'oat-link-checker/1.0' },
+          method: 'GET',
+          redirect: 'follow',
+        });
+      }
+
+      result = {
+        finalUrl: response.url,
+        ok: response.ok,
+        reason: response.ok ? null : `HTTP ${response.status}`,
+        status: response.status,
+      };
+    } catch (error) {
+      result = {
+        finalUrl: null,
+        ok: false,
+        reason: String(error),
+        status: null,
+      };
+    }
+
+    fetchCache.set(key, result);
+    return result;
+  }
+
+  while (crawlQueue.length && crawled.size < options.maxPages) {
+    const next = crawlQueue.shift();
+    if (!next || crawled.has(next)) continue;
+    crawled.add(next);
+    await crawlOne(next);
+  }
+
+  const broken: BrokenLink[] = [];
+  for (const entry of links.values()) {
+    const target = new URL(entry.url);
+    const noHash = normalizeNoHash(target.href);
+    const targetIsInternalPage = isInternalDocsPage(
+      new URL(noHash),
+      start,
+      prefix,
+    );
+
+    if (targetIsInternalPage) {
+      const data = pageData.get(noHash);
+      if (!data) {
+        const checked = await fetchCheck(new URL(noHash));
+        if (!checked.ok) {
+          broken.push({
+            reason: checked.reason,
+            sources: entry.sources,
+            status: checked.status,
+            type: 'internal-page',
+            url: entry.url,
+          });
+        }
+        continue;
+      }
+
+      if (data.status && data.status >= 400) {
+        broken.push({
+          reason: `HTTP ${data.status}`,
+          sources: entry.sources,
+          status: data.status,
+          type: 'internal-page',
+          url: entry.url,
+        });
+        continue;
+      }
+
+      if (target.hash) {
+        const fragment = decodeURIComponent(target.hash.slice(1));
+        if (!data.fragments.has(fragment)) {
+          broken.push({
+            reason: `Missing fragment #${fragment}`,
+            sources: entry.sources,
+            status: null,
+            type: 'internal-fragment',
+            url: entry.url,
+          });
+        }
+      }
+      continue;
+    }
+
+    if (!options.checkExternal && target.origin !== start.origin) {
+      continue;
+    }
+
+    const checked = await fetchCheck(target);
+    if (!checked.ok) {
+      broken.push({
+        reason: checked.reason,
+        sources: entry.sources,
+        status: checked.status,
+        type: target.origin === start.origin ? 'internal-resource' : 'external',
+        url: entry.url,
+      });
+    }
+  }
+
+  broken.sort((left, right) => left.url.localeCompare(right.url));
+
+  const report: LinkCheckReport = {
+    broken,
+    brokenCount: broken.length,
+    crawledPages: crawled.size,
+    discoveredLinks: links.size,
+    startUrl: start.href,
+  };
+
+  if (options.output) {
+    await writeFile(options.output, JSON.stringify(report, null, 2));
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(
+      `Crawled ${report.crawledPages} pages, checked ${report.discoveredLinks} links, found ${report.brokenCount} broken links.`,
+    );
+    for (const brokenLink of report.broken) {
+      const sources = brokenLink.sources
+        .slice(0, 3)
+        .map((source) => `${source.source} (${source.text || 'no text'})`)
+        .join(', ');
+      console.log(
+        `- [${brokenLink.type}] ${brokenLink.url} :: ${brokenLink.reason ?? 'unknown error'} :: ${sources}`,
+      );
+    }
+  }
+
+  await browser.close();
+
+  if (report.brokenCount > 0) {
+    process.exitCode = 1;
+  }
+}
+
+void run();


### PR DESCRIPTION
## Summary
- fix docs markdown link rewriting so source-relative links resolve correctly in the exported site
- add a reusable Playwright-based docs link checker under `tools/docs/check-links.ts` and expose it as `pnpm docs:check-links`
- document the new checker in the docs contributor workflow
- bump all public packages from `0.0.10` to `0.0.11` to satisfy the lockstep publish rule

## Root Cause
The docs transform was rewriting markdown links relative to the rendered trailing-slash URL instead of the source markdown file path. That produced bad routes like `/guide/cli-reference/documentation/commands` on the deployed docs site.

## Validation
- `pnpm --filter @open-agent-toolkit/docs-transforms test`
- `pnpm --filter @open-agent-toolkit/docs-transforms type-check`
- `pnpm --filter oat-docs docs:lint`
- `pnpm build:docs`
- `pnpm release:validate`
- `pnpm docs:check-links --url http://127.0.0.1:4177/open-agent-toolkit/` (`82` pages, `424` links, `0` broken)