### PR TITLE
docs(oat-project-document): update backlog references

### DIFF
--- a/.agents/skills/oat-project-document/SKILL.md
+++ b/.agents/skills/oat-project-document/SKILL.md
@@ -222,7 +222,7 @@ Scan the repository for all documentation and instruction surfaces.
 
 4. **Reference files:**
    - Check `.oat/repo/reference/` directory
-   - Read: `current-state.md`, `backlog.md`, `roadmap.md`, `decision-record.md` (whichever exist)
+   - Read: `current-state.md`, `backlog/index.md`, `backlog/completed.md`, `roadmap.md`, `decision-record.md`, and relevant `backlog/items/*.md` files as needed (whichever exist)
 
 **3b. Instruction surfaces (secondary — strong signals only):**
 

--- a/.agents/skills/oat-project-document/SKILL.md
+++ b/.agents/skills/oat-project-document/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-document
-version: 1.0.0
+version: 1.0.1
 description: Run when implementation is complete and documentation needs updating. Analyzes project artifacts to produce documentation update recommendations, then applies approved changes before project completion.
 argument-hint: '[project-path] [--auto]'
 disable-model-invocation: true


### PR DESCRIPTION
## Summary
- update `oat-project-document` to read the canonical file-backed backlog references
- replace the legacy `backlog.md` pointer with `backlog/index.md`, `backlog/completed.md`, and relevant `backlog/items/*.md` files

## Why
`backlog.md` is now a migration shim, while the current repo model treats `.oat/repo/reference/backlog/` as the source of truth. This keeps the skill instructions aligned with the actual backlog layout.

## Validation
- `type-check` (pre-push hook)
- `lint` (pre-push hook)
- `format` (pre-push hook)