### PR TITLE
fix: docs init markdown lint options

### DIFF
--- a/apps/oat-docs/docs/guide/documentation/commands.md
+++ b/apps/oat-docs/docs/guide/documentation/commands.md
@@ -50,6 +50,7 @@ Supported flags:
 - `--target-dir <path>`
 - `--framework <fumadocs|mkdocs>` (default: `fumadocs` in non-interactive mode)
 - `--description <text>` (site description, optional)
+- `--lint <none|markdownlint-cli2>`
 - `--format <oxfmt|none>`
 - `--yes`
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/docs/init/index.ts
+++ b/packages/cli/src/commands/docs/init/index.ts
@@ -203,6 +203,12 @@ export function createDocsInitCommand(
     )
     .addOption(new Option('--description <text>', 'Site description'))
     .addOption(
+      new Option('--lint <mode>', 'Markdown lint mode').choices([
+        'none',
+        'markdownlint-cli2',
+      ]),
+    )
+    .addOption(
       new Option('--format <mode>', 'Markdown format mode').choices([
         'oxfmt',
         'none',

--- a/packages/cli/src/commands/docs/init/integration.test.ts
+++ b/packages/cli/src/commands/docs/init/integration.test.ts
@@ -301,4 +301,38 @@ describe('scaffold integration', () => {
       expect(result.documentationConfig.tooling).toBe('mkdocs');
     },
   );
+
+  it(
+    'scaffolds markdownlint-cli2 when requested',
+    { timeout: 30_000 },
+    async () => {
+      assetsRoot = await bundleAssets();
+      const root = await mkdtemp(join(tmpdir(), 'oat-integration-lint-'));
+      createdRoots.push(root);
+
+      const result = await scaffoldDocsApp({
+        assetsRoot,
+        repoRoot: root,
+        repoShape: 'single-package',
+        framework: 'fumadocs',
+        appName: 'docs',
+        targetDir: 'docs',
+        siteDescription: '',
+        lint: 'markdownlint-cli2',
+        format: 'none',
+      });
+
+      const packageJson = JSON.parse(
+        await readFile(join(result.appRoot, 'package.json'), 'utf8'),
+      ) as {
+        scripts: Record<string, string>;
+        devDependencies: Record<string, string>;
+      };
+
+      expect(packageJson.scripts['docs:lint']).toBe(
+        "markdownlint-cli2 'docs/**/*.md'",
+      );
+      expect(packageJson.devDependencies['markdownlint-cli2']).toBe('^0.13.0');
+    },
+  );
 });

--- a/packages/cli/src/commands/docs/init/resolve-options.test.ts
+++ b/packages/cli/src/commands/docs/init/resolve-options.test.ts
@@ -166,4 +166,37 @@ describe('docs init option resolution', () => {
     expect(getTemplateDir('fumadocs')).toBe('docs-app-fuma');
     expect(getTemplateDir('mkdocs')).toBe('docs-app-mkdocs');
   });
+
+  it('accepts markdownlint-cli2 as a lint mode', async () => {
+    const inputWithDefault = vi.fn();
+    const selectWithAbort = vi.fn();
+
+    const result = await resolveDocsInitOptions({
+      repoRoot: '/tmp/open-agent-toolkit',
+      repoShape: 'monorepo',
+      interactive: true,
+      acceptDefaults: false,
+      providedFramework: 'mkdocs',
+      providedAppName: 'oat-docs',
+      providedTargetDir: 'apps/oat-docs',
+      providedSiteDescription: 'My docs',
+      providedLint: 'markdownlint-cli2',
+      providedFormat: 'oxfmt',
+      inputWithDefault,
+      selectWithAbort,
+    });
+
+    expect(result).toEqual({
+      repoRoot: '/tmp/open-agent-toolkit',
+      repoShape: 'monorepo',
+      framework: 'mkdocs',
+      appName: 'oat-docs',
+      targetDir: 'apps/oat-docs',
+      siteDescription: 'My docs',
+      lint: 'markdownlint-cli2',
+      format: 'oxfmt',
+    });
+    expect(inputWithDefault).not.toHaveBeenCalled();
+    expect(selectWithAbort).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/commands/docs/init/resolve-options.ts
+++ b/packages/cli/src/commands/docs/init/resolve-options.ts
@@ -8,7 +8,7 @@ import { dirExists, fileExists } from '@fs/io';
 
 export type DocsRepoShape = 'monorepo' | 'single-package';
 export type DocsFramework = 'fumadocs' | 'mkdocs';
-export type DocsLintMode = 'none';
+export type DocsLintMode = 'none' | 'markdownlint-cli2';
 export type DocsFormatMode = 'oxfmt' | 'none';
 
 export interface DocsInitResolvedOptions {
@@ -58,6 +58,7 @@ const FRAMEWORK_CHOICES: SelectChoice<DocsFramework>[] = [
 
 const LINT_CHOICES: SelectChoice<DocsLintMode>[] = [
   { label: 'none', value: 'none' },
+  { label: 'markdownlint-cli2', value: 'markdownlint-cli2' },
 ];
 
 const FORMAT_CHOICES: SelectChoice<DocsFormatMode>[] = [

--- a/packages/cli/src/commands/docs/init/scaffold.test.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.test.ts
@@ -208,6 +208,39 @@ describe('scaffoldDocsApp', () => {
     ).rejects.toThrow();
   });
 
+  it('scaffolds markdownlint-cli2 when lint mode is enabled', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-docs-lint-'));
+    createdRoots.push(root);
+    const assetsRoot = await seedAssets(
+      root,
+      'docs-app-mkdocs',
+      MKDOCS_TEMPLATE_FILES,
+    );
+
+    const result = await scaffoldDocsApp({
+      assetsRoot,
+      repoRoot: root,
+      repoShape: 'single-package',
+      framework: 'mkdocs',
+      appName: 'docs',
+      targetDir: 'docs',
+      siteDescription: '',
+      lint: 'markdownlint-cli2',
+      format: 'none',
+    });
+
+    const packageJson = JSON.parse(
+      await readFile(join(result.appRoot, 'package.json'), 'utf8'),
+    ) as {
+      scripts: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    expect(packageJson.scripts['docs:lint']).toBe(
+      "markdownlint-cli2 'docs/**/*.md'",
+    );
+    expect(packageJson.devDependencies['markdownlint-cli2']).toBe('^0.13.0');
+  });
+
   it('scaffolds a Fumadocs app with token replacements', async () => {
     const root = await mkdtemp(join(tmpdir(), 'oat-docs-fuma-'));
     createdRoots.push(root);

--- a/packages/cli/src/commands/docs/init/scaffold.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.ts
@@ -188,6 +188,10 @@ function buildDevDependencies(
 ): string {
   const entries: string[] = [];
 
+  if (lint === 'markdownlint-cli2') {
+    entries.push('    "markdownlint-cli2": "^0.13.0"');
+  }
+
   if (format === 'oxfmt') {
     entries.push('    "oxfmt": "^0.36.0"');
   }
@@ -200,6 +204,10 @@ function buildFumaDevDependencies(
   format: DocsFormatMode,
 ): string {
   const entries: string[] = [];
+
+  if (lint === 'markdownlint-cli2') {
+    entries.push('    "markdownlint-cli2": "^0.13.0"');
+  }
 
   if (format === 'oxfmt') {
     entries.push('    "oxfmt": "^0.36.0"');
@@ -238,7 +246,10 @@ function renderTemplate(
     '{{PACKAGE_NAME}}': options.appName,
     '{{SITE_NAME}}': siteName,
     '{{SITE_DESCRIPTION}}': options.siteDescription,
-    '{{DOCS_LINT_SCRIPT}}': "echo 'docs lint disabled'",
+    '{{DOCS_LINT_SCRIPT}}':
+      options.lint === 'markdownlint-cli2'
+        ? "markdownlint-cli2 'docs/**/*.md'"
+        : "echo 'docs lint disabled'",
     '{{DOCS_FORMAT_SCRIPT}}':
       options.format === 'oxfmt'
         ? "oxfmt 'docs/**/*.md'"

--- a/packages/cli/src/commands/help-snapshots.test.ts
+++ b/packages/cli/src/commands/help-snapshots.test.ts
@@ -481,6 +481,8 @@ describe('help output snapshots', () => {
         --app-name <name>        Docs app name
         --target-dir <path>      Target directory for the docs app
         --description <text>     Site description
+        --lint <mode>            Markdown lint mode (choices: "none",
+                                 "markdownlint-cli2")
         --format <mode>          Markdown format mode (choices: "oxfmt", "none")
         --yes                    Accept defaults without prompting
         -h, --help               display help for command

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- add `markdownlint-cli2` as a supported `oat docs init` lint mode instead of hard-coding `none`
- wire `--lint <mode>` into the CLI, help output, docs, and scaffolded package scripts/devDependencies
- add coverage for the new lint mode and apply the required lockstep public package version bump to `0.0.12`

## Root Cause

`oat docs init` exposed a markdown lint prompt, but the implementation only defined `DocsLintMode` as `none`, only offered `none` in the prompt choices, and always rendered a disabled lint script in scaffolded docs apps.

## Impact

Users can now choose a real markdown linting mode during docs init or pass `--lint markdownlint-cli2` non-interactively. The generated docs app installs and runs `markdownlint-cli2` when selected.

## Validation

- `pnpm --filter @open-agent-toolkit/cli test -- --run src/commands/docs/init/resolve-options.test.ts src/commands/docs/init/scaffold.test.ts src/commands/docs/init/integration.test.ts src/commands/help-snapshots.test.ts src/commands/docs/init/index.test.ts`
- `pnpm --filter @open-agent-toolkit/cli type-check`
- `pnpm release:validate`
