### PR TITLE
fix(release): cut 0.0.14 via GitHub release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ secrets.VOXOPS_GITHUB_ACCESS_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to publish (for example: v0.0.13)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,6 +22,8 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
     steps:
       # Publish workflow contract:
@@ -27,6 +35,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -84,13 +93,35 @@ jobs:
     needs: publish
     permissions:
       contents: write
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
     steps:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: Release ${{ env.RELEASE_TAG }}
           draft: false
           prerelease: false
           generate_release_notes: true
+          body: |
+            ## Packages
+
+            This release publishes the current lockstep version of the public
+            `@open-agent-toolkit/*` packages:
+
+            - `@open-agent-toolkit/cli`
+            - `@open-agent-toolkit/docs-config`
+            - `@open-agent-toolkit/docs-theme`
+            - `@open-agent-toolkit/docs-transforms`
+
+            ## Installation
+
+            ```bash
+            npm install -g @open-agent-toolkit/cli
+            ```
+
+            ## Full Changelog
+
+            See below for auto-generated release notes.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- bump the four public packages to `0.0.14`
- push release tags with `VOXOPS_GITHUB_ACCESS_TOKEN` so the tag can trigger the separate release workflow
- add a GitHub Release body and manual `workflow_dispatch` support for publishing an existing tag if needed

## Verification
- `pnpm release:validate`
- push hooks ran `pnpm type-check`, `pnpm lint`, and `pnpm format` successfully
