### PR TITLE
fix(release): call reusable release workflow from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      release_tag: ${{ steps.create_release_tag.outputs.release_tag }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.VOXOPS_GITHUB_ACCESS_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -76,8 +77,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Create release tag for lockstep package bump
+        id: create_release_tag
         run: >
           pnpm exec tsx tools/release/create-public-package-tag.ts
           --base-ref "${{ github.event.before }}"
           --head-ref "${{ github.sha }}"
           --push
+
+  release-public-packages:
+    if: needs.tag-public-release.outputs.release_tag != ''
+    needs: tag-public-release
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.tag-public-release.outputs.release_tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,16 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Existing release tag to publish (for example: v0.0.14)'
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing release tag to publish (for example: v0.0.13)'
+        description: 'Existing release tag to publish (for example: v0.0.14)'
         required: true
         type: string
 
@@ -16,14 +19,14 @@ permissions:
   id-token: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag }}
   cancel-in-progress: false
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      RELEASE_TAG: ${{ inputs.tag }}
 
     steps:
       # Publish workflow contract:
@@ -94,7 +97,7 @@ jobs:
     permissions:
       contents: write
     env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+      RELEASE_TAG: ${{ inputs.tag }}
 
     steps:
       - name: Create GitHub Release

--- a/tools/release/create-public-package-tag.ts
+++ b/tools/release/create-public-package-tag.ts
@@ -1,3 +1,4 @@
+import { appendFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
 import { getPublicPackageContracts } from '../../packages/cli/src/release/public-package-contract';
@@ -113,7 +114,7 @@ async function createTag(tagName: string, headRef: string, push: boolean) {
 
   if (tagExists) {
     console.log(`release tag ${tagName} already exists`);
-    return;
+    return false;
   }
 
   await runCommand('git', ['tag', tagName, headRef]);
@@ -123,6 +124,17 @@ async function createTag(tagName: string, headRef: string, push: boolean) {
     await runCommand('git', ['push', 'origin', `refs/tags/${tagName}`]);
     console.log(`pushed release tag ${tagName}`);
   }
+
+  return true;
+}
+
+async function writeGithubOutput(name: string, value: string) {
+  const outputPath = process.env.GITHUB_OUTPUT?.trim();
+  if (!outputPath) {
+    return;
+  }
+
+  await appendFile(outputPath, `${name}=${value}\n`, 'utf8');
 }
 
 async function main() {
@@ -133,6 +145,7 @@ async function main() {
     console.log(
       'no comparable base ref available; skipping release tag creation',
     );
+    await writeGithubOutput('release_tag', '');
     return;
   }
 
@@ -140,6 +153,7 @@ async function main() {
     console.log(
       `base ref ${baseRef} is not available locally; skipping release tag creation`,
     );
+    await writeGithubOutput('release_tag', '');
     return;
   }
 
@@ -154,10 +168,12 @@ async function main() {
     console.log(
       'no public package version bump detected; skipping release tag creation',
     );
+    await writeGithubOutput('release_tag', '');
     return;
   }
 
   await createTag(tagName, options.headRef, options.push);
+  await writeGithubOutput('release_tag', tagName);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## Summary
- change `release.yml` into a reusable workflow that supports both `workflow_call` and manual `workflow_dispatch`
- have `ci.yml` call the release workflow after the tag job creates a release tag
- write the created tag to `GITHUB_OUTPUT` so the follow-up release job can be skipped cleanly when no version bump exists

## Verification
- `pnpm type-check`
- workflow YAML parsed successfully
