### PR TITLE
fix(ci): allow reusable release workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
   release-public-packages:
     if: needs.tag-public-release.outputs.release_tag != ''
     needs: tag-public-release
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.tag-public-release.outputs.release_tag }}


### PR DESCRIPTION
## Summary
- grant the `release-public-packages` caller job the `contents: write` and `id-token: write` permissions required by the reusable release workflow
- keep the reusable workflow unchanged and fix the permission boundary at the caller, where GitHub enforces it

## Verification
- workflow YAML parses cleanly
