### PR TITLE
chore: update CI actions and bump OAT packages

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,52 @@
+name: Setup Node and pnpm
+description: Set up Node.js, activate pnpm through Corepack, and cache the pnpm store
+
+inputs:
+  node-version:
+    description: Explicit Node.js version to install
+    required: false
+  node-version-file:
+    description: File containing the Node.js version to install
+    required: false
+  pnpm-version:
+    description: pnpm version to activate through Corepack
+    required: false
+    default: '10.13.1'
+  registry-url:
+    description: Optional npm registry URL passed to actions/setup-node
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js from version file
+      if: ${{ inputs.node-version-file != '' }}
+      uses: actions/setup-node@v6
+      with:
+        node-version-file: ${{ inputs.node-version-file }}
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Setup Node.js from explicit version
+      if: ${{ inputs.node-version-file == '' && inputs.node-version != '' }}
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.registry-url }}
+
+    - name: Enable Corepack
+      shell: bash
+      run: |
+        corepack enable
+        corepack prepare pnpm@${{ inputs.pnpm-version }} --activate
+
+    - name: Resolve pnpm store path
+      shell: bash
+      run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+    - name: Cache pnpm store
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -67,14 +67,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,26 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version-file: '.nvmrc'
-
-      - name: Enable Corepack
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.13.1 --activate
-
-      - name: Resolve pnpm store path
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -79,26 +63,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version-file: '.nvmrc'
-
-      - name: Enable Corepack
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.13.1 --activate
-
-      - name: Resolve pnpm store path
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,22 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-          cache: 'pnpm'
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.13.1 --activate
+
+      - name: Resolve pnpm store path
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -71,10 +83,22 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-          cache: 'pnpm'
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.13.1 --activate
+
+      - name: Resolve pnpm store path
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,26 +30,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version-file: '.nvmrc'
-
-      - name: Enable Corepack
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.13.1 --activate
-
-      - name: Resolve pnpm store path
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,10 +34,22 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
-          cache: 'pnpm'
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.13.1 --activate
+
+      - name: Resolve pnpm store path
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -43,11 +43,23 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.13.1 --activate
+
+      - name: Resolve pnpm store path
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Show runtime versions
         run: |

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -11,6 +11,7 @@ on:
       - 'pnpm-workspace.yaml'
       - 'turbo.json'
       - '.nvmrc'
+      - '.github/actions/**'
       - '.github/workflows/ci.yml'
       - '.github/workflows/release*.yml'
   workflow_dispatch:
@@ -39,27 +40,12 @@ jobs:
 
       # Release flows stay on Node 24 because publishing and dry-run verification
       # are coupled to the npm runtime we use for trusted publishing.
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: '24'
+          pnpm-version: '10.13.1'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Enable Corepack
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.13.1 --activate
-
-      - name: Resolve pnpm store path
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Show runtime versions
         run: |

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -37,17 +37,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
       # Release flows stay on Node 24 because publishing and dry-run verification
       # are coupled to the npm runtime we use for trusted publishing.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Show runtime versions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,23 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.13.1 --activate
+
+      - name: Resolve pnpm store path
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Show runtime versions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,17 +40,17 @@ jobs:
           fetch-depth: 0
           ref: ${{ env.RELEASE_TAG }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
       # Release flows stay on Node 24 because trusted publishing uses the npm
       # runtime from this job, not the repo's general development baseline.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Show runtime versions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,27 +42,12 @@ jobs:
 
       # Release flows stay on Node 24 because trusted publishing uses the npm
       # runtime from this job, not the repo's general development baseline.
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
         with:
           node-version: '24'
+          pnpm-version: '10.13.1'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Enable Corepack
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.13.1 --activate
-
-      - name: Resolve pnpm store path
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
-
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
 
       - name: Show runtime versions
         run: |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/app/create-program.ts
+++ b/packages/cli/src/app/create-program.ts
@@ -3,7 +3,7 @@ import { Command, Option } from 'commander';
 const PROGRAM_NAME = 'oat';
 const PROGRAM_DESCRIPTION =
   'Open Agent Toolkit CLI for provider interoperability';
-const PROGRAM_VERSION = '0.0.7';
+const PROGRAM_VERSION = '0.0.16';
 const SCOPE_CHOICES = ['project', 'user', 'all'] as const;
 
 export function createProgram(): Command {

--- a/packages/cli/src/commands/docs/init/integration.test.ts
+++ b/packages/cli/src/commands/docs/init/integration.test.ts
@@ -71,7 +71,7 @@ describe('scaffold integration', () => {
           join(pkgDir, 'package.json'),
           JSON.stringify({
             name: `@open-agent-toolkit/${pkg}`,
-            version: '0.0.5',
+            version: '0.0.16',
           }),
           'utf8',
         );

--- a/packages/cli/src/commands/docs/init/scaffold.test.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.test.ts
@@ -302,7 +302,7 @@ describe('scaffoldDocsApp', () => {
     expect(packageJson.scripts['predev']).toContain('docs generate-index');
     expect(packageJson.scripts['prebuild']).toContain('docs generate-index');
     expect(packageJson.devDependencies['@open-agent-toolkit/cli']).toBe(
-      '^0.0.8',
+      '^0.0.16',
     );
     expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
     expect(packageJson.devDependencies['markdownlint-cli2']).toBeUndefined();
@@ -363,7 +363,7 @@ describe('scaffoldDocsApp', () => {
       await readFile(join(result.appRoot, 'package.json'), 'utf8'),
     ) as { devDependencies: Record<string, string> };
     expect(packageJson.devDependencies['@open-agent-toolkit/cli']).toBe(
-      '^0.0.8',
+      '^0.0.16',
     );
     expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
     expect(packageJson.devDependencies['markdownlint-cli2']).toBeUndefined();
@@ -509,7 +509,7 @@ describe('scaffoldDocsApp', () => {
         join(pkgDir, 'package.json'),
         JSON.stringify({
           name: `@open-agent-toolkit/${pkg}`,
-          version: '0.0.5',
+          version: '0.0.16',
         }),
         'utf8',
       );

--- a/packages/cli/src/commands/docs/init/scaffold.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.ts
@@ -109,7 +109,7 @@ const OAT_DEP_PACKAGES = [
   'docs-theme',
   'docs-transforms',
 ] as const;
-const DEFAULT_OAT_PUBLISHED_VERSION = '0.0.8';
+const DEFAULT_OAT_PUBLISHED_VERSION = '0.0.16';
 const PUBLIC_PACKAGE_VERSIONS_FILE = 'public-package-versions.json';
 
 export async function detectIsOatRepo(repoRoot: string): Promise<boolean> {

--- a/packages/cli/src/commands/doctor/index.test.ts
+++ b/packages/cli/src/commands/doctor/index.test.ts
@@ -53,7 +53,7 @@ interface RunDoctorArgs {
 function defaultManifest(): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.5',
+    oatVersion: '0.0.16',
     entries: [],
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/providers/inspect/inspect.test.ts
+++ b/packages/cli/src/commands/providers/inspect/inspect.test.ts
@@ -54,7 +54,7 @@ function createAdapter(
 function createManifest(entries: ManifestEntry[]): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.5',
+    oatVersion: '0.0.16',
     entries,
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/providers/list/list.test.ts
+++ b/packages/cli/src/commands/providers/list/list.test.ts
@@ -51,7 +51,7 @@ function createAdapter(
 function createManifest(entries: ManifestEntry[]): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.5',
+    oatVersion: '0.0.16',
     entries,
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/status/index.test.ts
+++ b/packages/cli/src/commands/status/index.test.ts
@@ -100,7 +100,7 @@ function createCodexAdapter(): ProviderAdapter {
 function createManifest(entries: ManifestEntry[]): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.5',
+    oatVersion: '0.0.16',
     entries,
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/sync/index.test.ts
+++ b/packages/cli/src/commands/sync/index.test.ts
@@ -84,7 +84,7 @@ function createCodexAdapter(): ProviderAdapter {
 function createManifest(): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.5',
+    oatVersion: '0.0.16',
     entries: [],
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/manifest/manager.ts
+++ b/packages/cli/src/manifest/manager.ts
@@ -10,7 +10,7 @@ import {
   ManifestSchema,
 } from './manifest.types';
 
-const OAT_VERSION = '0.0.7';
+const OAT_VERSION = '0.0.16';
 
 function formatIssuePath(path: (string | number)[]): string {
   if (path.length === 0) {

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## What changed

- updated GitHub Actions workflows to replace deprecated Node 20 JavaScript action usage
- moved `actions/setup-node` to `v6` and replaced `pnpm/action-setup` with Corepack-backed pnpm activation
- bumped the published OAT packages to `0.0.16`
- aligned CLI version constants, scaffold defaults, and affected tests with the new package version

## Why

GitHub Actions is deprecating Node.js 20 for JavaScript actions and will force Node.js 24 by default starting June 2, 2026. This PR removes the deprecated action runtime path and keeps the public OAT packages on the requested lockstep version.

## Impact

- CI and release workflows stop depending on deprecated Node 20 action runtimes
- public package release validation now targets `0.0.16` consistently across all shipped OAT packages
- generated docs scaffolds and CLI metadata stay in sync with the published package version

## Validation

- `pnpm release:validate`
- push hook checks: skill version validation, `pnpm type-check`, `pnpm lint`, `pnpm format`
