### PR TITLE
fix: keep summary exports on current branch

### DIFF
--- a/.agents/skills/oat-project-complete/SKILL.md
+++ b/.agents/skills/oat-project-complete/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-complete
-version: 1.3.4
+version: 1.3.5
 description: Use when all implementation work is finished and the project is ready to close. Marks the OAT project lifecycle as complete.
 disable-model-invocation: true
 user-invocable: true
@@ -342,7 +342,7 @@ echo "Project archived to $ARCHIVE_PATH"
 **Canonical helper behaviors (required):**
 
 - Always archive locally first. The local archive is the authoritative completion artifact even when remote sync is also configured.
-- If `archive.summaryExportPath` is configured and `summary.md` exists after archive, copy it to `{repoRoot}/{archive.summaryExportPath}/{PROJECT_NAME}.md`.
+- If `archive.summaryExportPath` is configured and `summary.md` exists after archive, copy it to `{repoRoot}/{archive.summaryExportPath}/YYYYMMDD-{PROJECT_NAME}.md`.
 - If `archive.s3SyncOnComplete=true` and `archive.s3Uri` is configured, sync the archived project to `{archive.s3Uri}/{repo-slug}/{PROJECT_NAME}/`.
 - If AWS CLI is missing or unusable for that S3 sync, warn and continue. Completion must not fail after the local archive succeeds.
 - If `archive.s3SyncOnComplete` is false or `archive.s3Uri` is unset, skip remote sync without prompting.
@@ -378,9 +378,10 @@ PRIMARY_REPO_ARCHIVE="${PRIMARY_REPO_ROOT}/.oat/projects/archived"
 
 Guidance:
 
-- In a worktree, prefer moving directly to `PRIMARY_REPO_ARCHIVE` instead of archiving locally and copying later.
+- In a worktree, only prefer `PRIMARY_REPO_ARCHIVE` when the archive destination is local-only/gitignored in the current checkout. If `.oat/projects/archived/` is version controlled on the current branch, archive in the current checkout instead.
 - Do not treat the worktree-local archive as durable.
 - If forced to use a local-only archive, warn and require explicit user confirmation.
+- Always write the dated `archive.summaryExportPath` copy into the current checkout (`repoRoot`), even when the project archive itself is written to the primary checkout.
 - Do not hardcode user-specific absolute paths.
 
 ### Step 9: Regenerate Dashboard

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.0.17",
-  "docs-config": "0.0.17",
-  "docs-theme": "0.0.17",
-  "docs-transforms": "0.0.17"
+  "cli": "0.0.18",
+  "docs-config": "0.0.18",
+  "docs-theme": "0.0.18",
+  "docs-transforms": "0.0.18"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/app/create-program.ts
+++ b/packages/cli/src/app/create-program.ts
@@ -3,7 +3,7 @@ import { Command, Option } from 'commander';
 const PROGRAM_NAME = 'oat';
 const PROGRAM_DESCRIPTION =
   'Open Agent Toolkit CLI for provider interoperability';
-const PROGRAM_VERSION = '0.0.16';
+const PROGRAM_VERSION = '0.0.18';
 const SCOPE_CHOICES = ['project', 'user', 'all'] as const;
 
 export function createProgram(): Command {

--- a/packages/cli/src/commands/docs/init/integration.test.ts
+++ b/packages/cli/src/commands/docs/init/integration.test.ts
@@ -71,7 +71,7 @@ describe('scaffold integration', () => {
           join(pkgDir, 'package.json'),
           JSON.stringify({
             name: `@open-agent-toolkit/${pkg}`,
-            version: '0.0.16',
+            version: '0.0.18',
           }),
           'utf8',
         );

--- a/packages/cli/src/commands/docs/init/scaffold.test.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.test.ts
@@ -302,7 +302,7 @@ describe('scaffoldDocsApp', () => {
     expect(packageJson.scripts['predev']).toContain('docs generate-index');
     expect(packageJson.scripts['prebuild']).toContain('docs generate-index');
     expect(packageJson.devDependencies['@open-agent-toolkit/cli']).toBe(
-      '^0.0.17',
+      '^0.0.18',
     );
     expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
     expect(packageJson.devDependencies['markdownlint-cli2']).toBeUndefined();
@@ -363,7 +363,7 @@ describe('scaffoldDocsApp', () => {
       await readFile(join(result.appRoot, 'package.json'), 'utf8'),
     ) as { devDependencies: Record<string, string> };
     expect(packageJson.devDependencies['@open-agent-toolkit/cli']).toBe(
-      '^0.0.17',
+      '^0.0.18',
     );
     expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
     expect(packageJson.devDependencies['markdownlint-cli2']).toBeUndefined();
@@ -567,7 +567,7 @@ describe('scaffoldDocsApp', () => {
         join(pkgDir, 'package.json'),
         JSON.stringify({
           name: `@open-agent-toolkit/${pkg}`,
-          version: '0.0.16',
+          version: '0.0.18',
         }),
         'utf8',
       );

--- a/packages/cli/src/commands/docs/init/scaffold.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.ts
@@ -110,7 +110,7 @@ const OAT_DEP_PACKAGES = [
   'docs-theme',
   'docs-transforms',
 ] as const;
-const DEFAULT_OAT_PUBLISHED_VERSION = '0.0.17';
+const DEFAULT_OAT_PUBLISHED_VERSION = '0.0.18';
 const PUBLIC_PACKAGE_VERSIONS_FILE = 'public-package-versions.json';
 
 export async function detectIsOatRepo(repoRoot: string): Promise<boolean> {

--- a/packages/cli/src/commands/doctor/index.test.ts
+++ b/packages/cli/src/commands/doctor/index.test.ts
@@ -53,7 +53,7 @@ interface RunDoctorArgs {
 function defaultManifest(): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.16',
+    oatVersion: '0.0.18',
     entries: [],
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/project/archive/archive-utils.test.ts
+++ b/packages/cli/src/commands/project/archive/archive-utils.test.ts
@@ -239,6 +239,18 @@ describe('archive utils', () => {
     const execFile = vi.fn(async (file: string, args: string[]) => {
       if (
         file === 'git' &&
+        args[0] === 'check-ignore' &&
+        args[1] === '--quiet' &&
+        args[2] === '--no-index' &&
+        args[3] === '.oat/projects/archived/demo'
+      ) {
+        return {
+          stdout: '',
+          stderr: '',
+        };
+      }
+      if (
+        file === 'git' &&
         args[0] === 'rev-parse' &&
         args[1] === '--git-common-dir'
       ) {
@@ -278,6 +290,94 @@ describe('archive utils', () => {
 
     expect(result.archivePath).toBe(
       join(mainRepoRoot, '.oat', 'projects', 'archived', 'demo'),
+    );
+    expect(result.summaryExportFile).toBe(
+      join(
+        worktreeRoot,
+        '.oat',
+        'repo',
+        'reference',
+        'project-summaries',
+        '20260401-demo.md',
+      ),
+    );
+    await expect(readFile(result.summaryExportFile!, 'utf8')).resolves.toBe(
+      '# summary\n',
+    );
+    await expect(
+      readFile(join(result.archivePath, 'summary.md'), 'utf8'),
+    ).resolves.toBe('# summary\n');
+  });
+
+  it('archives in the current worktree when the archive path is version controlled', async () => {
+    const tempRoot = await createRepoRoot();
+    const mainRepoRoot = join(tempRoot, 'main-repo');
+    const worktreeRoot = join(tempRoot, 'feature-worktree');
+    const projectPath = join(
+      worktreeRoot,
+      '.oat',
+      'projects',
+      'shared',
+      'demo',
+    );
+
+    await mkdir(join(mainRepoRoot, '.git'), { recursive: true });
+    await mkdir(projectPath, { recursive: true });
+    await writeFile(join(projectPath, 'summary.md'), '# summary\n', 'utf8');
+
+    const execFile = vi.fn(async (file: string, args: string[]) => {
+      if (
+        file === 'git' &&
+        args[0] === 'check-ignore' &&
+        args[1] === '--quiet' &&
+        args[2] === '--no-index' &&
+        args[3] === '.oat/projects/archived/demo'
+      ) {
+        const error = new Error('not ignored') as NodeJS.ErrnoException;
+        error.code = 1;
+        throw error;
+      }
+      if (
+        file === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[1] === '--git-common-dir'
+      ) {
+        return {
+          stdout: join(mainRepoRoot, '.git'),
+          stderr: '',
+        };
+      }
+      if (
+        file === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[1] === '--git-dir'
+      ) {
+        return {
+          stdout: join(mainRepoRoot, '.git', 'worktrees', 'feature-worktree'),
+          stderr: '',
+        };
+      }
+
+      throw new Error(`Unexpected command: ${file} ${args.join(' ')}`);
+    });
+
+    const result = await archiveProjectOnCompletion(
+      {
+        repoRoot: worktreeRoot,
+        projectPath,
+        projectName: 'demo',
+        projectsRoot: '.oat/projects/shared',
+        s3SyncOnComplete: false,
+        summaryExportPath: '.oat/repo/reference/project-summaries',
+      },
+      {
+        gitExecFile: execFile,
+        timestamp: () => '2026-04-01T12:34:56Z',
+      },
+    );
+
+    expect(result.archivePath).toBe(
+      join(worktreeRoot, '.oat', 'projects', 'archived', 'demo'),
     );
     expect(result.summaryExportFile).toBe(
       join(

--- a/packages/cli/src/commands/project/archive/archive-utils.ts
+++ b/packages/cli/src/commands/project/archive/archive-utils.ts
@@ -206,10 +206,58 @@ function resolveGitPath(repoRoot: string, gitPath: string): string {
     : join(repoRoot, normalizedPath);
 }
 
+function isExitCode(error: unknown, code: number): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    Number(error.code) === code
+  );
+}
+
+async function isGitignoredArchivePath(
+  repoRoot: string,
+  archiveProjectPath: string,
+  dependencies: ArchiveProjectOnCompletionDependencies,
+): Promise<boolean> {
+  const execFile = dependencies.gitExecFile ?? execFileAsync;
+
+  try {
+    await execFile(
+      'git',
+      ['check-ignore', '--quiet', '--no-index', archiveProjectPath],
+      {
+        cwd: repoRoot,
+        env: dependencies.env ?? process.env,
+      },
+    );
+    return true;
+  } catch (error) {
+    if (isExitCode(error, 1)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 async function resolveArchiveRepoRoot(
   repoRoot: string,
+  archiveProjectPath: string,
   dependencies: ArchiveProjectOnCompletionDependencies,
 ): Promise<string> {
+  try {
+    const archivePathIsGitignored = await isGitignoredArchivePath(
+      repoRoot,
+      archiveProjectPath,
+      dependencies,
+    );
+    if (!archivePathIsGitignored) {
+      return repoRoot;
+    }
+  } catch {
+    return repoRoot;
+  }
+
   const execFile = dependencies.gitExecFile ?? execFileAsync;
 
   try {
@@ -301,8 +349,13 @@ export async function archiveProjectOnCompletion(
   const execFile = dependencies.execFile ?? execFileAsync;
   const timestamp = dependencies.timestamp?.() ?? new Date().toISOString();
   const snapshotName = buildArchiveSnapshotName(options.projectName, timestamp);
+  const archiveProjectPath = resolveLocalArchiveProjectPath(
+    options.projectsRoot,
+    options.projectName,
+  );
   const archiveRepoRoot = await resolveArchiveRepoRoot(
     options.repoRoot,
+    archiveProjectPath,
     dependencies,
   );
 

--- a/packages/cli/src/commands/providers/inspect/inspect.test.ts
+++ b/packages/cli/src/commands/providers/inspect/inspect.test.ts
@@ -54,7 +54,7 @@ function createAdapter(
 function createManifest(entries: ManifestEntry[]): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.16',
+    oatVersion: '0.0.18',
     entries,
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/providers/list/list.test.ts
+++ b/packages/cli/src/commands/providers/list/list.test.ts
@@ -51,7 +51,7 @@ function createAdapter(
 function createManifest(entries: ManifestEntry[]): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.16',
+    oatVersion: '0.0.18',
     entries,
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/status/index.test.ts
+++ b/packages/cli/src/commands/status/index.test.ts
@@ -100,7 +100,7 @@ function createCodexAdapter(): ProviderAdapter {
 function createManifest(entries: ManifestEntry[]): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.16',
+    oatVersion: '0.0.18',
     entries,
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/sync/index.test.ts
+++ b/packages/cli/src/commands/sync/index.test.ts
@@ -84,7 +84,7 @@ function createCodexAdapter(): ProviderAdapter {
 function createManifest(): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.16',
+    oatVersion: '0.0.18',
     entries: [],
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/manifest/manager.ts
+++ b/packages/cli/src/manifest/manager.ts
@@ -10,7 +10,7 @@ import {
   ManifestSchema,
 } from './manifest.types';
 
-const OAT_VERSION = '0.0.16';
+const OAT_VERSION = '0.0.18';
 
 function formatIssuePath(path: (string | number)[]): string {
   if (path.length === 0) {

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- keep project archive writes on the current branch when `.oat/projects/archived` is version controlled
- continue routing local-only archived projects from worktrees into the primary checkout
- always write the dated `archive.summaryExportPath` summary export into the current checkout
- align the `oat-project-complete` skill contract with the implemented archive behavior and dated summary export naming

## Root Cause
The archive helper always preferred the primary checkout when running from a git worktree. That was correct for local-only archived projects, but wrong when `.oat/projects/archived` was itself version controlled in the current branch.

## Validation
- `pnpm --filter @open-agent-toolkit/cli test -- src/commands/project/archive/archive-utils.test.ts`
- `pnpm --filter @open-agent-toolkit/cli format`
