### PR TITLE
chore: enable archive sync on completion

### DIFF
--- a/.oat/config.json
+++ b/.oat/config.json
@@ -7,7 +7,8 @@
     "root": ".oat/projects/shared"
   },
   "archive": {
-    "s3Uri": "s3://vox-media-open-agent-toolkit/repositories",
+    "s3Uri": "s3://vox-media-open-agent-toolkit/repositories/",
+    "s3SyncOnComplete": true,
     "summaryExportPath": ".oat/repo/reference/project-summaries"
   },
   "documentation": {


### PR DESCRIPTION
## Summary
- add \ to \
- align \ with the requested \ value
- keep \ pointed at \

## Why
Project completion already had an archive block configured, but it was missing the flag that actually enables automatic S3 sync on completion.

## Impact
Completed OAT projects in this repository will now sync archived artifacts to S3 under the repo-scoped \ path while continuing to export version-controlled summaries locally.

## Validation
- verified the \ archive block contains the requested values
- \
> open-agent-toolkit@0.0.5 cli /Users/thomas.stang/.codex/worktrees/d201/open-agent-toolkit
> bash packages/cli/scripts/bundle-assets.sh && tsx --tsconfig packages/cli/tsconfig.json packages/cli/src/index.ts -- config get archive.s3SyncOnComplete

true returned \
- direct JSON parse of \ confirmed the full archive block after the edit
- note: additional \
> open-agent-toolkit@0.0.5 cli /Users/thomas.stang/.codex/worktrees/d201/open-agent-toolkit
> bash packages/cli/scripts/bundle-assets.sh && tsx --tsconfig packages/cli/tsconfig.json packages/cli/src/index.ts -- config get ...

 ELIFECYCLE  Command failed with exit code 1. invocations hit an existing asset-bundling issue in \, unrelated to this config change