### PR TITLE
fix(status): resolve false-positive drift for copy-strategy rules

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/providers/inspect/inspect.ts
+++ b/packages/cli/src/commands/providers/inspect/inspect.ts
@@ -106,6 +106,10 @@ async function collectInspectResult(
         missing: 0,
       };
 
+      const copyTransform = mapping.transformCanonical
+        ? { transformCanonical: mapping.transformCanonical }
+        : undefined;
+
       for (const entry of manifest.entries) {
         if (entry.provider !== adapter.name) {
           continue;
@@ -115,7 +119,11 @@ async function collectInspectResult(
         }
 
         state.managed += 1;
-        const report = await dependencies.detectDrift(entry, scopeRoot.root);
+        const report = await dependencies.detectDrift(
+          entry,
+          scopeRoot.root,
+          copyTransform,
+        );
         if (report.state.status === 'in_sync') {
           state.inSync += 1;
           continue;

--- a/packages/cli/src/commands/providers/list/list.ts
+++ b/packages/cli/src/commands/providers/list/list.ts
@@ -11,14 +11,18 @@ import {
   resolveConcreteScopes,
 } from '@commands/shared/shared.utils';
 import { detectDrift } from '@drift/index';
-import { resolveProjectRoot, resolveScopeRoot } from '@fs/paths';
+import {
+  normalizeToPosixPath,
+  resolveProjectRoot,
+  resolveScopeRoot,
+} from '@fs/paths';
 import { loadManifest } from '@manifest/index';
 import { claudeAdapter } from '@providers/claude';
 import { codexAdapter } from '@providers/codex';
 import { copilotAdapter } from '@providers/copilot';
 import { cursorAdapter } from '@providers/cursor';
 import { geminiAdapter } from '@providers/gemini';
-import { getSyncMappings } from '@providers/shared';
+import { getSyncMappings, type PathMapping } from '@providers/shared';
 import type { ContentType } from '@shared/types';
 import { Command } from 'commander';
 
@@ -136,9 +140,11 @@ async function collectProviderList(
   for (const adapter of dependencies.getAdapters()) {
     const summary = createEmptySummary();
     const contentTypes = new Set<ContentType>();
+    const allMappings: PathMapping[] = [];
     for (const scope of scopes) {
       for (const mapping of dependencies.getSyncMappings(adapter, scope)) {
         contentTypes.add(mapping.contentType);
+        allMappings.push(mapping);
       }
     }
     let detected = false;
@@ -159,7 +165,23 @@ async function collectProviderList(
         }
 
         summary.managed += 1;
-        const report = await dependencies.detectDrift(entry, scopeRoot.root);
+        const matchedMapping = allMappings.find((mapping) => {
+          const normalizedEntry = normalizeToPosixPath(entry.providerPath);
+          const normalizedDir = normalizeToPosixPath(mapping.providerDir);
+          return (
+            mapping.contentType === entry.contentType &&
+            (normalizedEntry === normalizedDir ||
+              normalizedEntry.startsWith(`${normalizedDir}/`))
+          );
+        });
+        const copyTransform = matchedMapping?.transformCanonical
+          ? { transformCanonical: matchedMapping.transformCanonical }
+          : undefined;
+        const report = await dependencies.detectDrift(
+          entry,
+          scopeRoot.root,
+          copyTransform,
+        );
         if (report.state.status === 'in_sync') {
           summary.inSync += 1;
           continue;

--- a/packages/cli/src/commands/providers/providers.types.ts
+++ b/packages/cli/src/commands/providers/providers.types.ts
@@ -1,6 +1,6 @@
 import type { CommandContext, GlobalOptions } from '@app/command-context';
 import type { SyncConfig } from '@config/index';
-import type { DriftReport } from '@drift/index';
+import type { CopyTransform, DriftReport } from '@drift/index';
 import type { Manifest } from '@manifest/index';
 import type { PathMapping, ProviderAdapter } from '@providers/shared';
 import type {
@@ -38,6 +38,7 @@ export interface ProvidersListDependencies {
   detectDrift: (
     entry: Manifest['entries'][number],
     scopeRoot: string,
+    copyTransform?: CopyTransform,
   ) => Promise<DriftReport>;
 }
 
@@ -74,6 +75,7 @@ export interface ProvidersInspectDependencies {
   detectDrift: (
     entry: Manifest['entries'][number],
     scopeRoot: string,
+    copyTransform?: CopyTransform,
   ) => Promise<DriftReport>;
 }
 

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -24,7 +24,12 @@ import {
   readGlobalOptions,
   resolveConcreteScopes,
 } from '@commands/shared/shared.utils';
-import { type DriftReport, detectDrift, detectStrays } from '@drift/index';
+import {
+  type CopyTransform,
+  type DriftReport,
+  detectDrift,
+  detectStrays,
+} from '@drift/index';
 import { type CanonicalEntry, scanCanonical } from '@engine/index';
 import {
   normalizeToPosixPath,
@@ -96,6 +101,7 @@ interface StatusDependencies {
   detectDrift: (
     entry: Manifest['entries'][number],
     scopeRoot: string,
+    copyTransform?: CopyTransform,
   ) => Promise<DriftReport>;
   detectStrays: (
     provider: string,
@@ -319,15 +325,23 @@ async function collectScopeReports(
       if (!contentTypeAllowed(entry.contentType, scope)) {
         continue;
       }
-      if (
-        !mappings.some((mapping) =>
+
+      const matchedMapping = mappings.find(
+        (mapping) =>
+          mapping.contentType === entry.contentType &&
           entryInsideMapping(entry.providerPath, mapping.providerDir),
-        )
-      ) {
+      );
+      if (!matchedMapping) {
         continue;
       }
 
-      reports.push(await dependencies.detectDrift(entry, scopeRoot));
+      const copyTransform = matchedMapping.transformCanonical
+        ? { transformCanonical: matchedMapping.transformCanonical }
+        : undefined;
+
+      reports.push(
+        await dependencies.detectDrift(entry, scopeRoot, copyTransform),
+      );
     }
 
     for (const mapping of mappings) {

--- a/packages/cli/src/drift/detector.test.ts
+++ b/packages/cli/src/drift/detector.test.ts
@@ -6,6 +6,7 @@ import { computeDirectoryHash, computeFileHash } from '@manifest/hash';
 import type { ManifestEntry } from '@manifest/manifest.types';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import type { CopyTransform } from './detector';
 import { detectDrift } from './detector';
 
 function createManifestEntry(
@@ -188,5 +189,127 @@ describe('detectDrift', () => {
     );
 
     expect(report.state).toEqual({ status: 'in_sync' });
+  });
+
+  it('returns in_sync via transform fallback when manifest hash is stale', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-drift-detector-'));
+    tempDirs.push(root);
+    await mkdir(join(root, '.agents', 'rules'), { recursive: true });
+    await mkdir(join(root, '.claude', 'rules'), { recursive: true });
+
+    // Canonical has frontmatter that gets stripped by the transform
+    await writeFile(
+      join(root, '.agents', 'rules', 'observability.md'),
+      '---\ndescription: obs rules\nactivation: always\n---\n\n# Obs\n',
+      'utf8',
+    );
+    // Provider has the rendered (transformed) content
+    const renderedContent =
+      '# Obs\n\n<!-- OAT-managed: Source: .agents/rules/observability.md -->\n';
+    await writeFile(
+      join(root, '.claude', 'rules', 'observability.md'),
+      renderedContent,
+      'utf8',
+    );
+
+    const transform: CopyTransform = {
+      transformCanonical: (content: string, _path: string) => {
+        // Simulate stripping frontmatter + appending marker
+        const body = content.replace(/^---\n[\s\S]*?\n---\n\n?/, '');
+        return `${body.trimEnd()}\n\n<!-- OAT-managed: Source: .agents/rules/observability.md -->\n`;
+      },
+    };
+
+    const report = await detectDrift(
+      createManifestEntry({
+        canonicalPath: '.agents/rules/observability.md',
+        providerPath: '.claude/rules/observability.md',
+        provider: 'claude',
+        contentType: 'rule',
+        strategy: 'copy',
+        // Stale hash — simulates hash computed from a previous version
+        contentHash: 'stale-hash-from-previous-sync',
+        isFile: true,
+      }),
+      root,
+      transform,
+    );
+
+    expect(report.state).toEqual({ status: 'in_sync' });
+  });
+
+  it('returns drifted when provider was manually edited even with transform', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-drift-detector-'));
+    tempDirs.push(root);
+    await mkdir(join(root, '.agents', 'rules'), { recursive: true });
+    await mkdir(join(root, '.claude', 'rules'), { recursive: true });
+
+    await writeFile(
+      join(root, '.agents', 'rules', 'observability.md'),
+      '---\ndescription: obs rules\nactivation: always\n---\n\n# Obs\n',
+      'utf8',
+    );
+    // Provider was manually edited — content differs from transform output
+    await writeFile(
+      join(root, '.claude', 'rules', 'observability.md'),
+      '# MANUALLY EDITED\n',
+      'utf8',
+    );
+
+    const transform: CopyTransform = {
+      transformCanonical: (content: string, _path: string) => {
+        const body = content.replace(/^---\n[\s\S]*?\n---\n\n?/, '');
+        return `${body.trimEnd()}\n\n<!-- OAT-managed: Source: .agents/rules/observability.md -->\n`;
+      },
+    };
+
+    const report = await detectDrift(
+      createManifestEntry({
+        canonicalPath: '.agents/rules/observability.md',
+        providerPath: '.claude/rules/observability.md',
+        provider: 'claude',
+        contentType: 'rule',
+        strategy: 'copy',
+        contentHash: 'stale-hash',
+        isFile: true,
+      }),
+      root,
+      transform,
+    );
+
+    expect(report.state).toEqual({ status: 'drifted', reason: 'modified' });
+  });
+
+  it('skips transform fallback when no copyTransform provided', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-drift-detector-'));
+    tempDirs.push(root);
+    await mkdir(join(root, '.agents', 'rules'), { recursive: true });
+    await mkdir(join(root, '.claude', 'rules'), { recursive: true });
+
+    await writeFile(
+      join(root, '.agents', 'rules', 'test-rule.md'),
+      '---\nactivation: always\n---\n\n# Rule\n',
+      'utf8',
+    );
+    await writeFile(
+      join(root, '.claude', 'rules', 'test-rule.md'),
+      '# Rule\n',
+      'utf8',
+    );
+
+    const report = await detectDrift(
+      createManifestEntry({
+        canonicalPath: '.agents/rules/test-rule.md',
+        providerPath: '.claude/rules/test-rule.md',
+        provider: 'claude',
+        contentType: 'rule',
+        strategy: 'copy',
+        contentHash: 'wrong-hash',
+        isFile: true,
+      }),
+      root,
+    );
+
+    expect(report.state).toEqual({ status: 'drifted', reason: 'modified' });
   });
 });

--- a/packages/cli/src/drift/detector.ts
+++ b/packages/cli/src/drift/detector.ts
@@ -1,10 +1,14 @@
-import { lstat, readlink, stat } from 'node:fs/promises';
+import { lstat, readFile, readlink, stat } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
-import { computeContentHash } from '@manifest/hash';
+import { computeContentHash, computeStringHash } from '@manifest/hash';
 import type { ManifestEntry } from '@manifest/manifest.types';
 
 import type { DriftReport } from './drift.types';
+
+export interface CopyTransform {
+  transformCanonical: (content: string, canonicalPath: string) => string;
+}
 
 function createReport(
   entry: ManifestEntry,
@@ -21,6 +25,7 @@ function createReport(
 export async function detectDrift(
   entry: ManifestEntry,
   scopeRoot: string,
+  copyTransform?: CopyTransform,
 ): Promise<DriftReport> {
   const providerPath = resolve(scopeRoot, entry.providerPath);
   const canonicalPath = resolve(scopeRoot, entry.canonicalPath);
@@ -82,6 +87,21 @@ export async function detectDrift(
   const currentHash = await computeContentHash(providerPath, entry.isFile);
   if (entry.contentHash === currentHash) {
     return createReport(entry, { status: 'in_sync' });
+  }
+
+  // When the manifest hash is stale (e.g. frontmatter-only edits to the
+  // canonical source that don't change the rendered output), re-derive the
+  // expected provider content from the current canonical + transform and
+  // compare that instead.
+  if (copyTransform && entry.isFile) {
+    const canonicalContent = await readFile(canonicalPath, 'utf8');
+    const rendered = copyTransform.transformCanonical(
+      canonicalContent,
+      entry.canonicalPath,
+    );
+    if (computeStringHash(rendered) === currentHash) {
+      return createReport(entry, { status: 'in_sync' });
+    }
   }
 
   return createReport(entry, {

--- a/packages/cli/src/drift/index.ts
+++ b/packages/cli/src/drift/index.ts
@@ -1,3 +1,4 @@
 export { detectDrift } from './detector';
+export type { CopyTransform } from './detector';
 export type { DriftReport, DriftState } from './drift.types';
 export { detectStrays } from './strays';

--- a/packages/cli/src/e2e/workflow.test.ts
+++ b/packages/cli/src/e2e/workflow.test.ts
@@ -294,6 +294,46 @@ describe('e2e workflow', () => {
     expect(entry?.contentHash).toBeTruthy();
   });
 
+  it('rule status: sync → frontmatter edit → status still in sync', async () => {
+    const root = await createWorkspace();
+    tempDirs.push(root);
+
+    await runCli(root, ['init']);
+    await mkdir(join(root, '.agents', 'rules'), { recursive: true });
+    await writeFile(
+      join(root, '.agents', 'rules', 'test-rule.md'),
+      '---\ndescription: original\nactivation: always\n---\n\n# Rule Body\n',
+      'utf8',
+    );
+
+    // First sync creates the copies
+    const firstSync = await runCli(root, ['sync']);
+    expect(firstSync.exitCode).toBe(0);
+
+    // Status should be clean
+    const beforeEdit = await runCli(root, ['status', '--json'], ['--json']);
+    expect(beforeEdit.exitCode).toBe(0);
+    const beforePayload = JSON.parse(beforeEdit.stdout);
+    expect(beforePayload.summary.drifted).toBe(0);
+
+    // Edit only frontmatter (body stays the same)
+    await writeFile(
+      join(root, '.agents', 'rules', 'test-rule.md'),
+      '---\ndescription: updated description\nactivation: always\n---\n\n# Rule Body\n',
+      'utf8',
+    );
+
+    // Sync should skip (transformed output unchanged for claude)
+    const secondSync = await runCli(root, ['sync']);
+    expect(secondSync.exitCode).toBe(0);
+
+    // Status should still report in sync (not false-positive drift)
+    const afterEdit = await runCli(root, ['status', '--json'], ['--json']);
+    expect(afterEdit.exitCode).toBe(0);
+    const afterPayload = JSON.parse(afterEdit.stdout);
+    expect(afterPayload.summary.drifted).toBe(0);
+  });
+
   it('removal: delete canonical → sync removes provider view', async () => {
     const root = await createWorkspace();
     tempDirs.push(root);

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- `oat status` reported false-positive `drifted:modified` for rules synced via copy strategy when the manifest `contentHash` was stale, even though `oat sync` correctly identified files as in-sync.
- Added a transform-aware fallback to `detectDrift`: when the fast-path hash comparison fails and a `transformCanonical` function is available, re-derives expected provider content from the current canonical source and compares that hash instead.
- Threaded the transform through all three drift-reporting surfaces (`status`, `providers list`, `providers inspect`) so they give consistent answers.

## Test plan

- [x] 3 unit tests in `detector.test.ts`: stale hash with transform fallback (in_sync), manually edited provider with transform (still drifted), no transform provided (original behavior preserved)
- [x] 1 e2e test in `workflow.test.ts`: full flow of sync → frontmatter edit → sync (skip) → status (in_sync)
- [x] All 1164 existing tests pass
- [x] Type-check, lint, format all clean
- [ ] Manual test: create rule with frontmatter, sync, corrupt manifest hash, verify `oat status` reports in_sync