### PR TITLE
fix: enforce public package version checks on push

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",
     "prepare": "test \"$GIT_HOOKS\" = \"0\" && exit 0; node tools/git-hooks/manage-hooks.js setup 2>/dev/null || true",
+    "release:check-versions": "tsx tools/release/check-version-bumps.ts",
     "release:validate": "tsx tools/release/validate-public-packages.ts",
     "test": "turbo run test",
     "type-check": "turbo run type-check",

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,0 @@
-{
-  "cli": "0.0.20",
-  "docs-config": "0.0.20",
-  "docs-theme": "0.0.20",
-  "docs-transforms": "0.0.20"
-}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/release/check-version-bumps.test.ts
+++ b/packages/cli/src/release/check-version-bumps.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { runVersionBumpCheck } from '../../../../tools/release/check-version-bumps';
+import { getPublicPackageContracts } from './public-package-contract';
+
+describe('runVersionBumpCheck', () => {
+  it('skips the check when no merge base is available', async () => {
+    await expect(
+      runVersionBumpCheck({
+        resolveMergeBaseFn: async () => null,
+      }),
+    ).resolves.toEqual({
+      status: 'skipped',
+      summary: 'no merge base found — skipping version bump check',
+      errors: [],
+    });
+  });
+
+  it('passes when no public packages changed since the merge base', async () => {
+    const contracts = getPublicPackageContracts();
+
+    await expect(
+      runVersionBumpCheck({
+        contracts,
+        resolveMergeBaseFn: async () => 'origin/main',
+        findChangedWorkspaceDirsFn: async () => new Set<string>(),
+      }),
+    ).resolves.toEqual({
+      status: 'passed',
+      summary: 'no public package changes — version bump check passed',
+      errors: [],
+    });
+  });
+
+  it('fails when changed public packages keep their base versions', async () => {
+    const contracts = getPublicPackageContracts();
+
+    const result = await runVersionBumpCheck({
+      contracts,
+      resolveMergeBaseFn: async () => 'origin/main',
+      findChangedWorkspaceDirsFn: async () => new Set(['packages/cli']),
+      readCurrentPackageJsonFn: async () => ({ version: '0.0.4' }),
+      readBasePackageJsonFn: async () => ({ version: '0.0.4' }),
+    });
+
+    expect(result).toEqual({
+      status: 'failed',
+      summary: 'version bump check failed:',
+      errors: [
+        'publishable package changes require a lockstep version bump across all public packages. Changed packages: @open-agent-toolkit/cli. Packages still at their base version: @open-agent-toolkit/cli@0.0.4, @open-agent-toolkit/docs-config@0.0.4, @open-agent-toolkit/docs-theme@0.0.4, @open-agent-toolkit/docs-transforms@0.0.4',
+      ],
+    });
+  });
+});

--- a/packages/cli/src/release/public-package-contract.test.ts
+++ b/packages/cli/src/release/public-package-contract.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+import { isVersionPolicyIgnoredPath } from '../../../../tools/release/release-utils';
 import { findMissingBuildArtifacts } from '../../../../tools/release/validate-public-packages';
 import { findLockstepVersionBumpErrors } from '../../../../tools/release/validate-public-packages';
 import {
@@ -76,6 +77,9 @@ describe('getPublicPackageContracts', () => {
           'dist/index.js',
           'assets',
           'README.md',
+        ]),
+        versionPolicyIgnorePatterns: expect.arrayContaining([
+          'assets/public-package-versions.json',
         ]),
         forbiddenPathPatterns: expect.arrayContaining([
           'src/**',
@@ -175,6 +179,23 @@ describe('getPublicPackageContracts', () => {
       'dependencies.@open-agent-toolkit/docs-transforms=workspace:*',
       'devDependencies.@open-agent-toolkit/cli=workspace:^',
     ]);
+  });
+
+  it('ignores generated version metadata for release version policy checks', () => {
+    const cliContract = getPublicPackageContracts()[0];
+
+    expect(
+      isVersionPolicyIgnoredPath(
+        cliContract,
+        'packages/cli/assets/public-package-versions.json',
+      ),
+    ).toBe(true);
+    expect(
+      isVersionPolicyIgnoredPath(
+        cliContract,
+        'packages/cli/assets/skills/oat-project-document/SKILL.md',
+      ),
+    ).toBe(false);
   });
 
   it('reports missing build artifacts before packing', async () => {

--- a/packages/cli/src/release/public-package-contract.ts
+++ b/packages/cli/src/release/public-package-contract.ts
@@ -7,6 +7,7 @@ export interface PublicPackageContract {
   requiredMetadataFields: string[];
   requiredPaths: string[];
   forbiddenPathPatterns: string[];
+  versionPolicyIgnorePatterns: string[];
 }
 
 const COMMON_METADATA_FIELDS = [
@@ -39,6 +40,7 @@ const PUBLIC_PACKAGE_CONTRACTS: PublicPackageContract[] = [
     requiredMetadataFields: [...COMMON_METADATA_FIELDS, 'bin.oat'],
     requiredPaths: ['dist/index.js', 'assets', 'README.md'],
     forbiddenPathPatterns: [...COMMON_FORBIDDEN_PATH_PATTERNS],
+    versionPolicyIgnorePatterns: ['assets/public-package-versions.json'],
   },
   {
     workspaceDir: 'packages/docs-config',
@@ -47,6 +49,7 @@ const PUBLIC_PACKAGE_CONTRACTS: PublicPackageContract[] = [
     requiredMetadataFields: [...COMMON_METADATA_FIELDS, 'exports', 'types'],
     requiredPaths: ['dist/index.js', 'dist/index.d.ts', 'README.md'],
     forbiddenPathPatterns: [...COMMON_FORBIDDEN_PATH_PATTERNS],
+    versionPolicyIgnorePatterns: [],
   },
   {
     workspaceDir: 'packages/docs-theme',
@@ -55,6 +58,7 @@ const PUBLIC_PACKAGE_CONTRACTS: PublicPackageContract[] = [
     requiredMetadataFields: [...COMMON_METADATA_FIELDS, 'exports', 'types'],
     requiredPaths: ['dist/index.js', 'dist/index.d.ts', 'README.md'],
     forbiddenPathPatterns: [...COMMON_FORBIDDEN_PATH_PATTERNS],
+    versionPolicyIgnorePatterns: [],
   },
   {
     workspaceDir: 'packages/docs-transforms',
@@ -63,6 +67,7 @@ const PUBLIC_PACKAGE_CONTRACTS: PublicPackageContract[] = [
     requiredMetadataFields: [...COMMON_METADATA_FIELDS, 'exports', 'types'],
     requiredPaths: ['dist/index.js', 'dist/index.d.ts', 'README.md'],
     forbiddenPathPatterns: [...COMMON_FORBIDDEN_PATH_PATTERNS],
+    versionPolicyIgnorePatterns: [],
   },
 ];
 
@@ -95,6 +100,7 @@ export function getPublicPackageContracts(): PublicPackageContract[] {
     requiredMetadataFields: [...contract.requiredMetadataFields],
     requiredPaths: [...contract.requiredPaths],
     forbiddenPathPatterns: [...contract.forbiddenPathPatterns],
+    versionPolicyIgnorePatterns: [...contract.versionPolicyIgnorePatterns],
   }));
 }
 

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",

--- a/tools/git-hooks/README.md
+++ b/tools/git-hooks/README.md
@@ -6,7 +6,7 @@ Repository git hooks for code quality and consistency.
 
 - `pre-commit` - runs `lint-staged`
 - `commit-msg` - validates commit messages with `commitlint`
-- `pre-push` - runs canonical skill version-bump validation plus `type-check`, `lint`, and `format`
+- `pre-push` - runs public package version-bump validation, canonical skill version-bump validation, plus `type-check`, `lint`, and `format`
 - `post-checkout` - runs `pnpm install` when lockfile-sensitive branch switches happen
 
 ## Default Behavior

--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Fast quality gate before pushing — CI handles tests and full builds
+pnpm release:check-versions
 pnpm run cli -- internal validate-skill-version-bumps --base-ref origin/main
 pnpm run type-check
 pnpm run lint

--- a/tools/release/check-version-bumps.ts
+++ b/tools/release/check-version-bumps.ts
@@ -1,0 +1,125 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  getPublicPackageContracts,
+  type PublicPackageContract,
+} from '../../packages/cli/src/release/public-package-contract';
+import {
+  findChangedWorkspaceDirs,
+  getPackageVersion,
+  readPackageJsonAtGitRef,
+  REPO_ROOT,
+  resolveMergeBase,
+} from './release-utils';
+import {
+  findLockstepVersionBumpErrors,
+  type PublicPackageVersionState,
+} from './validate-public-packages';
+
+export interface VersionBumpCheckResult {
+  status: 'skipped' | 'passed' | 'failed';
+  summary: string;
+  errors: string[];
+}
+
+interface VersionBumpCheckDependencies {
+  contracts?: readonly PublicPackageContract[];
+  resolveMergeBaseFn?: typeof resolveMergeBase;
+  findChangedWorkspaceDirsFn?: typeof findChangedWorkspaceDirs;
+  readCurrentPackageJsonFn?: (
+    workspaceDir: string,
+  ) => Promise<Record<string, unknown> | null>;
+  readBasePackageJsonFn?: (
+    baseRef: string,
+    workspaceDir: string,
+  ) => Promise<Record<string, unknown> | null>;
+}
+
+async function readCurrentPackageJson(
+  workspaceDir: string,
+): Promise<Record<string, unknown>> {
+  return JSON.parse(
+    await readFile(join(REPO_ROOT, workspaceDir, 'package.json'), 'utf8'),
+  ) as Record<string, unknown>;
+}
+
+export async function runVersionBumpCheck(
+  dependencies: VersionBumpCheckDependencies = {},
+): Promise<VersionBumpCheckResult> {
+  const contracts = dependencies.contracts ?? getPublicPackageContracts();
+  const mergeBase = await (
+    dependencies.resolveMergeBaseFn ?? resolveMergeBase
+  )();
+
+  if (!mergeBase) {
+    return {
+      status: 'skipped',
+      summary: 'no merge base found — skipping version bump check',
+      errors: [],
+    };
+  }
+
+  const changedWorkspaceDirs = await (
+    dependencies.findChangedWorkspaceDirsFn ?? findChangedWorkspaceDirs
+  )(mergeBase, 'HEAD', contracts);
+
+  if (changedWorkspaceDirs.size === 0) {
+    return {
+      status: 'passed',
+      summary: 'no public package changes — version bump check passed',
+      errors: [],
+    };
+  }
+
+  const states: PublicPackageVersionState[] = await Promise.all(
+    contracts.map(async (contract) => {
+      const currentPackageJson = await (
+        dependencies.readCurrentPackageJsonFn ?? readCurrentPackageJson
+      )(contract.workspaceDir);
+      const basePackageJson = await (
+        dependencies.readBasePackageJsonFn ?? readPackageJsonAtGitRef
+      )(mergeBase, contract.workspaceDir);
+      return {
+        contract,
+        changedSinceBase: changedWorkspaceDirs.has(contract.workspaceDir),
+        currentVersion: getPackageVersion(currentPackageJson) ?? '',
+        baseVersion: getPackageVersion(basePackageJson),
+      };
+    }),
+  );
+
+  const errors = findLockstepVersionBumpErrors(states);
+
+  return errors.length === 0
+    ? {
+        status: 'passed',
+        summary: 'version bump check passed',
+        errors: [],
+      }
+    : {
+        status: 'failed',
+        summary: 'version bump check failed:',
+        errors,
+      };
+}
+
+async function main() {
+  const result = await runVersionBumpCheck();
+
+  if (result.status === 'failed') {
+    console.error(result.summary);
+    for (const error of result.errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(result.summary);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/tools/release/release-utils.ts
+++ b/tools/release/release-utils.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { dirname, join } from 'node:path';
+import { dirname, join, matchesGlob } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
@@ -94,10 +94,25 @@ export async function findChangedWorkspaceDirs(
         path === candidate.workspaceDir ||
         path.startsWith(`${candidate.workspaceDir}/`),
     );
-    if (contract) {
+    if (contract && !isVersionPolicyIgnoredPath(contract, path)) {
       changedDirs.add(contract.workspaceDir);
     }
   }
 
   return changedDirs;
+}
+
+export function isVersionPolicyIgnoredPath(
+  contract: PublicPackageContract,
+  workspacePath: string,
+): boolean {
+  const relativePath = workspacePath.startsWith(`${contract.workspaceDir}/`)
+    ? workspacePath.slice(contract.workspaceDir.length + 1)
+    : workspacePath === contract.workspaceDir
+      ? ''
+      : workspacePath;
+
+  return contract.versionPolicyIgnorePatterns.some((pattern) =>
+    matchesGlob(relativePath, pattern),
+  );
 }


### PR DESCRIPTION
## Summary
- add a dedicated `release:check-versions` script and run it from the `pre-push` hook before the existing skill/type/lint/format checks
- refactor the new version-check wrapper into a testable helper and add direct Vitest coverage for merge-base, no-change, and failure paths
- update the hook docs and refresh the CLI bundled public package version map to match the bumped package manifests

## Why
CI was still catching missing public package version bumps after developers had already pushed. Moving the lockstep version check into `pre-push` blocks that class of mistake earlier and makes the failure local and obvious.

## Impact
Developers get a fast local failure when they modify a publishable package without updating the lockstep public package versions.

## Validation
- `pnpm release:check-versions`
- `pnpm --filter @open-agent-toolkit/cli type-check`
- `pnpm --filter @open-agent-toolkit/cli lint`
- `pnpm format`
- `pnpm --filter @open-agent-toolkit/cli test -- --run src/release/check-version-bumps.test.ts`
- `git push -u origin codex/pre-push-version-bump-check`
