### PR TITLE
fix: clarify summary generation skill workflow

### DIFF
--- a/.agents/skills/oat-project-complete/SKILL.md
+++ b/.agents/skills/oat-project-complete/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-complete
-version: 1.3.6
+version: 1.3.7
 description: Use when all implementation work is finished and the project is ready to close. Marks the OAT project lifecycle as complete.
 disable-model-invocation: true
 user-invocable: true

--- a/.agents/skills/oat-project-complete/SKILL.md
+++ b/.agents/skills/oat-project-complete/SKILL.md
@@ -64,11 +64,20 @@ Ask all user questions at once so the user can answer them in a single interacti
 
 Before asking the batched questions, read `oat_pr_status` and `oat_pr_url` from `state.md` frontmatter.
 
+Also preflight summary status using the same freshness rules as `oat-project-summary`:
+
+- `summary.md` is `missing` when `{PROJECT_PATH}/summary.md` does not exist
+- `summary.md` is `stale` when the tracking frontmatter fields `oat_summary_last_task`, `oat_summary_revision_count`, or `oat_summary_includes_revisions` no longer match `current_last_task`, `current_rev_count`, or `current_rev_list` as defined in `oat-project-summary` Step 3
+- `summary.md` is `current` when those tracking fields still match the `oat-project-summary` Step 3 comparison inputs
+
 **Questions to ask (in a single prompt):**
 
 1. **Confirm completion:** "Ready to mark **{PROJECT_NAME}** as complete?"
 2. **Archive** (only if `IS_SHARED_PROJECT` is `true`): "Archive the project after completion?"
-3. **Open PR:** "Open a PR in GitHub after generating the PR description?" — ask this only when no tracked open PR already exists.
+3. **Generate or refresh summary** (only if summary status is `missing` or `stale`): present the status explicitly:
+   - Missing example: "A summary has not been generated yet. Would you like me to generate it now as part of completion?"
+   - Stale example: "The project summary is out of date. Would you like me to refresh it now as part of completion?"
+4. **Open PR:** "Open a PR in GitHub after generating the PR description?" — ask this only when no tracked open PR already exists.
 
 If `oat_pr_status` is `open`, do not ask the Open PR question. Set `SHOULD_OPEN_PR="false"` and treat the existing PR as already tracked.
 
@@ -78,12 +87,15 @@ Present all applicable questions together. Example combined prompt:
 Ready to complete project **{PROJECT_NAME}**?
 
 1. Archive the project after completion? (yes/no)
-2. Open a PR in GitHub? (yes/no)
+2. A summary has not been generated yet. Generate it now as part of completion? (yes/no)
+3. Open a PR in GitHub? (yes/no)
 ```
 
 If the user declines the completion confirmation, exit gracefully.
 
-Store the answers as `SHOULD_ARCHIVE` and `SHOULD_OPEN_PR` for use in later steps.
+Store the answers as `SHOULD_ARCHIVE`, `SHOULD_GENERATE_SUMMARY`, and `SHOULD_OPEN_PR` for use in later steps.
+
+If the summary status is `current`, set `SHOULD_GENERATE_SUMMARY="false"` and note that a current summary is already available.
 
 If `oat_pr_url` is present, show it in the completion summary.
 
@@ -187,8 +199,11 @@ After collecting all warnings from 3.1, 3.2, and 3.3:
 
 Check if `{PROJECT_PATH}/summary.md` exists and whether it is current against the implementation state:
 
-- If `summary.md` is missing or stale, invoke `oat-project-summary` automatically before completing.
-- Do not prompt the user about whether to generate `summary.md` during completion.
+- If `summary.md` is missing or stale and `SHOULD_GENERATE_SUMMARY="true"`, generate or refresh it before completing.
+- Prefer running the `oat-project-summary` skill when skill-to-skill invocation is available in the current host/runtime.
+- If direct skill invocation is unavailable, generate or update `summary.md` inline by following the same synthesis rules as `oat-project-summary` (validate implementation state, read the same project artifacts, apply the same freshness checks, update the same frontmatter tracking fields, and write a complete `summary.md` before continuing).
+- Do not assume `oat-project-summary` is a shell command on `PATH`. Only execute a shell command with that name if the environment explicitly provides a real executable.
+- If `summary.md` is missing or stale and `SHOULD_GENERATE_SUMMARY="false"`, emit: `Warning: Proceeding without summary generation.`
 - If summary generation succeeds, proceed with the refreshed `summary.md` available for PR and archive steps.
 - If summary generation fails mid-way (context limits, missing artifacts, etc.), warn "Summary generation failed: {reason}. Proceeding without summary." Do NOT leave a half-written summary.md — either it completes fully or clean up the partial file and proceed without it.
 - If `summary.md` already exists and is current, note it as available. Summary.md will be:

--- a/.agents/skills/oat-project-pr-final/SKILL.md
+++ b/.agents/skills/oat-project-pr-final/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-pr-final
-version: 1.3.1
+version: 1.3.2
 description: Use when an active OAT project has completed all phases and is ready for final merge to main. Generates the final OAT lifecycle PR description from artifacts and review status, then creates the PR automatically.
 disable-model-invocation: true
 user-invocable: true
@@ -173,7 +173,10 @@ If `FINAL_ROW` is missing or does not contain `passed`:
 
 Check if `{PROJECT_PATH}/summary.md` exists:
 
-- If `summary.md` is missing or stale, invoke `oat-project-summary` automatically before proceeding.
+- If `summary.md` is missing or stale, refresh it automatically before proceeding.
+- Prefer running the `oat-project-summary` skill when skill-to-skill invocation is available in the current host/runtime.
+- If direct skill invocation is unavailable, generate or update `summary.md` inline by following the same synthesis rules as `oat-project-summary` (validate implementation state, read the same project artifacts, apply the same freshness checks, update the same frontmatter tracking fields, and write a complete `summary.md` before continuing).
+- Do not assume `oat-project-summary` is a shell command on `PATH`. Only execute a shell command with that name if the environment explicitly provides a real executable.
 - Do not ask whether to generate or refresh `summary.md` during pr-final.
 - **If generation succeeds:** Read the refreshed `summary.md` and use it as the primary source for the PR description's `## Summary` section. The PR Summary should be a condensed version of summary.md's Overview + What Was Implemented sections — reviewer-oriented and actionable, not a copy-paste.
 - **If generation fails:** Warn and fall back to the raw artifact synthesis below.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
+++ b/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
@@ -75,7 +75,7 @@ describe('review skill contracts', () => {
     );
   });
 
-  it('requires automatic summary refresh during pr-final and completion', () => {
+  it('defines runtime-safe summary handling during pr-final and completion', () => {
     const prFinalPath = repoFilePath(
       '.agents/skills/oat-project-pr-final/SKILL.md',
     );
@@ -87,16 +87,32 @@ describe('review skill contracts', () => {
     const completeContent = readFileSync(completePath, 'utf8');
 
     expect(prFinalContent).toContain(
-      'If `summary.md` is missing or stale, invoke `oat-project-summary` automatically before proceeding.',
+      'If `summary.md` is missing or stale, refresh it automatically before proceeding.',
+    );
+    expect(prFinalContent).toContain(
+      'Prefer running the `oat-project-summary` skill when skill-to-skill invocation is available in the current host/runtime.',
+    );
+    expect(prFinalContent).toContain(
+      'Do not assume `oat-project-summary` is a shell command on `PATH`.',
     );
     expect(prFinalContent).toContain(
       'Do not ask whether to generate or refresh `summary.md` during pr-final.',
     );
     expect(completeContent).toContain(
-      'If `summary.md` is missing or stale, invoke `oat-project-summary` automatically before completing.',
+      'Also preflight summary status using the same freshness rules as `oat-project-summary`:',
     );
     expect(completeContent).toContain(
-      'Do not prompt the user about whether to generate `summary.md` during completion.',
+      'Would you like me to generate it now as part of completion?',
+    );
+    expect(completeContent).toContain('SHOULD_GENERATE_SUMMARY');
+    expect(completeContent).toContain(
+      'If `summary.md` is missing or stale and `SHOULD_GENERATE_SUMMARY="true"`, generate or refresh it before completing.',
+    );
+    expect(completeContent).toContain(
+      'Do not assume `oat-project-summary` is a shell command on `PATH`.',
+    );
+    expect(completeContent).toContain(
+      'Warning: Proceeding without summary generation.',
     );
   });
 });

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- stop `oat-project-pr-final` from assuming `oat-project-summary` is a shell command and document the supported fallback behavior
- update `oat-project-complete` to preflight summary freshness and ask the user whether to generate or refresh `summary.md` during completion
- make the completion guidance more explicit by naming the summary freshness tracking fields and the skip-warning output

## Why
`oat-project-pr-final` and `oat-project-complete` both treated `oat-project-summary` like a guaranteed executable. In hosts without a matching command on `PATH`, that can skip or fail summary generation even though the workflow implies it succeeded.

## Validation
- push-time canonical skill version validation against `origin/main`
- `pnpm type-check`
- `pnpm lint`
- `pnpm format`
