### PR TITLE
fix: install worktree-safe git hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "turbo run test",
     "type-check": "turbo run type-check",
     "cli:link": "pnpm run build --filter=@open-agent-toolkit/cli && cd packages/cli && pnpm link --global",
-    "worktree:init": "pnpm install && pnpm run build && pnpm run cli -- sync --scope project"
+    "worktree:init": "pnpm install && pnpm hooks setup && pnpm run build && pnpm run cli -- sync --scope project"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/tools/git-hooks/README.md
+++ b/tools/git-hooks/README.md
@@ -35,6 +35,7 @@ GIT_HOOKS=0 pnpm install
 
 ## Notes
 
-- Hooks are symlinked from `tools/git-hooks/` into `.git/hooks/`
-- Disabled hooks are tracked in `.git/hooks/.disabled-hooks`
-- Git `core.hooksPath` is unset so hooks run from `.git/hooks/`
+- Hooks are installed as managed wrapper scripts in Git's active hooks directory
+- The wrappers dispatch to the current checkout's `tools/git-hooks/` scripts, so they work correctly from git worktrees
+- Disabled hooks are tracked in Git's active hooks directory via `.disabled-hooks`
+- Git `core.hooksPath` is unset so hooks run from Git's default hooks directory

--- a/tools/git-hooks/manage-hooks.js
+++ b/tools/git-hooks/manage-hooks.js
@@ -1,11 +1,26 @@
 #!/usr/bin/env node
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const hooks = ['commit-msg', 'pre-commit', 'pre-push', 'post-checkout'];
-const hooksSourceDir = 'tools/git-hooks';
-const gitHooksDir = '.git/hooks';
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+const hooksSourceDir = path.join(repoRoot, 'tools', 'git-hooks');
+const MANAGED_HOOK_MARKER = '# open-agent-toolkit managed hook';
+
+function resolveGitPath(...segments) {
+  return execFileSync('git', ['rev-parse', '--git-path', ...segments], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
+}
+
+const gitHooksDir = resolveGitPath('hooks');
 const disabledHooksFile = path.join(gitHooksDir, '.disabled-hooks');
 
 function showUsage() {
@@ -58,27 +73,47 @@ function isHookDisabled(hookName) {
   return getDisabledHooks().has(hookName);
 }
 
-/**
- * Check if a Git hook is enabled (symlink exists and target is executable)
- * @param {string} hookName - The name of the hook to check
- * @returns {boolean} True if hook is enabled
- */
-function isHookEnabled(hookName) {
-  const hookPath = path.join(gitHooksDir, hookName);
+function getHookPath(hookName) {
+  return path.join(gitHooksDir, hookName);
+}
+
+function getHookState(hookName) {
+  const hookPath = getHookPath(hookName);
 
   try {
-    // Check if symlink exists (use lstat to check the link itself)
     const linkStats = fs.lstatSync(hookPath);
-    if (!linkStats.isSymbolicLink() && !linkStats.isFile()) {
-      return false;
+
+    if (linkStats.isSymbolicLink()) {
+      const target = fs.readlinkSync(hookPath);
+      return target.includes('tools/git-hooks') ? 'legacy-managed' : 'custom';
     }
 
-    // Check if target is executable (use stat to follow symlink)
-    const stats = fs.statSync(hookPath);
-    return !!(stats.mode & 0o100); // Check if executable
+    if (!linkStats.isFile()) {
+      return 'missing';
+    }
+
+    const content = fs.readFileSync(hookPath, 'utf8');
+    return content.includes(MANAGED_HOOK_MARKER) ? 'managed' : 'custom';
   } catch {
-    return false;
+    return 'missing';
   }
+}
+
+function createManagedHookContents(hookName) {
+  return `#!/bin/sh
+${MANAGED_HOOK_MARKER}
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+hook_script="$repo_root/tools/git-hooks/${hookName}"
+
+if [ ! -x "$hook_script" ]; then
+  echo "❌ Hook file $hook_script not found or not executable" >&2
+  exit 1
+fi
+
+exec "$hook_script" "$@"
+`;
 }
 
 /**
@@ -87,10 +122,15 @@ function isHookEnabled(hookName) {
  */
 function enableHook(hookName) {
   const sourcePath = path.join(hooksSourceDir, hookName);
-  const hookPath = path.join(gitHooksDir, hookName);
+  const hookPath = getHookPath(hookName);
 
   if (fs.existsSync(sourcePath)) {
-    // Remove existing hook if present (could be old copy or broken symlink)
+    const state = getHookState(hookName);
+    if (state === 'custom') {
+      console.log(`⏭️  Skipped ${hookName} hook (custom hook already exists)`);
+      return;
+    }
+
     if (
       fs.existsSync(hookPath) ||
       fs.lstatSync(hookPath, { throwIfNoEntry: false })
@@ -98,11 +138,10 @@ function enableHook(hookName) {
       fs.unlinkSync(hookPath);
     }
 
-    // Create relative symlink from .git/hooks to tools/git-hooks
-    const relativeSourcePath = path.relative(gitHooksDir, sourcePath);
-    fs.symlinkSync(relativeSourcePath, hookPath);
+    fs.mkdirSync(gitHooksDir, { recursive: true });
+    fs.writeFileSync(hookPath, createManagedHookContents(hookName), 'utf8');
+    fs.chmodSync(hookPath, 0o755);
 
-    // Remove from disabled list when enabling
     unmarkHookAsDisabled(hookName);
     console.log(`✅ Enabled ${hookName} hook`);
   } else {
@@ -111,10 +150,9 @@ function enableHook(hookName) {
 }
 
 function disableHook(hookName) {
-  const hookPath = path.join(gitHooksDir, hookName);
+  const hookPath = getHookPath(hookName);
   if (fs.existsSync(hookPath)) {
     fs.unlinkSync(hookPath);
-    // Mark as intentionally disabled
     markHookAsDisabled(hookName);
     console.log(`🚫 Disabled ${hookName} hook`);
   } else {
@@ -127,13 +165,18 @@ function showStatus() {
   console.log('===================');
 
   hooks.forEach((hook) => {
-    const enabled = isHookEnabled(hook);
+    const state = getHookState(hook);
+    const enabled = state === 'managed';
     const disabled = isHookDisabled(hook);
     let status;
     if (enabled) {
       status = '✅ Enabled';
     } else if (disabled) {
       status = '🚫 Disabled (intentional)';
+    } else if (state === 'custom') {
+      status = '⚪ Custom hook present';
+    } else if (state === 'legacy-managed') {
+      status = '⚠️ Legacy managed hook';
     } else {
       status = '⚪ Not installed';
     }
@@ -151,40 +194,41 @@ if (!action) {
 
 switch (action) {
   case 'enable-all':
-    // Ensure Git uses the default .git/hooks directory
     try {
       execSync('git config --unset core.hooksPath', { stdio: 'ignore' });
     } catch {
-      // Ignore error if hooksPath wasn't set
+      // Ignore unset errors when Git is already using its default hooks path.
     }
     hooks.forEach(enableHook);
     console.log('✅ All hooks enabled');
     break;
 
   case 'setup': {
-    // Ensure Git uses the default .git/hooks directory
     try {
       execSync('git config --unset core.hooksPath', { stdio: 'ignore' });
     } catch {
-      // Ignore error if hooksPath wasn't set
+      // Ignore unset errors when Git is already using its default hooks path.
     }
 
-    // Check if all hooks are already set up
     const allHooksReady = hooks.every(
-      (hook) => isHookDisabled(hook) || isHookEnabled(hook),
+      (hook) =>
+        isHookDisabled(hook) ||
+        getHookState(hook) === 'managed' ||
+        getHookState(hook) === 'custom',
     );
 
     if (allHooksReady) {
-      // All hooks already configured - show brief confirmation
       console.log('✅ Git hooks already configured');
       process.exit(0);
     }
 
-    // Only enable hooks that don't exist AND weren't intentionally disabled
     hooks.forEach((hook) => {
+      const state = getHookState(hook);
       if (isHookDisabled(hook)) {
         console.log(`⏭️  Skipped ${hook} hook (intentionally disabled)`);
-      } else if (!isHookEnabled(hook)) {
+      } else if (state === 'custom') {
+        console.log(`⏭️  Skipped ${hook} hook (custom hook already exists)`);
+      } else if (state !== 'managed') {
         enableHook(hook);
       } else {
         console.log(`⏭️  Skipped ${hook} hook (already exists)`);


### PR DESCRIPTION
## Summary
- replace the shared git-hook symlink strategy with managed wrapper scripts that resolve the current checkout via `git rev-parse --show-toplevel`
- make `tools/git-hooks/manage-hooks.js` worktree-safe by resolving Git's active hooks directory instead of assuming `.git/hooks` exists under the current checkout
- update `worktree:init` to run explicit hook setup after install and refresh the hook README to document the new wrapper behavior

## Root Cause
Git worktrees share the common repository's hooks directory. Our previous hook installer created symlinks from that shared hooks directory to `tools/git-hooks/*` in whichever checkout happened to install them first.

That meant pushes from a worktree could execute hook scripts from a different checkout, including stale `pre-push` logic that did not run `pnpm release:check-versions`. On top of that, the hook manager assumed `.git/hooks` existed under the current checkout, which is false in a worktree because `.git` is a file.

## What Changed
The hook manager now installs wrapper scripts into Git's actual active hooks directory. Each wrapper computes the current checkout root at runtime and dispatches to that checkout's `tools/git-hooks/<hook>`, so worktrees always execute their own branch's hook content.

`worktree:init` now runs `pnpm hooks setup` explicitly after `pnpm install`. The `prepare` hook remains a silent best-effort path, but `worktree:init` now gives worktree bootstrap a visible hook installation step.

## Validation
- `node tools/git-hooks/manage-hooks.js setup`
- `node tools/git-hooks/manage-hooks.js status`
- `pnpm exec oxfmt --check tools/git-hooks/manage-hooks.js tools/git-hooks/README.md package.json`
- `pnpm exec oxlint tools/git-hooks/manage-hooks.js`
- direct execution of the installed shared hook: `"$(git rev-parse --git-path hooks/pre-push)"`
- `git push -u origin codex/fix-worktree-git-hooks`

## Notes
The local worktree still has an unrelated generated modification in `packages/cli/assets/skills/oat-project-document/SKILL.md`. That file was intentionally left out of this PR.
