### PR TITLE
fix: align fumadocs search with base paths

### DIFF
--- a/.oat/templates/docs-app-fuma/app/layout.tsx
+++ b/.oat/templates/docs-app-fuma/app/layout.tsx
@@ -5,11 +5,20 @@ import type { ReactNode } from 'react';
 import './globals.css';
 import { source } from '@/lib/source';
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang='en' suppressHydrationWarning>
       <body>
-        <RootProvider search={{ options: { type: 'static' as const } }}>
+        <RootProvider
+          search={{
+            options: {
+              type: 'static' as const,
+              api: `${basePath}/api/search`,
+            },
+          }}
+        >
           <DocsLayout
             branding={{
               title: '{{SITE_NAME}}',

--- a/.oat/templates/docs-app-fuma/next.config.js
+++ b/.oat/templates/docs-app-fuma/next.config.js
@@ -1,6 +1,9 @@
 import { createDocsConfig } from '@open-agent-toolkit/docs-config';
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || undefined;
+
 export default createDocsConfig({
   title: '{{SITE_NAME}}',
   description: '{{SITE_DESCRIPTION}}',
+  ...(basePath ? { basePath } : {}),
 });

--- a/apps/oat-docs/app/layout.tsx
+++ b/apps/oat-docs/app/layout.tsx
@@ -5,11 +5,21 @@ import type { ReactNode } from 'react';
 import './globals.css';
 import { source } from '@/lib/source';
 
+const basePath = '/open-agent-toolkit';
+
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <html lang='en' suppressHydrationWarning>
       <body>
-        <RootProvider search={{ options: { type: 'static' as const } }}>
+        <RootProvider
+          search={{
+            options: {
+              type: 'static' as const,
+              // Static search does not inherit Next.js basePath automatically.
+              api: `${basePath}/api/search`,
+            },
+          }}
+        >
           <DocsLayout
             branding={{
               title: 'Open Agent Toolkit',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/docs/init/integration.test.ts
+++ b/packages/cli/src/commands/docs/init/integration.test.ts
@@ -119,6 +119,7 @@ describe('scaffold integration', () => {
       );
       expect(nextConfig).toContain('Test Docs Documentation');
       expect(nextConfig).toContain('Integration test documentation');
+      expect(nextConfig).toContain('NEXT_PUBLIC_BASE_PATH');
 
       // Verify layout has branding
       const layout = await readFile(
@@ -127,6 +128,8 @@ describe('scaffold integration', () => {
       );
       expect(layout).toContain('Test Docs Documentation');
       expect(layout).toContain('Integration test documentation');
+      expect(layout).toContain('NEXT_PUBLIC_BASE_PATH');
+      expect(layout).toContain('/api/search');
 
       const tsconfig = JSON.parse(
         await readFile(join(result.appRoot, 'tsconfig.json'), 'utf8'),

--- a/packages/cli/src/commands/docs/init/scaffold.test.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.test.ts
@@ -35,7 +35,7 @@ const FUMA_TEMPLATE_FILES: Record<string, string> = {
   '.gitignore':
     '# Dependencies\nnode_modules/\n\n# Next.js build output\n.next/\nout/\n\n# fumadocs-mdx generated source\n.source/\n\n# Next.js generated types\nnext-env.d.ts\n',
   'next.config.js':
-    "import { createDocsConfig } from '@open-agent-toolkit/docs-config';\nexport default createDocsConfig({ title: '{{SITE_NAME}}', description: '{{SITE_DESCRIPTION}}' });\n",
+    "import { createDocsConfig } from '@open-agent-toolkit/docs-config';\nconst basePath = process.env.NEXT_PUBLIC_BASE_PATH || undefined;\nexport default createDocsConfig({ title: '{{SITE_NAME}}', description: '{{SITE_DESCRIPTION}}', ...(basePath ? { basePath } : {}) });\n",
   'postcss.config.mjs':
     "const config = {\n  plugins: {\n    '@tailwindcss/postcss': {},\n  },\n};\n\nexport default config;\n",
   'source.config.ts':
@@ -78,7 +78,7 @@ const FUMA_TEMPLATE_FILES: Record<string, string> = {
   'app/globals.css':
     "@import 'tailwindcss';\n@import 'fumadocs-ui/css/black.css';\n@import 'fumadocs-ui/css/preset.css';\n\n@source '../node_modules/fumadocs-ui/dist/**/*.js';\n",
   'app/layout.tsx':
-    "import { DocsLayout } from '@open-agent-toolkit/docs-theme';\nexport default function Layout({ children }) { return <DocsLayout branding={{ title: '{{SITE_NAME}}', description: '{{SITE_DESCRIPTION}}' }} tree={{}}>{children}</DocsLayout>; }\n",
+    "import { DocsLayout } from '@open-agent-toolkit/docs-theme';\nconst basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';\nexport default function Layout({ children }) { return <DocsLayout branding={{ title: '{{SITE_NAME}}', description: '{{SITE_DESCRIPTION}}' }} tree={{}} searchApi={`${basePath}/api/search`}>{children}</DocsLayout>; }\n",
   'app/[[...slug]]/page.tsx':
     "import { DocsPage, Mermaid, Tab, Tabs } from '@open-agent-toolkit/docs-theme';\nimport defaultComponents from 'fumadocs-ui/mdx';\nexport default function Page() { return <div />; }\n",
   'app/api/search/route.ts':
@@ -274,12 +274,15 @@ describe('scaffoldDocsApp', () => {
     );
     expect(nextConfig).toContain('My Docs Documentation');
     expect(nextConfig).toContain('Project documentation site');
+    expect(nextConfig).toContain('NEXT_PUBLIC_BASE_PATH');
 
     const layout = await readFile(
       join(result.appRoot, 'app', 'layout.tsx'),
       'utf8',
     );
     expect(layout).toContain('Project documentation site');
+    expect(layout).toContain('NEXT_PUBLIC_BASE_PATH');
+    expect(layout).toContain('/api/search');
 
     const docsIndex = await readFile(
       join(result.appRoot, 'docs', 'index.md'),

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- fix the OAT docs app search client to use the deployed base path for static search
- update the Fumadocs scaffold so generated sites keep `basePath` and search API paths aligned via `NEXT_PUBLIC_BASE_PATH`
- add/update scaffold coverage and bump public package versions to 0.0.24

## Testing
- pnpm --filter @open-agent-toolkit/cli test -- src/commands/docs/init/scaffold.test.ts src/commands/docs/init/integration.test.ts
- pnpm release:validate
- pnpm --filter oat-docs build
- local browser verification against a static export served under `/open-agent-toolkit`