### PR TITLE
fix: account for workspace dependency changes in release checks

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/release/release-utils.test.ts
+++ b/packages/cli/src/release/release-utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { findChangedWorkspaceDirsFromPaths } from '../../../../tools/release/release-utils';
+import {
+  findChangedWorkspaceDirsFromPaths,
+  findVersionPolicyDependencyRootsByWorkspaceDir,
+} from '../../../../tools/release/release-utils';
 import { getPublicPackageContracts } from './public-package-contract';
 
 describe('findChangedWorkspaceDirsFromPaths', () => {
@@ -36,5 +39,43 @@ describe('findChangedWorkspaceDirsFromPaths', () => {
         getPublicPackageContracts(),
       ),
     ).toEqual(new Set(['packages/cli', 'packages/docs-theme']));
+  });
+
+  it('tracks internal workspace dependency changes for dependent public packages', () => {
+    expect(
+      findChangedWorkspaceDirsFromPaths(
+        ['packages/control-plane/src/index.ts'],
+        getPublicPackageContracts(),
+        new Map([['packages/cli', ['packages/control-plane']]]),
+      ),
+    ).toEqual(new Set(['packages/cli']));
+  });
+
+  it('marks all affected public packages when a shared dependency changes', () => {
+    expect(
+      findChangedWorkspaceDirsFromPaths(
+        ['packages/docs-transforms/src/index.ts'],
+        getPublicPackageContracts(),
+        new Map([['packages/docs-config', ['packages/docs-transforms']]]),
+      ),
+    ).toEqual(new Set(['packages/docs-config', 'packages/docs-transforms']));
+  });
+});
+
+describe('findVersionPolicyDependencyRootsByWorkspaceDir', () => {
+  it('derives release-impacting workspace dependencies from package manifests', async () => {
+    const dependencyRoots =
+      await findVersionPolicyDependencyRootsByWorkspaceDir(
+        getPublicPackageContracts(),
+      );
+
+    expect(dependencyRoots.get('packages/cli')).toEqual([
+      'packages/control-plane',
+    ]);
+    expect(dependencyRoots.get('packages/docs-config')).toEqual([
+      'packages/docs-transforms',
+    ]);
+    expect(dependencyRoots.get('packages/docs-theme')).toEqual([]);
+    expect(dependencyRoots.get('packages/docs-transforms')).toEqual([]);
   });
 });

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.7
+      tsc-alias:
+        specifier: ^1.8.10
+        version: 1.8.16
       typescript:
         specifier: ^5.8.3
         version: 5.9.3

--- a/tools/release/release-utils.ts
+++ b/tools/release/release-utils.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { readFile, readdir } from 'node:fs/promises';
 import { dirname, join, matchesGlob } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
@@ -12,6 +13,18 @@ export const REPO_ROOT = join(
   '..',
   '..',
 );
+
+const WORKSPACE_DIRECTORIES = ['apps', 'packages'] as const;
+const WORKSPACE_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'optionalDependencies',
+] as const;
+
+interface WorkspacePackageInfo {
+  name: string;
+  workspaceDir: string;
+  dependencyNames: string[];
+}
 
 export async function runCommand(
   command: string,
@@ -76,6 +89,8 @@ export async function findChangedWorkspaceDirs(
   headRef: string,
   contracts: readonly PublicPackageContract[],
 ): Promise<Set<string>> {
+  const dependencyRootsByWorkspaceDir =
+    await findVersionPolicyDependencyRootsByWorkspaceDir(contracts);
   const diff = await runCommand('git', [
     'diff',
     '--name-only',
@@ -86,6 +101,7 @@ export async function findChangedWorkspaceDirs(
         contracts.flatMap((contract) => [
           contract.workspaceDir,
           ...contract.versionPolicyAdditionalRoots,
+          ...(dependencyRootsByWorkspaceDir.get(contract.workspaceDir) ?? []),
         ]),
       ),
     ),
@@ -97,27 +113,156 @@ export async function findChangedWorkspaceDirs(
       .map((line) => line.trim())
       .filter(Boolean),
     contracts,
+    dependencyRootsByWorkspaceDir,
   );
 }
 
 export function findChangedWorkspaceDirsFromPaths(
   changedPaths: readonly string[],
   contracts: readonly PublicPackageContract[],
+  dependencyRootsByWorkspaceDir: ReadonlyMap<
+    string,
+    readonly string[]
+  > = new Map(),
 ): Set<string> {
   const changedDirs = new Set<string>();
 
   for (const path of changedPaths) {
-    const contract = contracts.find((candidate) =>
-      [candidate.workspaceDir, ...candidate.versionPolicyAdditionalRoots].some(
-        (root) => path === root || path.startsWith(`${root}/`),
-      ),
-    );
-    if (contract && !isVersionPolicyIgnoredPath(contract, path)) {
-      changedDirs.add(contract.workspaceDir);
+    for (const contract of contracts) {
+      const roots = [
+        contract.workspaceDir,
+        ...contract.versionPolicyAdditionalRoots,
+        ...(dependencyRootsByWorkspaceDir.get(contract.workspaceDir) ?? []),
+      ];
+
+      if (
+        roots.some((root) => path === root || path.startsWith(`${root}/`)) &&
+        !isVersionPolicyIgnoredPath(contract, path)
+      ) {
+        changedDirs.add(contract.workspaceDir);
+      }
     }
   }
 
   return changedDirs;
+}
+
+export async function findVersionPolicyDependencyRootsByWorkspaceDir(
+  contracts: readonly PublicPackageContract[],
+): Promise<Map<string, string[]>> {
+  const workspacePackages = await loadWorkspacePackageInfos();
+  const dependencyRootsByWorkspaceDir = new Map<string, string[]>();
+
+  for (const contract of contracts) {
+    const dependencyRoots = collectWorkspaceDependencyRoots(
+      contract.publicName,
+      workspacePackages,
+    ).filter((workspaceDir) => workspaceDir !== contract.workspaceDir);
+    dependencyRootsByWorkspaceDir.set(contract.workspaceDir, dependencyRoots);
+  }
+
+  return dependencyRootsByWorkspaceDir;
+}
+
+async function loadWorkspacePackageInfos(): Promise<
+  Map<string, WorkspacePackageInfo>
+> {
+  const workspacePackages = new Map<string, WorkspacePackageInfo>();
+
+  for (const workspaceDirectory of WORKSPACE_DIRECTORIES) {
+    const absoluteWorkspaceDirectory = join(REPO_ROOT, workspaceDirectory);
+    let entries: Awaited<ReturnType<typeof readdir>>;
+
+    try {
+      entries = await readdir(absoluteWorkspaceDirectory, {
+        withFileTypes: true,
+      });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const workspaceDir = join(workspaceDirectory, entry.name);
+      const packageJsonPath = join(REPO_ROOT, workspaceDir, 'package.json');
+      let packageJson: Record<string, unknown>;
+
+      try {
+        packageJson = JSON.parse(
+          await readFile(packageJsonPath, 'utf8'),
+        ) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      const name = packageJson.name;
+      if (typeof name !== 'string' || name.trim().length === 0) {
+        continue;
+      }
+
+      workspacePackages.set(name, {
+        name,
+        workspaceDir,
+        dependencyNames: getWorkspaceDependencyNames(packageJson),
+      });
+    }
+  }
+
+  return workspacePackages;
+}
+
+function collectWorkspaceDependencyRoots(
+  packageName: string,
+  workspacePackages: ReadonlyMap<string, WorkspacePackageInfo>,
+): string[] {
+  const dependencyRoots = new Set<string>();
+  const visitedPackageNames = new Set<string>();
+
+  function visit(currentPackageName: string) {
+    const currentPackage = workspacePackages.get(currentPackageName);
+    if (!currentPackage) {
+      return;
+    }
+
+    for (const dependencyName of currentPackage.dependencyNames) {
+      const dependencyPackage = workspacePackages.get(dependencyName);
+      if (!dependencyPackage || visitedPackageNames.has(dependencyName)) {
+        continue;
+      }
+
+      visitedPackageNames.add(dependencyName);
+      dependencyRoots.add(dependencyPackage.workspaceDir);
+      visit(dependencyName);
+    }
+  }
+
+  visit(packageName);
+
+  return Array.from(dependencyRoots).sort();
+}
+
+function getWorkspaceDependencyNames(
+  packageJson: Record<string, unknown>,
+): string[] {
+  const dependencyNames = new Set<string>();
+
+  for (const field of WORKSPACE_DEPENDENCY_FIELDS) {
+    const dependencies = packageJson[field];
+    if (!dependencies || typeof dependencies !== 'object') {
+      continue;
+    }
+
+    for (const dependencyName of Object.keys(
+      dependencies as Record<string, unknown>,
+    )) {
+      dependencyNames.add(dependencyName);
+    }
+  }
+
+  return Array.from(dependencyNames).sort();
 }
 
 export function isVersionPolicyIgnoredPath(


### PR DESCRIPTION
## What changed

- make release/version-bump change detection dependency-aware for public packages
- treat internal workspace dependency changes like `packages/control-plane` as affecting `@open-agent-toolkit/cli`
- treat shared public dependency changes like `packages/docs-transforms` as affecting dependent public packages like `@open-agent-toolkit/docs-config`
- add tests for injected dependency-root mappings and the real manifest-derived workspace graph
- refresh `pnpm-lock.yaml` for the earlier `tsc-alias` addition in `packages/control-plane`

## Why

The existing release policy only looked at direct public package roots plus a few CLI-owned extra roots. That meant a behavior-changing update in an internal workspace dependency could bypass the version-bump policy for the published package that actually ships that behavior.

This branch closes that gap by deriving dependency roots from workspace package manifests and feeding them into the same change-detection path used by release validation and release-tag creation.

## Impact

- release checks now require a public package version bump when one of its workspace dependencies changes
- tag creation for releases now uses the same dependency-aware signal
- docs package dependency changes are handled consistently with CLI internal dependency changes

## Validation

- `pnpm type-check`
- `pnpm --filter @open-agent-toolkit/cli exec vitest run src/release/release-utils.test.ts src/release/check-version-bumps.test.ts src/release/public-package-contract.test.ts`
- `pnpm exec oxfmt --check tools/release/release-utils.ts packages/cli/src/release/release-utils.test.ts`
