### PR TITLE
fix: publish control-plane with cli releases

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Verify publishable tarballs
         run: |
           for pkg_name in \
+            @open-agent-toolkit/control-plane \
             @open-agent-toolkit/docs-transforms \
             @open-agent-toolkit/docs-config \
             @open-agent-toolkit/docs-theme \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
       # - support reruns from an existing release tag via workflow_dispatch
       # - use npm trusted publishing via GitHub OIDC
       # - rerun the same build and release validation path as dry-run
-      # - publish the four @open-agent-toolkit/* packages in lockstep
+      # - publish the five @open-agent-toolkit/* packages in lockstep
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -112,6 +112,7 @@ jobs:
       - name: Publish packages
         run: |
           for pkg_name in \
+            @open-agent-toolkit/control-plane \
             @open-agent-toolkit/docs-transforms \
             @open-agent-toolkit/docs-config \
             @open-agent-toolkit/docs-theme \
@@ -156,6 +157,7 @@ jobs:
             `@open-agent-toolkit/*` packages:
 
             - `@open-agent-toolkit/cli`
+            - `@open-agent-toolkit/control-plane`
             - `@open-agent-toolkit/docs-config`
             - `@open-agent-toolkit/docs-theme`
             - `@open-agent-toolkit/docs-transforms`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/release/check-version-bumps.test.ts
+++ b/packages/cli/src/release/check-version-bumps.test.ts
@@ -47,7 +47,7 @@ describe('runVersionBumpCheck', () => {
       status: 'failed',
       summary: 'version bump check failed:',
       errors: [
-        'publishable package changes require a lockstep version bump across all public packages. Changed packages: @open-agent-toolkit/cli. Packages still at their base version: @open-agent-toolkit/cli@0.0.4, @open-agent-toolkit/docs-config@0.0.4, @open-agent-toolkit/docs-theme@0.0.4, @open-agent-toolkit/docs-transforms@0.0.4',
+        'publishable package changes require a lockstep version bump across all public packages. Changed packages: @open-agent-toolkit/cli. Packages still at their base version: @open-agent-toolkit/cli@0.0.4, @open-agent-toolkit/control-plane@0.0.4, @open-agent-toolkit/docs-config@0.0.4, @open-agent-toolkit/docs-theme@0.0.4, @open-agent-toolkit/docs-transforms@0.0.4',
       ],
     });
   });

--- a/packages/cli/src/release/public-package-contract.test.ts
+++ b/packages/cli/src/release/public-package-contract.test.ts
@@ -12,12 +12,16 @@ import {
   findForbiddenPackedPaths,
   findMissingMetadataFields,
   findMissingPackedPaths,
+  findNonPublicWorkspaceDependencySpecs,
   findWorkspaceProtocolDependencySpecs,
   getPublicPackageContracts,
 } from './public-package-contract';
 
 const cliPackageJsonPath = fileURLToPath(
   new URL('../../package.json', import.meta.url),
+);
+const controlPlanePackageJsonPath = fileURLToPath(
+  new URL('../../../control-plane/package.json', import.meta.url),
 );
 const docsConfigPackageJsonPath = fileURLToPath(
   new URL('../../../docs-config/package.json', import.meta.url),
@@ -40,18 +44,20 @@ async function readJson(path: string): Promise<Record<string, unknown>> {
 }
 
 describe('getPublicPackageContracts', () => {
-  it('defines the four public packages for the first release', () => {
+  it('defines the five public packages for release publishing', () => {
     const contracts = getPublicPackageContracts();
 
-    expect(contracts).toHaveLength(4);
+    expect(contracts).toHaveLength(5);
     expect(contracts.map((contract) => contract.publicName)).toEqual([
       '@open-agent-toolkit/cli',
+      '@open-agent-toolkit/control-plane',
       '@open-agent-toolkit/docs-config',
       '@open-agent-toolkit/docs-theme',
       '@open-agent-toolkit/docs-transforms',
     ]);
     expect(contracts.map((contract) => contract.workspaceDir)).toEqual([
       'packages/cli',
+      'packages/control-plane',
       'packages/docs-config',
       'packages/docs-theme',
       'packages/docs-transforms',
@@ -90,6 +96,15 @@ describe('getPublicPackageContracts', () => {
           'src/**',
           '**/*.test.*',
           'tsconfig.tsbuildinfo',
+        ]),
+      }),
+      expect.objectContaining({
+        publicName: '@open-agent-toolkit/control-plane',
+        role: 'support-library',
+        requiredPaths: expect.arrayContaining([
+          'dist/index.js',
+          'dist/index.d.ts',
+          'README.md',
         ]),
       }),
       expect.objectContaining({
@@ -186,6 +201,30 @@ describe('getPublicPackageContracts', () => {
     ]);
   });
 
+  it('reports packed dependencies on non-public workspace packages', () => {
+    expect(
+      findNonPublicWorkspaceDependencySpecs(
+        {
+          dependencies: {
+            '@open-agent-toolkit/control-plane': '0.0.1',
+            '@open-agent-toolkit/docs-config': '0.0.27',
+            chalk: '^5.6.2',
+          },
+        },
+        [
+          '@open-agent-toolkit/cli',
+          '@open-agent-toolkit/docs-config',
+          '@open-agent-toolkit/docs-theme',
+          '@open-agent-toolkit/docs-transforms',
+        ],
+        [
+          '@open-agent-toolkit/control-plane',
+          '@open-agent-toolkit/docs-config',
+        ],
+      ),
+    ).toEqual(['dependencies.@open-agent-toolkit/control-plane=0.0.1']);
+  });
+
   it('ignores generated version metadata for release version policy checks', () => {
     const cliContract = getPublicPackageContracts()[0];
 
@@ -210,14 +249,17 @@ describe('getPublicPackageContracts', () => {
   });
 
   it('reports missing build artifacts before packing', async () => {
-    const docsThemeContract = getPublicPackageContracts()[2];
+    const docsThemeContract = getPublicPackageContracts().find(
+      (contract) => contract.publicName === '@open-agent-toolkit/docs-theme',
+    );
+    expect(docsThemeContract).toBeDefined();
     const packageDir = await mkdtemp(join(tmpdir(), 'oat-release-validate-'));
     await mkdir(join(packageDir, 'dist'), { recursive: true });
     await writeFile(join(packageDir, 'dist', 'index.js'), '', 'utf8');
     await writeFile(join(packageDir, 'README.md'), '', 'utf8');
 
     await expect(
-      findMissingBuildArtifacts(packageDir, docsThemeContract),
+      findMissingBuildArtifacts(packageDir, docsThemeContract!),
     ).resolves.toEqual(['dist/index.d.ts']);
   });
 
@@ -250,9 +292,15 @@ describe('getPublicPackageContracts', () => {
           currentVersion: '0.0.4',
           baseVersion: '0.0.4',
         },
+        {
+          contract: contracts[4],
+          changedSinceBase: false,
+          currentVersion: '0.0.4',
+          baseVersion: '0.0.4',
+        },
       ]),
     ).toEqual([
-      'publishable package changes require a lockstep version bump across all public packages. Changed packages: @open-agent-toolkit/cli. Packages still at their base version: @open-agent-toolkit/cli@0.0.4, @open-agent-toolkit/docs-config@0.0.4, @open-agent-toolkit/docs-theme@0.0.4, @open-agent-toolkit/docs-transforms@0.0.4',
+      'publishable package changes require a lockstep version bump across all public packages. Changed packages: @open-agent-toolkit/cli. Packages still at their base version: @open-agent-toolkit/cli@0.0.4, @open-agent-toolkit/control-plane@0.0.4, @open-agent-toolkit/docs-config@0.0.4, @open-agent-toolkit/docs-theme@0.0.4, @open-agent-toolkit/docs-transforms@0.0.4',
     ]);
   });
 
@@ -300,9 +348,15 @@ describe('getPublicPackageContracts', () => {
           currentVersion: '0.0.5',
           baseVersion: '0.0.4',
         },
+        {
+          contract: contracts[4],
+          changedSinceBase: false,
+          currentVersion: '0.0.5',
+          baseVersion: '0.0.4',
+        },
       ]),
     ).toEqual([
-      'public packages must stay on the same version for lockstep release publishes. Found: @open-agent-toolkit/cli@0.0.5, @open-agent-toolkit/docs-config@0.0.6, @open-agent-toolkit/docs-theme@0.0.5, @open-agent-toolkit/docs-transforms@0.0.5',
+      'public packages must stay on the same version for lockstep release publishes. Found: @open-agent-toolkit/cli@0.0.5, @open-agent-toolkit/control-plane@0.0.6, @open-agent-toolkit/docs-config@0.0.5, @open-agent-toolkit/docs-theme@0.0.5, @open-agent-toolkit/docs-transforms@0.0.5',
     ]);
   });
 
@@ -330,8 +384,11 @@ describe('getPublicPackageContracts', () => {
   });
 
   it('matches the docs package manifests to the public contract', async () => {
-    const contracts = getPublicPackageContracts().slice(1);
+    const contracts = getPublicPackageContracts().filter(
+      (contract) => contract.role !== 'cli',
+    );
     const manifests = await Promise.all([
+      readJson(controlPlanePackageJsonPath),
       readJson(docsConfigPackageJsonPath),
       readJson(docsThemePackageJsonPath),
       readJson(docsTransformsPackageJsonPath),
@@ -366,7 +423,7 @@ describe('getPublicPackageContracts', () => {
       });
     }
 
-    expect(manifests[0].dependencies).toMatchObject({
+    expect(manifests[1].dependencies).toMatchObject({
       '@open-agent-toolkit/docs-transforms': 'workspace:*',
     });
   });

--- a/packages/cli/src/release/public-package-contract.ts
+++ b/packages/cli/src/release/public-package-contract.ts
@@ -3,7 +3,7 @@ import { matchesGlob } from 'node:path';
 export interface PublicPackageContract {
   workspaceDir: string;
   publicName: string;
-  role: 'cli' | 'docs-library';
+  role: 'cli' | 'docs-library' | 'support-library';
   requiredMetadataFields: string[];
   requiredPaths: string[];
   forbiddenPathPatterns: string[];
@@ -49,6 +49,16 @@ const PUBLIC_PACKAGE_CONTRACTS: PublicPackageContract[] = [
       'apps/oat-docs/docs',
     ],
     versionPolicyIgnorePatterns: ['assets/**'],
+  },
+  {
+    workspaceDir: 'packages/control-plane',
+    publicName: '@open-agent-toolkit/control-plane',
+    role: 'support-library',
+    requiredMetadataFields: [...COMMON_METADATA_FIELDS, 'exports', 'types'],
+    requiredPaths: ['dist/index.js', 'dist/index.d.ts', 'README.md'],
+    forbiddenPathPatterns: [...COMMON_FORBIDDEN_PATH_PATTERNS],
+    versionPolicyAdditionalRoots: [],
+    versionPolicyIgnorePatterns: [],
   },
   {
     workspaceDir: 'packages/docs-config',
@@ -166,4 +176,36 @@ export function findWorkspaceProtocolDependencySpecs(
   }
 
   return workspaceSpecs;
+}
+
+export function findNonPublicWorkspaceDependencySpecs(
+  packageJson: Record<string, unknown>,
+  publicPackageNames: readonly string[],
+  workspacePackageNames: readonly string[],
+): string[] {
+  const publicPackageNameSet = new Set(publicPackageNames);
+  const workspacePackageNameSet = new Set(workspacePackageNames);
+  const invalidSpecs: string[] = [];
+
+  for (const dependencyField of PACKED_DEPENDENCY_FIELDS) {
+    const dependencies = packageJson[dependencyField];
+    if (!dependencies || typeof dependencies !== 'object') {
+      continue;
+    }
+
+    for (const [dependencyName, spec] of Object.entries(
+      dependencies as Record<string, unknown>,
+    )) {
+      if (
+        workspacePackageNameSet.has(dependencyName) &&
+        !publicPackageNameSet.has(dependencyName)
+      ) {
+        invalidSpecs.push(
+          `${dependencyField}.${dependencyName}=${String(spec)}`,
+        );
+      }
+    }
+  }
+
+  return invalidSpecs;
 }

--- a/packages/cli/src/release/release-utils.test.ts
+++ b/packages/cli/src/release/release-utils.test.ts
@@ -41,14 +41,14 @@ describe('findChangedWorkspaceDirsFromPaths', () => {
     ).toEqual(new Set(['packages/cli', 'packages/docs-theme']));
   });
 
-  it('tracks internal workspace dependency changes for dependent public packages', () => {
+  it('tracks shared public package changes for dependents and the package itself', () => {
     expect(
       findChangedWorkspaceDirsFromPaths(
         ['packages/control-plane/src/index.ts'],
         getPublicPackageContracts(),
         new Map([['packages/cli', ['packages/control-plane']]]),
       ),
-    ).toEqual(new Set(['packages/cli']));
+    ).toEqual(new Set(['packages/cli', 'packages/control-plane']));
   });
 
   it('marks all affected public packages when a shared dependency changes', () => {

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,8 +1,22 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.1",
-  "private": true,
+  "version": "0.0.27",
+  "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
+  "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",
+  "bugs": {
+    "url": "https://github.com/voxmedia/open-agent-toolkit/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/voxmedia/open-agent-toolkit.git",
+    "directory": "packages/control-plane"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,6 +25,9 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc && tsc-alias",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",

--- a/tools/release/validate-public-packages.ts
+++ b/tools/release/validate-public-packages.ts
@@ -8,6 +8,7 @@ import {
   findForbiddenPackedPaths,
   findMissingMetadataFields,
   findMissingPackedPaths,
+  findNonPublicWorkspaceDependencySpecs,
   findWorkspaceProtocolDependencySpecs,
   getPublicPackageContracts,
   type PublicPackageContract,
@@ -42,6 +43,8 @@ export interface PublicPackageVersionState {
   currentVersion: string;
   baseVersion: string | null;
 }
+
+const WORKSPACE_DIRECTORIES = ['apps', 'packages'] as const;
 
 function getPackageDir(contract: PublicPackageContract): string {
   return join(REPO_ROOT, contract.workspaceDir);
@@ -197,6 +200,46 @@ async function packPackage(
   }
 }
 
+async function findWorkspacePackageNames(): Promise<Set<string>> {
+  const workspacePackageNames = new Set<string>();
+
+  for (const workspaceDirectory of WORKSPACE_DIRECTORIES) {
+    const absoluteWorkspaceDirectory = join(REPO_ROOT, workspaceDirectory);
+    let entries: Awaited<ReturnType<typeof readdir>>;
+
+    try {
+      entries = await readdir(absoluteWorkspaceDirectory, {
+        withFileTypes: true,
+      });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      try {
+        const packageJson = JSON.parse(
+          await readFile(
+            join(absoluteWorkspaceDirectory, entry.name, 'package.json'),
+            'utf8',
+          ),
+        ) as { name?: unknown };
+
+        if (typeof packageJson.name === 'string') {
+          workspacePackageNames.add(packageJson.name);
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return workspacePackageNames;
+}
+
 async function buildPublicPackages(
   contracts: readonly PublicPackageContract[],
 ) {
@@ -214,6 +257,8 @@ async function buildPublicPackages(
 
 async function validatePackage(
   contract: PublicPackageContract,
+  publicPackageNames: readonly string[],
+  workspacePackageNames: readonly string[],
 ): Promise<PackageValidationFailure | null> {
   const packageJson = await readPackageJson(contract);
   const missingMetadataFields = findMissingMetadataFields(
@@ -232,6 +277,12 @@ async function validatePackage(
   );
   const workspaceProtocolSpecs =
     findWorkspaceProtocolDependencySpecs(packedPackageJson);
+  const nonPublicWorkspaceDependencySpecs =
+    findNonPublicWorkspaceDependencySpecs(
+      packedPackageJson,
+      publicPackageNames,
+      workspacePackageNames,
+    );
   const packedPaths = packedArtifact.files.map((file) => file.path);
   const missingPackedPaths = findMissingPackedPaths(packedPaths, contract);
   const forbiddenPackedPaths = findForbiddenPackedPaths(packedPaths, contract);
@@ -273,6 +324,12 @@ async function validatePackage(
     );
   }
 
+  if (nonPublicWorkspaceDependencySpecs.length > 0) {
+    errors.push(
+      `packed package.json depends on non-public workspace packages: ${nonPublicWorkspaceDependencySpecs.join(', ')}`,
+    );
+  }
+
   if (errors.length === 0) {
     console.log(
       `validated ${contract.publicName} (${packedArtifact.filename})`,
@@ -287,6 +344,8 @@ export async function runReleaseValidation(): Promise<
   PackageValidationFailure[]
 > {
   const contracts = getPublicPackageContracts();
+  const publicPackageNames = contracts.map((contract) => contract.publicName);
+  const workspacePackageNames = Array.from(await findWorkspacePackageNames());
   await buildPublicPackages(contracts);
 
   const failures: PackageValidationFailure[] = [];
@@ -295,7 +354,11 @@ export async function runReleaseValidation(): Promise<
     failures.push(versionFailure);
   }
   for (const contract of contracts) {
-    const failure = await validatePackage(contract);
+    const failure = await validatePackage(
+      contract,
+      publicPackageNames,
+      workspacePackageNames,
+    );
     if (failure) {
       failures.push(failure);
     }


### PR DESCRIPTION
## What changed

- make `@open-agent-toolkit/control-plane` a published package and add it to the public release contract
- bump the lockstep public package version set to `0.0.27`
- update release and release-dry-run workflows to publish and verify `control-plane` alongside the other public packages
- tighten `release:validate` so packed public tarballs fail if they depend on non-public workspace packages
- extend release tests to cover the new public package set and the packed dependency validation rule

## Why

`@open-agent-toolkit/cli@0.0.26` was published with a runtime dependency on `@open-agent-toolkit/control-plane`, but `control-plane` was still private and unpublished. That made downstream installs fail when npm tried to resolve `@open-agent-toolkit/control-plane` from the registry.

This change fixes the immediate packaging issue and closes the validation gap that allowed the tarball to ship in that state.

## Impact

- external installs that pull `@open-agent-toolkit/cli` can resolve `@open-agent-toolkit/control-plane`
- release validation now catches future leaks of non-public workspace packages into published tarballs
- release workflows and release notes stay aligned with the actual public package set

## Validation

- `pnpm --filter @open-agent-toolkit/cli exec vitest run src/release/public-package-contract.test.ts src/release/check-version-bumps.test.ts src/release/release-utils.test.ts`
- `pnpm release:validate`
