### PR TITLE
docs: tighten review receive minor triage

### DIFF
--- a/.agents/skills/oat-project-review-receive/SKILL.md
+++ b/.agents/skills/oat-project-review-receive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-review-receive
-version: 1.3.0
+version: 1.4.0
 description: Use when review findings from oat-project-review-provide need closure. Converts review artifacts into actionable plan tasks.
 disable-model-invocation: true
 user-invocable: true
@@ -175,7 +175,7 @@ For each finding, build a structured register entry:
 - For non-final scopes:
   - Mark the review as `passed` in the plan.md Reviews table (if plan.md exists)
   - No fix tasks are added
-  - Minor findings may be auto-deferred by default (Step 9)
+  - Minor findings still follow the Step 9 recommendation/disposition rules before routing onward
   - Route user to normal next action
 - For `final` scope:
   - Do not mark `passed` until both gates are complete:
@@ -502,9 +502,13 @@ If any Medium is proposed for deferral:
 Minor findings handling is scope-aware:
 
 - If `scope != final`:
-  - Minor findings are auto-deferred by default.
-  - Record them in implementation.md under "Deferred Findings".
-  - Do not block review completion on minor disposition.
+  - Minor findings are not auto-deferred just because they are non-functional.
+  - Default to converting a Minor finding to a task when either of these is true:
+    - it is likely future cleanup (better than even chance that the team will need to address it later), or
+    - the fix scope is `Negligible` or `Minor`.
+  - Only propose deferral when the finding is genuinely low-probability cleanup, blocked by another change, duplicated elsewhere, explicitly out of scope, or fixing now would create disproportionate churn/risk.
+  - If deferred, record rationale in implementation.md under "Deferred Findings".
+  - Do not block review completion on minor disposition once each finding has been converted or explicitly deferred with rationale.
 
 - If `scope == final`:
   - Minor findings are NOT auto-deferred silently.
@@ -512,6 +516,9 @@ Minor findings handling is scope-aware:
     - what the issue is,
     - potential user/maintainer impact,
     - why fixing now vs deferring is reasonable.
+  - Recommendation default:
+    - recommend `convert` when the finding is likely future cleanup or the fix scope is `Negligible`/`Minor`;
+    - recommend `defer` only when the finding is unlikely to matter soon, blocked, duplicated, or high-churn to address now.
   - Keep explanations concise (1-3 sentences per minor) and include file/line when available.
   - Ask user explicitly:
 

--- a/.agents/skills/oat-review-receive/SKILL.md
+++ b/.agents/skills/oat-review-receive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-review-receive
-version: 1.2.0
+version: 1.3.0
 description: Use when processing review findings outside project context. Converts local review artifacts into actionable task lists.
 disable-model-invocation: true
 user-invocable: true
@@ -42,6 +42,7 @@ If you catch yourself:
 - Editing project lifecycle docs in ad-hoc mode -> STOP and revert to task-list output only.
 - Triaging without presenting a findings overview first -> STOP and show overview before disposition prompts.
 - Skipping Medium finding rationale when proposing deferral -> STOP and collect explicit rationale.
+- Auto-deferring Minor findings without checking future cleanup likelihood or fix cost -> STOP and re-evaluate the recommendation.
 
 **Recovery:**
 
@@ -181,11 +182,12 @@ Default suggestions:
 - Critical -> `convert`
 - Important -> `convert`
 - Medium -> `convert` (propose `defer` only with concrete rationale)
-- Minor -> `defer`
+- Minor -> `convert` when future cleanup is likely or the fix is trivial; otherwise `defer` with concrete rationale
 
 Rules:
 
 - Require explicit rationale for `defer` or `dismiss`.
+- Do not recommend `defer` for a Minor finding solely because it does not impact current functionality. If there is a better-than-even chance the team will need to clean it up later, or the fix is `Negligible`/`Minor`, recommend `convert`.
 - Do not silently skip findings.
 
 ### Step 5: Generate Task List Output

--- a/apps/oat-docs/docs/workflows/projects/reviews.md
+++ b/apps/oat-docs/docs/workflows/projects/reviews.md
@@ -53,8 +53,8 @@ Status progression in `plan.md` Reviews table:
 
 - Critical/Important: address before pass.
 - Medium: address by default; defer only with explicit approval and recorded rationale/disposition.
-- Minor (non-final scopes): auto-deferred by default with rationale; do not block review completion.
-- Minor (final scope): not auto-deferred; require explicit user disposition (defer vs convert), and explain each minor in plain language before asking.
+- Minor (non-final scopes): do not auto-defer by default. Convert when likely future cleanup or when the fix is trivial; defer only with recorded rationale.
+- Minor (final scope): not auto-deferred; require explicit user disposition (defer vs convert), and recommend convert when likely future cleanup or trivial to fix.
 
 ## Auto-review at checkpoints
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- tighten `oat-project-review-receive` so minor findings are no longer deferred just because they do not affect current functionality
- prefer converting minor findings when they are likely future cleanup or trivial to fix, and reserve deferral for low-probability or high-churn cases
- align the ad-hoc `oat-review-receive` skill and published review workflow docs with the same policy

## Why

Review receive was too willing to defer known cleanup debt when the issue was non-functional today. This change adds more conviction to the default recommendation so cheap or likely-future cleanup is handled while context is fresh.

## Validation

- pre-commit formatting via `lint-staged` / `oxfmt --write`
- pre-push hooks ran `pnpm type-check`, `pnpm lint`, and `pnpm format` successfully
