### PR TITLE
fix: repair global cli entrypoint and version metadata

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/app/create-program.ts
+++ b/packages/cli/src/app/create-program.ts
@@ -1,16 +1,16 @@
+import { OAT_VERSION } from '@shared/oat-version';
 import { Command, Option } from 'commander';
 
 const PROGRAM_NAME = 'oat';
 const PROGRAM_DESCRIPTION =
   'Open Agent Toolkit CLI for provider interoperability';
-const PROGRAM_VERSION = '0.0.24';
 const SCOPE_CHOICES = ['project', 'user', 'all'] as const;
 
 export function createProgram(): Command {
   return new Command()
     .name(PROGRAM_NAME)
     .description(PROGRAM_DESCRIPTION)
-    .version(PROGRAM_VERSION)
+    .version(OAT_VERSION)
     .option('--json', 'Output a single JSON document')
     .option('--verbose', 'Enable verbose debug output')
     .addOption(

--- a/packages/cli/src/commands/docs/init/integration.test.ts
+++ b/packages/cli/src/commands/docs/init/integration.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { OAT_VERSION } from '@shared/oat-version';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { scaffoldDocsApp } from './scaffold';
@@ -71,7 +72,7 @@ describe('scaffold integration', () => {
           join(pkgDir, 'package.json'),
           JSON.stringify({
             name: `@open-agent-toolkit/${pkg}`,
-            version: '0.0.24',
+            version: OAT_VERSION,
           }),
           'utf8',
         );

--- a/packages/cli/src/commands/docs/init/scaffold.test.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { OAT_VERSION } from '@shared/oat-version';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { scaffoldDocsApp } from './scaffold';
@@ -305,7 +306,7 @@ describe('scaffoldDocsApp', () => {
     expect(packageJson.scripts['predev']).toContain('docs generate-index');
     expect(packageJson.scripts['prebuild']).toContain('docs generate-index');
     expect(packageJson.devDependencies['@open-agent-toolkit/cli']).toBe(
-      '^0.0.24',
+      `^${OAT_VERSION}`,
     );
     expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
     expect(packageJson.devDependencies['markdownlint-cli2']).toBeUndefined();
@@ -366,7 +367,7 @@ describe('scaffoldDocsApp', () => {
       await readFile(join(result.appRoot, 'package.json'), 'utf8'),
     ) as { devDependencies: Record<string, string> };
     expect(packageJson.devDependencies['@open-agent-toolkit/cli']).toBe(
-      '^0.0.24',
+      `^${OAT_VERSION}`,
     );
     expect(packageJson.devDependencies['@types/node']).toBe('^22.10.0');
     expect(packageJson.devDependencies['markdownlint-cli2']).toBeUndefined();
@@ -570,7 +571,7 @@ describe('scaffoldDocsApp', () => {
         join(pkgDir, 'package.json'),
         JSON.stringify({
           name: `@open-agent-toolkit/${pkg}`,
-          version: '0.0.24',
+          version: OAT_VERSION,
         }),
         'utf8',
       );

--- a/packages/cli/src/commands/docs/init/scaffold.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join } from 'node:path';
 
 import type { OatDocumentationConfig } from '@config/oat-config';
 import { dirExists, ensureDir, fileExists } from '@fs/io';
+import { OAT_VERSION } from '@shared/oat-version';
 
 import type {
   DocsFormatMode,
@@ -110,7 +111,7 @@ const OAT_DEP_PACKAGES = [
   'docs-theme',
   'docs-transforms',
 ] as const;
-const DEFAULT_OAT_PUBLISHED_VERSION = '0.0.24';
+const DEFAULT_OAT_PUBLISHED_VERSION = OAT_VERSION;
 const PUBLIC_PACKAGE_VERSIONS_FILE = 'public-package-versions.json';
 
 export async function detectIsOatRepo(repoRoot: string): Promise<boolean> {
@@ -120,17 +121,6 @@ export async function detectIsOatRepo(repoRoot: string): Promise<boolean> {
     }
   }
   return true;
-}
-
-async function readCliVersion(assetsRoot: string): Promise<string> {
-  const cliRoot = dirname(assetsRoot);
-  try {
-    const content = await readFile(join(cliRoot, 'package.json'), 'utf8');
-    const pkg = JSON.parse(content) as { version?: string };
-    return pkg.version ?? DEFAULT_OAT_PUBLISHED_VERSION;
-  } catch {
-    return DEFAULT_OAT_PUBLISHED_VERSION;
-  }
 }
 
 async function readBundledOatPackageVersions(
@@ -149,6 +139,17 @@ async function readBundledOatPackageVersions(
     );
   } catch {
     return {};
+  }
+}
+
+async function readCliVersion(assetsRoot: string): Promise<string> {
+  const cliRoot = dirname(assetsRoot);
+  try {
+    const content = await readFile(join(cliRoot, 'package.json'), 'utf8');
+    const pkg = JSON.parse(content) as { version?: string };
+    return pkg.version ?? DEFAULT_OAT_PUBLISHED_VERSION;
+  } catch {
+    return DEFAULT_OAT_PUBLISHED_VERSION;
   }
 }
 

--- a/packages/cli/src/commands/doctor/index.test.ts
+++ b/packages/cli/src/commands/doctor/index.test.ts
@@ -4,6 +4,7 @@ import {
   type LoggerCapture,
 } from '@commands/__tests__/helpers';
 import type { Manifest } from '@manifest/index';
+import { OAT_VERSION } from '@shared/oat-version';
 import type { Scope } from '@shared/types';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -53,7 +54,7 @@ interface RunDoctorArgs {
 function defaultManifest(): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.24',
+    oatVersion: OAT_VERSION,
     entries: [],
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/providers/inspect/inspect.test.ts
+++ b/packages/cli/src/commands/providers/inspect/inspect.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@commands/__tests__/helpers';
 import type { Manifest, ManifestEntry } from '@manifest/index';
 import type { ProviderAdapter } from '@providers/shared';
+import { OAT_VERSION } from '@shared/oat-version';
 import type { Scope } from '@shared/types';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -54,7 +55,7 @@ function createAdapter(
 function createManifest(entries: ManifestEntry[]): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.24',
+    oatVersion: OAT_VERSION,
     entries,
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/providers/list/list.test.ts
+++ b/packages/cli/src/commands/providers/list/list.test.ts
@@ -6,6 +6,7 @@ import {
 import { createProvidersCommand } from '@commands/providers/index';
 import type { Manifest, ManifestEntry } from '@manifest/index';
 import type { ProviderAdapter } from '@providers/shared';
+import { OAT_VERSION } from '@shared/oat-version';
 import type { Scope } from '@shared/types';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -51,7 +52,7 @@ function createAdapter(
 function createManifest(entries: ManifestEntry[]): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.24',
+    oatVersion: OAT_VERSION,
     entries,
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/status/index.test.ts
+++ b/packages/cli/src/commands/status/index.test.ts
@@ -10,6 +10,7 @@ import { CliError } from '@errors/index';
 import type { Manifest, ManifestEntry } from '@manifest/index';
 import type { CodexExtensionPlan } from '@providers/codex/codec/sync-extension';
 import type { ProviderAdapter } from '@providers/shared';
+import { OAT_VERSION } from '@shared/oat-version';
 import type { Scope } from '@shared/types';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -100,7 +101,7 @@ function createCodexAdapter(): ProviderAdapter {
 function createManifest(entries: ManifestEntry[]): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.24',
+    oatVersion: OAT_VERSION,
     entries,
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/commands/sync/index.test.ts
+++ b/packages/cli/src/commands/sync/index.test.ts
@@ -14,6 +14,7 @@ import type {
   ConfigAwareAdaptersResult,
   ProviderAdapter,
 } from '@providers/shared';
+import { OAT_VERSION } from '@shared/oat-version';
 import type { Scope } from '@shared/types';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -84,7 +85,7 @@ function createCodexAdapter(): ProviderAdapter {
 function createManifest(): Manifest {
   return {
     version: 1,
-    oatVersion: '0.0.24',
+    oatVersion: OAT_VERSION,
     entries: [],
     lastUpdated: '2026-02-14T00:00:00.000Z',
   };

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,4 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { parseAsyncMock, createProgramMock, registerCommandsMock } = vi.hoisted(
   () => ({
@@ -16,7 +21,7 @@ vi.mock('./commands', () => ({
   registerCommands: registerCommandsMock,
 }));
 
-import { main, normalizeArgv } from './index';
+import { isEntrypoint, main, normalizeArgv } from './index';
 
 describe('normalizeArgv', () => {
   it('strips pnpm sentinel -- after script path', () => {
@@ -53,5 +58,38 @@ describe('main', () => {
       'all',
       '--dry-run',
     ]);
+  });
+});
+
+describe('isEntrypoint', () => {
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  it('returns true when argv points at a symlinked entrypoint', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'oat-entrypoint-'));
+    const targetPath = join(tempDir, 'dist-index.js');
+    const linkPath = join(tempDir, 'oat');
+
+    await writeFile(targetPath, '#!/usr/bin/env node\n', 'utf8');
+    await symlink(targetPath, linkPath);
+
+    expect(
+      isEntrypoint(['node', linkPath], pathToFileURL(targetPath).href),
+    ).toBe(true);
+  });
+
+  it('returns false when argv points at a different file', () => {
+    expect(
+      isEntrypoint(
+        ['node', '/tmp/not-the-entrypoint.js'],
+        pathToFileURL('/tmp/actual-entrypoint.js').href,
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { createProgram } from './app/create-program';
 import { registerCommands } from './commands';
@@ -29,12 +30,22 @@ export async function main(argv: string[] = process.argv): Promise<void> {
   await program.parseAsync(normalizeArgv(argv));
 }
 
-function isEntrypoint(): boolean {
-  if (!process.argv[1]) {
+export function isEntrypoint(
+  argv: string[] = process.argv,
+  entrypointUrl: string = import.meta.url,
+): boolean {
+  if (!argv[1]) {
     return false;
   }
 
-  return import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+  const entrypointPath = fileURLToPath(entrypointUrl);
+  const argvPath = resolve(argv[1]);
+
+  try {
+    return realpathSync(entrypointPath) === realpathSync(argvPath);
+  } catch {
+    return entrypointUrl === pathToFileURL(argvPath).href;
+  }
 }
 
 if (isEntrypoint()) {

--- a/packages/cli/src/manifest/manager.ts
+++ b/packages/cli/src/manifest/manager.ts
@@ -3,14 +3,13 @@ import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
 import { CliError } from '@errors/index';
+import { OAT_VERSION } from '@shared/oat-version';
 
 import {
   type Manifest,
   type ManifestEntry,
   ManifestSchema,
 } from './manifest.types';
-
-const OAT_VERSION = '0.0.24';
 
 function formatIssuePath(path: (string | number)[]): string {
   if (path.length === 0) {

--- a/packages/cli/src/shared/oat-version.ts
+++ b/packages/cli/src/shared/oat-version.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+
+interface CliPackageJson {
+  version?: string;
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8'),
+) as CliPackageJson;
+
+export const OAT_VERSION = packageJson.version ?? '0.0.0';

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- fix the CLI entrypoint so symlinked global installs from npm/pnpm actually execute instead of silently exiting
- add regression coverage for the symlinked entrypoint path
- centralize the CLI package version so the program banner, manifest metadata, and docs-init fallback stay in sync
- bump all public packages to 0.0.31 in lockstep

## Root Cause

The published CLI only called `main()` when `import.meta.url` exactly matched `process.argv[1]`. Global installs expose the executable through a symlink, so that comparison failed and `oat --help` / `oat init` exited 0 with no output.

## Impact

- global installs now behave correctly for `oat --help`, `oat init`, and other commands
- future package bumps do not need manual version edits across multiple CLI modules

## Validation

- `pnpm --filter @open-agent-toolkit/cli test -- src/commands/docs/init/scaffold.test.ts src/commands/docs/init/integration.test.ts src/index.test.ts src/commands/status/index.test.ts src/commands/sync/index.test.ts src/commands/doctor/index.test.ts src/commands/providers/list/list.test.ts src/commands/providers/inspect/inspect.test.ts src/manifest/manager.test.ts`
- `pnpm --filter @open-agent-toolkit/cli build`
- `node packages/cli/dist/index.js --version`
- `pnpm release:validate`
