### PR TITLE
fix: require quick-start project descriptions

### DIFF
--- a/.agents/skills/oat-docs/SKILL.md
+++ b/.agents/skills/oat-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-docs
-version: 1.0.0
+version: 1.0.1
 description: Use when a user asks questions about OAT workflows, CLI commands, skill authoring, configuration, or project lifecycle. Answers questions by reading locally-bundled OAT documentation.
 argument-hint: '[question]'
 disable-model-invocation: false
@@ -161,13 +161,15 @@ Would you like me to:
 To create a new OAT project, you have two main approaches:
 
 1. **Quick mode** (recommended for most tasks):
-   oat-project-quick-start <project-name>
+   oat-project-quick-start <project-name> "project description"
 
 2. **Spec-driven mode** (for complex features):
    oat-project-new <project-name>
 
 Quick mode goes straight from discovery to plan. Spec-driven mode adds
-formal spec and design phases.
+formal spec and design phases. If you invoke quick mode with only a
+project name, it should ask you for the missing project description
+before discovery starts.
 
 Both create a project directory under your projects root
 (default: .oat/projects/shared/<project-name>/) with standard artifacts:

--- a/.agents/skills/oat-project-quick-start/SKILL.md
+++ b/.agents/skills/oat-project-quick-start/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: oat-project-quick-start
-version: 1.3.1
+version: 1.3.3
 description: Use when a task is small enough for quick mode or rapid iteration is preferred. Scaffolds a lightweight OAT project from discovery directly to a runnable plan, with optional brainstorming and lightweight design.
-argument-hint: '<project-name>'
+argument-hint: '<project-name> ["project description"]'
 disable-model-invocation: true
 user-invocable: true
 allowed-tools: Read, Write, Bash, Glob, Grep, AskUserQuestion
@@ -83,7 +83,11 @@ PROJECTS_ROOT="${PROJECTS_ROOT%/}"
 
 If no valid active project exists:
 
-- Read `{project-name}` from `$ARGUMENTS`, or ask user.
+- Resolve startup input from `$ARGUMENTS` before doing any discovery work:
+  - Accept `{project-name}` plus an optional `{project-description}`.
+  - If `$ARGUMENTS` contains only a bare `{project-name}` (for example a slug or short title) without a substantive description, ask the user for a short project description before scanning the repo or drafting discovery.
+  - Do not infer requirements from the project name alone or go exploring the codebase to guess what the project means.
+  - If neither field is available, ask for both the project name and a short project description. One or two sentences is enough for the description.
 - Create project via the same scaffolding path used by `oat-project-new`:
 
 ```bash
@@ -115,6 +119,8 @@ If `"$PROJECT_PATH/discovery.md"` is missing, create it from `.oat/templates/dis
 #### 2a: Assess Request Ambiguity
 
 Before asking questions, classify the request:
+
+- Base this classification on the user's project description plus session context. A bare project name by itself is not enough context to start discovery.
 
 - **Well-understood** — the user has a clear mental model, requirements are specific, approach is obvious. Examples: "add a CLI flag for verbose output", "rename X to Y across the codebase."
   → Synthesize `discovery.md` from available session context quickly when enough detail is already available. Ask only the minimum additional questions needed to remove blockers for a quality plan.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@
 - All packages use `workspace:*` for internal dependencies
 - Build dependencies are automatically handled by Turborepo (`^build` dependency)
 - Publishable packages under `packages/` are released from npm and participate in PR release dry-runs.
-- Publishable package guardrail: if you change shipped functionality in any publishable package (`packages/cli`, `packages/docs-config`, `packages/docs-theme`, `packages/docs-transforms`), bump the public package versions in the same PR. The repo enforces lockstep bumps across all public packages.
+- Publishable package guardrail: the lockstep public package set is `packages/cli`, `packages/control-plane`, `packages/docs-config`, `packages/docs-theme`, and `packages/docs-transforms`. If a PR changes shipped functionality for any of them, bump all five public package versions together in the same PR.
+- For release policy, bundled assets count as shipped CLI functionality. Changes under `.agents/skills`, `.agents/agents`, `.oat/templates`, `.oat/scripts`, or `apps/oat-docs/docs` require the same lockstep public package version bump even if no file under `packages/cli/src` changed.
 - Definition of done for publishable package changes: run `pnpm release:validate` before finishing. A publishable-package PR is not done until that command passes.
 
 ## Architecture Overview

--- a/apps/oat-docs/docs/workflows/projects/lifecycle.md
+++ b/apps/oat-docs/docs/workflows/projects/lifecycle.md
@@ -104,7 +104,7 @@ When `autoReviewAtCheckpoints` is enabled (via `.oat/config.json` or `plan.md` f
 
 ### Quick lane diagram
 
-1. `oat-project-quick-start` (adaptive discovery — well-understood requests synthesize quickly, exploratory requests invest in solution space exploration)
+1. `oat-project-quick-start` (adaptive discovery — provide a project name and optional description; if only the name is provided, quick-start asks for the missing description before discovery. Well-understood requests synthesize quickly, exploratory requests invest in solution space exploration)
 2. Decision point: straight to plan, optional lightweight `design.md`, or promote to spec-driven
 3. Implement:
    - `oat-project-implement` (sequential)

--- a/apps/oat-docs/docs/workflows/skills/index.md
+++ b/apps/oat-docs/docs/workflows/skills/index.md
@@ -14,7 +14,7 @@ Use this section when you want to choose the right OAT skill for a task. If you 
 
 ## Key Skills by Use Case
 
-- Start a new tracked project: `oat-project-new` or `oat-project-quick-start`
+- Start a new tracked project: `oat-project-new` or `oat-project-quick-start` (quick start accepts a project name plus optional description; if you omit the description it should ask before discovery begins)
 - Resume an existing project: `oat-project-open` and `oat-project-progress`
 - Execute a ready plan: `oat-project-implement`
 - Import an existing plan: `oat-project-import-plan`

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.0.33",
-  "docs-config": "0.0.33",
-  "docs-theme": "0.0.33",
-  "docs-transforms": "0.0.33"
+  "cli": "0.0.34",
+  "docs-config": "0.0.34",
+  "docs-theme": "0.0.34",
+  "docs-transforms": "0.0.34"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/validation/skills.test.ts
+++ b/packages/cli/src/validation/skills.test.ts
@@ -634,7 +634,7 @@ describe('validateOatSkills', () => {
     );
     const content = await readFile(skillPath, 'utf8');
 
-    expect(content.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('1.3.1');
+    expect(content.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('1.3.3');
   });
 
   it('reports missing quick-start-specific discovery guidance', async () => {
@@ -681,6 +681,11 @@ describe('validateOatSkills', () => {
         message:
           'Quick-start must limit follow-up questions to the minimum needed to remove blockers',
       }),
+      expect.objectContaining({
+        file: skillPath,
+        message:
+          'Quick-start must treat a bare project name as insufficient input, ask for a project description, and avoid inferring scope from the repo',
+      }),
     ]);
   });
 
@@ -711,6 +716,9 @@ describe('validateOatSkills', () => {
         'Populate `discovery.md` from the current session context when enough detail already exists.',
         'Only ask the minimum follow-up questions required to unblock planning.',
         'If startup Q&A is needed, record that discussion and the resulting decisions back into discovery.md before finalizing plan.md.',
+        'A bare project name alone is not enough context to start discovery.',
+        'Ask the user for a short project description when only the project name was provided.',
+        'Do not infer requirements from the repo before that description is available.',
       ].join('\n'),
     );
 

--- a/packages/cli/src/validation/skills.ts
+++ b/packages/cli/src/validation/skills.ts
@@ -162,6 +162,25 @@ function validateQuickStartSemantics(
         'Quick-start must limit follow-up questions to the minimum needed to remove blockers',
     });
   }
+
+  if (
+    !(
+      /(project description|project brief)/i.test(content) &&
+      /(project name alone|bare .*project-name|only a bare .*project-name)/i.test(
+        content,
+      ) &&
+      /(ask the user|ask for)/i.test(content) &&
+      /(do not infer requirements from the project name alone|not enough context to start discovery)/i.test(
+        content,
+      )
+    )
+  ) {
+    findings.push({
+      file: skillPath,
+      message:
+        'Quick-start must treat a bare project name as insufficient input, ask for a project description, and avoid inferring scope from the repo',
+    });
+  }
 }
 
 async function listChangedSkillFiles(

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- require `oat-project-quick-start` to ask for a project description when invoked with only a project name
- update skill and docs surfaces to show the new quick-start invocation and behavior
- clarify in `AGENTS.md` that bundled skill/docs changes are part of the CLI release surface and bump all five public package versions in lockstep

## Why
A bare project name was enough to send quick-start exploring the repo and inferring intent. The command should ask for the missing project description first.

## Impact
Quick-start becomes explicitly user-led at startup, the docs now describe that behavior, and the release guidance matches the repo's actual public-package contract.

## Validation
- `pnpm --filter @open-agent-toolkit/cli test -- src/validation/skills.test.ts`
- `pnpm --filter @open-agent-toolkit/control-plane build`
- `pnpm --filter @open-agent-toolkit/cli type-check`
- `pnpm --filter @open-agent-toolkit/cli test -- src/release/public-package-contract.test.ts src/release/check-version-bumps.test.ts`
- `pnpm release:validate`
