### PR TITLE
fix: keep tracked project archives on active worktree

### DIFF
--- a/.agents/skills/oat-project-complete/SKILL.md
+++ b/.agents/skills/oat-project-complete/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-complete
-version: 1.4.1
+version: 1.4.2
 description: Use when all implementation work is finished and the project is ready to close. Marks the OAT project lifecycle as complete.
 disable-model-invocation: true
 user-invocable: true
@@ -312,13 +312,21 @@ The archive-side effects in this step are CLI-owned. Follow the canonical behavi
 
 ```bash
 ARCHIVED_ROOT=".oat/projects/archived"
+ARCHIVE_RELATIVE_PATH=".oat/projects/archived/${PROJECT_NAME}"
 PRIMARY_REPO_ARCHIVE=""
-LOCAL_ARCHIVED_ROOT=".oat/projects/archived"
+ARCHIVE_PATH_IS_GITIGNORED="false"
 USE_PRIMARY_REPO_ARCHIVE="false"
 
-# Heuristic: if this checkout is a worktree and the primary repo archive parent
-# exists, use that durable archive path as the canonical archive destination.
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+# First decide whether the archive destination is local-only in this checkout.
+# If the archive path is tracked here, keep the archive on the current worktree
+# and branch so the completion commit and PR carry the archived project.
+if git check-ignore --quiet --no-index "$ARCHIVE_RELATIVE_PATH" 2>/dev/null; then
+  ARCHIVE_PATH_IS_GITIGNORED="true"
+fi
+
+# Only fall back to the primary checkout when the archive destination is
+# gitignored/local-only in the current worktree.
+if [[ "$ARCHIVE_PATH_IS_GITIGNORED" == "true" ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || true)
   GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || true)
   if [[ -n "$GIT_COMMON_DIR" && -n "$GIT_DIR" && "$GIT_COMMON_DIR" != "$GIT_DIR" ]]; then
@@ -328,7 +336,7 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
       USE_PRIMARY_REPO_ARCHIVE="true"
       ARCHIVED_ROOT="$PRIMARY_REPO_ARCHIVE"
     else
-      echo "Warning: Running in a worktree, but the primary repo archive path is unavailable: $PRIMARY_REPO_ARCHIVE"
+      echo "Warning: Running in a worktree with a local-only archive path, but the primary repo archive path is unavailable: $PRIMARY_REPO_ARCHIVE"
       echo "A worktree-local archive may be deleted when the worktree is removed and is not a durable archive."
       echo "Require explicit confirmation before proceeding with local-only archive."
     fi
@@ -336,7 +344,7 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 if [[ "$USE_PRIMARY_REPO_ARCHIVE" != "true" ]]; then
-  ARCHIVED_ROOT="$LOCAL_ARCHIVED_ROOT"
+  ARCHIVED_ROOT=".oat/projects/archived"
 fi
 
 mkdir -p "$ARCHIVED_ROOT"
@@ -365,6 +373,7 @@ echo "Project archived to $ARCHIVE_PATH"
 - Ask the user explicitly: "Primary repo archive path is unavailable, so this archive may be lost when the worktree is deleted. Continue with local-only archive anyway?"
 - If the user declines, skip archiving and continue the completion flow without archive.
 - Resolve the durable repo root from `git rev-parse --git-common-dir` and `git rev-parse --git-dir`, matching the CLI helper in `packages/cli/src/commands/project/archive/archive-utils.ts`. Do not rely on a `main` checkout or default-branch naming.
+- Apply this guard only when `git check-ignore --quiet --no-index "$ARCHIVE_RELATIVE_PATH"` reports that the archive destination is local-only in the current checkout.
 
 **Git handling after archive:**
 
@@ -378,7 +387,7 @@ This stages the deletions from the shared directory. The archived copy is preser
 
 **Worktree archive target (required when available):**
 
-If running from a git worktree, the primary repo archive directory is the canonical/durable archive destination.
+If running from a git worktree, prefer the primary repo archive directory only when the archive destination is local-only/gitignored in the current checkout.
 
 Reference path:
 

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.0.38",
-  "docs-config": "0.0.38",
-  "docs-theme": "0.0.38",
-  "docs-transforms": "0.0.38"
+  "cli": "0.0.39",
+  "docs-config": "0.0.39",
+  "docs-theme": "0.0.39",
+  "docs-transforms": "0.0.39"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
+++ b/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
@@ -92,6 +92,24 @@ describe('review skill contracts', () => {
     );
   });
 
+  it('keeps version-controlled archives on the current worktree during completion', () => {
+    const skillPath = repoFilePath(
+      '.agents/skills/oat-project-complete/SKILL.md',
+    );
+    const content = readFileSync(skillPath, 'utf8');
+
+    expect(content).toContain('ARCHIVE_RELATIVE_PATH');
+    expect(content).toContain(
+      'git check-ignore --quiet --no-index "$ARCHIVE_RELATIVE_PATH"',
+    );
+    expect(content).toContain(
+      'If `.oat/projects/archived/` is version controlled on the current branch, archive in the current checkout instead.',
+    );
+    expect(content).not.toContain(
+      'If running from a git worktree, the primary repo archive directory is the canonical/durable archive destination.',
+    );
+  });
+
   it('defines runtime-safe summary handling during pr-final and completion', () => {
     const prFinalPath = repoFilePath(
       '.agents/skills/oat-project-pr-final/SKILL.md',

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- keep `oat-project-complete` on the current worktree and branch when `.oat/projects/archived` is version controlled there
- gate primary-checkout fallback on `git check-ignore` so it only applies to local-only archive destinations
- add a contract test covering the tracked-archive worktree case and bump the lockstep public package versions to `0.0.39`

## Root Cause

The CLI archive helper already distinguishes between tracked archive paths and local-only ones, but the `oat-project-complete` skill still carried the older worktree heuristic that preferred the primary checkout for any worktree archive. That let the skill drift away from the canonical archive behavior.

## Impact

- completed shared projects now remain in the active worktree when the archive directory is tracked on that branch, so the archive move is included in the completion commit and PR
- the durable-primary-checkout fallback still applies when the archive path is gitignored/local-only in the current worktree

## Validation

- `pnpm exec vitest run src/commands/init/tools/shared/review-skill-contracts.test.ts` (from `packages/cli`)
- `pnpm turbo run build --filter=@open-agent-toolkit/cli --filter=@open-agent-toolkit/control-plane --filter=@open-agent-toolkit/docs-config --filter=@open-agent-toolkit/docs-theme --filter=@open-agent-toolkit/docs-transforms`
- `pnpm release:validate`
- push hooks: `release:check-versions`, `internal validate-skill-version-bumps --base-ref origin/main`, `turbo run type-check`, `turbo run lint`, `turbo run format`
