### PR TITLE
fix: probe archive contents, not dir, for worktree durability

### DIFF
--- a/.agents/skills/oat-project-complete/SKILL.md
+++ b/.agents/skills/oat-project-complete/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-complete
-version: 1.4.2
+version: 1.4.3
 description: Use when all implementation work is finished and the project is ready to close. Marks the OAT project lifecycle as complete.
 disable-model-invocation: true
 user-invocable: true
@@ -310,23 +310,40 @@ Archive happens after PR description generation (so artifacts are readable at tr
 
 The archive-side effects in this step are CLI-owned. Follow the canonical behavior from `packages/cli/src/commands/project/archive/archive-utils.ts` rather than inventing separate S3 or summary-export logic inside the skill.
 
+**Anti-pattern (do NOT do this):** Running `git check-ignore` on the
+`.oat/projects/archived` directory itself to decide durability. A common
+gitignore shape for this repo is `.oat/projects/archived/**`, which leaves the
+directory visible in the tree while ignoring every file placed inside. A
+directory-level check reports "not ignored" and produces the inverse of the
+intended decision — archiving in the worktree when the archive must actually
+go to the primary repo. Always probe a representative path **inside** the
+archive directory (the project subpath or a probe filename), matching the CLI
+helper at `packages/cli/src/commands/project/archive/archive-utils.ts`.
+
 ```bash
 ARCHIVED_ROOT=".oat/projects/archived"
+# ARCHIVE_RELATIVE_PATH is the contents-level probe: a hypothetical file that
+# would live inside the archive directory. This is the same probe shape the
+# CLI helper uses — do not simplify this to the directory itself.
 ARCHIVE_RELATIVE_PATH=".oat/projects/archived/${PROJECT_NAME}"
 PRIMARY_REPO_ARCHIVE=""
-ARCHIVE_PATH_IS_GITIGNORED="false"
+ARCHIVE_CONTENTS_TRACKED="true"
 USE_PRIMARY_REPO_ARCHIVE="false"
 
-# First decide whether the archive destination is local-only in this checkout.
-# If the archive path is tracked here, keep the archive on the current worktree
-# and branch so the completion commit and PR carry the archived project.
+# Will a newly-archived file at ${ARCHIVE_RELATIVE_PATH} actually be tracked in
+# this checkout? Probe a representative path INSIDE the directory, not the
+# directory itself. A `.oat/projects/archived/**` gitignore pattern leaves the
+# directory visible in the tree but ignores everything placed inside, so a
+# directory-level check reports "tracked" and gives the inverse of the
+# intended answer.
 if git check-ignore --quiet --no-index "$ARCHIVE_RELATIVE_PATH" 2>/dev/null; then
-  ARCHIVE_PATH_IS_GITIGNORED="true"
+  ARCHIVE_CONTENTS_TRACKED="false"
 fi
 
-# Only fall back to the primary checkout when the archive destination is
-# gitignored/local-only in the current worktree.
-if [[ "$ARCHIVE_PATH_IS_GITIGNORED" == "true" ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+# Fall back to the primary checkout whenever archive contents are local-only
+# in the current worktree, regardless of whether the archive directory itself
+# happens to exist in the tree.
+if [[ "$ARCHIVE_CONTENTS_TRACKED" == "false" ]] && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || true)
   GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || true)
   if [[ -n "$GIT_COMMON_DIR" && -n "$GIT_DIR" && "$GIT_COMMON_DIR" != "$GIT_DIR" ]]; then
@@ -373,7 +390,7 @@ echo "Project archived to $ARCHIVE_PATH"
 - Ask the user explicitly: "Primary repo archive path is unavailable, so this archive may be lost when the worktree is deleted. Continue with local-only archive anyway?"
 - If the user declines, skip archiving and continue the completion flow without archive.
 - Resolve the durable repo root from `git rev-parse --git-common-dir` and `git rev-parse --git-dir`, matching the CLI helper in `packages/cli/src/commands/project/archive/archive-utils.ts`. Do not rely on a `main` checkout or default-branch naming.
-- Apply this guard only when `git check-ignore --quiet --no-index "$ARCHIVE_RELATIVE_PATH"` reports that the archive destination is local-only in the current checkout.
+- Apply this guard only when `git check-ignore --quiet --no-index "$ARCHIVE_RELATIVE_PATH"` reports that the archive **contents** are local-only in the current checkout. `$ARCHIVE_RELATIVE_PATH` must be a path **inside** the archive directory (the project subpath), never the directory itself — see the anti-pattern note above the bash block.
 
 **Git handling after archive:**
 
@@ -387,7 +404,7 @@ This stages the deletions from the shared directory. The archived copy is preser
 
 **Worktree archive target (required when available):**
 
-If running from a git worktree, prefer the primary repo archive directory only when the archive destination is local-only/gitignored in the current checkout.
+If running from a git worktree, prefer the primary repo archive directory whenever a newly-archived file inside `.oat/projects/archived/` would be local-only in the current checkout.
 
 Reference path:
 
@@ -399,7 +416,8 @@ PRIMARY_REPO_ARCHIVE="${PRIMARY_REPO_ROOT}/.oat/projects/archived"
 
 Guidance:
 
-- In a worktree, only prefer `PRIMARY_REPO_ARCHIVE` when the archive destination is local-only/gitignored in the current checkout. If `.oat/projects/archived/` is version controlled on the current branch, archive in the current checkout instead.
+- In a worktree, prefer `PRIMARY_REPO_ARCHIVE` whenever `git check-ignore --quiet --no-index "$ARCHIVE_RELATIVE_PATH"` reports the archive **contents** as ignored — regardless of whether the archive directory itself happens to exist in the tree. Only archive in the current checkout when a hypothetical file at `.oat/projects/archived/<project>/state.md` would actually be tracked here.
+- Do not check `git check-ignore` on `.oat/projects/archived` (the directory itself). A `.oat/projects/archived/**` ignore pattern leaves the directory unignored while ignoring all contents, so a directory-level check reports "tracked" and an agent can mistakenly archive in the worktree.
 - Do not treat the worktree-local archive as durable.
 - If forced to use a local-only archive, warn and require explicit user confirmation.
 - Always write the dated `archive.summaryExportPath` copy into the current checkout (`repoRoot`), even when the project archive itself is written to the primary checkout.

--- a/.agents/skills/oat-project-pr-final/SKILL.md
+++ b/.agents/skills/oat-project-pr-final/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-pr-final
-version: 1.3.2
+version: 1.3.3
 description: Use when an active OAT project has completed all phases and is ready for final merge to main. Generates the final OAT lifecycle PR description from artifacts and review status, then creates the PR automatically.
 disable-model-invocation: true
 user-invocable: true
@@ -255,6 +255,7 @@ Local path exclusion:
 
 - Read `.oat/config.json` and extract `localPaths` (glob patterns for gitignored directories).
 - Do **not** include References links to any path that matches a `localPaths` pattern — those paths are gitignored and will not exist on the remote.
+- Evaluate the match against the actual **file or subpath** you are about to link (e.g. `.oat/projects/<proj>/pr/project-pr-2026-04-01.md`), not against the parent directory. A pattern like `.oat/**/pr` is shorthand for "everything under this directory is local-only"; a directory-level `git check-ignore` on `.oat/projects/<proj>/pr` can report "not ignored" even when every file inside is local-only, so a directory-level check will produce a broken reference link.
 - Common matches: `.oat/projects/**/reviews/archived`, `.oat/projects/**/pr`. Active `reviews/` paths remain eligible for References when they are tracked; only archived review paths should be treated as local-only by default.
 
 Example link context:

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.0.40",
-  "docs-config": "0.0.40",
-  "docs-theme": "0.0.40",
-  "docs-transforms": "0.0.40"
+  "cli": "0.0.41",
+  "docs-config": "0.0.41",
+  "docs-theme": "0.0.41",
+  "docs-transforms": "0.0.41"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
+++ b/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
@@ -103,7 +103,10 @@ describe('review skill contracts', () => {
       'git check-ignore --quiet --no-index "$ARCHIVE_RELATIVE_PATH"',
     );
     expect(content).toContain(
-      'If `.oat/projects/archived/` is version controlled on the current branch, archive in the current checkout instead.',
+      'Only archive in the current checkout when a hypothetical file at `.oat/projects/archived/<project>/state.md` would actually be tracked here.',
+    );
+    expect(content).toContain(
+      'Do not check `git check-ignore` on `.oat/projects/archived` (the directory itself).',
     );
     expect(content).not.toContain(
       'If running from a git worktree, the primary repo archive directory is the canonical/durable archive destination.',

--- a/packages/cli/src/commands/project/archive/archive-utils.ts
+++ b/packages/cli/src/commands/project/archive/archive-utils.ts
@@ -221,6 +221,13 @@ function isExitCode(error: unknown, code: number): boolean {
   );
 }
 
+// archiveProjectPath must be the contents-level probe path
+// (.oat/projects/archived/<projectName>), not the archive directory itself
+// (.oat/projects/archived). A `.oat/projects/archived/**` gitignore pattern
+// leaves the directory visible in the tree while ignoring every file placed
+// inside — a directory-level check reports "not ignored" and produces the
+// inverse of the intended durability decision. Keep the probe inside the
+// directory; the `oat-project-complete` skill documents the same invariant.
 async function isGitignoredArchivePath(
   repoRoot: string,
   archiveProjectPath: string,

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- Fixes an ambiguous worktree-durability check in `oat-project-complete` Step 8 that caused archives to land in the disposable worktree-local `.oat/projects/archived/` instead of the durable primary checkout when `.gitignore` used a `.oat/projects/archived/**`-style pattern.
- Root cause: the skill's prose directed agents to check whether the archive directory was version-controlled, and the natural reading — `git check-ignore` on the directory itself — reports "not ignored" even when every file inside is ignored (trailing `/**` ignores contents but leaves the directory visible in the tree). That produced the inverse of the intended decision.
- Fix: the skill now spells out an unambiguous contents-level probe (a representative path **inside** the archive directory), matches the CLI helper's existing probe shape, adds an explicit anti-pattern note, and renames/inverts the tracking flag (`ARCHIVE_CONTENTS_TRACKED`) so it reads naturally. `oat-project-pr-final`'s `localPaths` exclusion guidance got an analogous tightening. The CLI helper at `archive-utils.ts` was already correct; it gains a comment pinning the probe-is-subpath invariant so a future refactor cannot silently regress.
- Lockstep version bump: `cli`, `control-plane`, `docs-config`, `docs-theme`, `docs-transforms` → `0.0.41`. Skill `version:` bumped on both edited canonical skills (`oat-project-complete` 1.4.2 → 1.4.3, `oat-project-pr-final` 1.3.2 → 1.3.3).

## Test plan

- [x] `pnpm --filter @open-agent-toolkit/cli exec vitest run src/commands/project/archive/archive-utils.test.ts` (14 tests pass; existing tests already pin the probe path to the project subpath and would fail on a directory-level regression)
- [x] `pnpm --filter @open-agent-toolkit/cli lint`
- [x] `pnpm --filter @open-agent-toolkit/cli type-check`
- [x] `pnpm release:validate` (5 public packages aligned at 0.0.41)
- [x] Verified skill prose scenarios manually against gitignore semantics:
  - Worktree + `.oat/projects/archived/**` ignored → probe on `.oat/projects/archived/<project>` returns ignored → falls back to primary checkout ✓
  - Tracked archive dir (no `**` ignore) → probe returns not-ignored → stays in current checkout ✓
  - Non-worktree checkout → `GIT_COMMON_DIR == GIT_DIR` → stays in current checkout ✓