### PR TITLE
fix: distinguish managed drift from unmanaged strays in pre-commit hook

### DIFF
--- a/apps/oat-docs/docs/contributing/hooks-and-safety.md
+++ b/apps/oat-docs/docs/contributing/hooks-and-safety.md
@@ -7,9 +7,16 @@ description: 'Pre-commit hooks and safety contracts for provider sync mutations.
 
 ## Optional pre-commit drift warning hook
 
-`oat init` can install a pre-commit hook that warns when project provider views appear out of sync.
+`oat init` can install a pre-commit hook that checks project provider sync state on every commit by invoking `oat status --scope project --hook`.
 
-OAT installs that hook into Git's currently active hook directory. When a consumer repo keeps hooks in a repo-managed folder such as `.githooks/`, Git must be configured to use that path before install, or OAT must configure it during the hook prompt flow.
+The hook distinguishes two states so unmanaged files are not reported the same as true drift:
+
+- **Warning (managed drift or missing):** a manifest-tracked provider entry has drifted or is missing. Emits `oat: managed provider views are out of sync - run 'oat sync --scope project'` to stderr.
+- **Info (unmanaged strays only):** provider files exist inside a managed directory but are not in the manifest. Emits `oat: unmanaged provider files detected - run 'oat status --scope project' to review` to stderr. Not treated as drift.
+
+The hook is non-blocking: it never fails the commit, even when managed drift is detected.
+
+OAT installs the hook into Git's currently active hook directory. When a consumer repo keeps hooks in a repo-managed folder such as `.githooks/`, Git must be configured to use that path before install, or OAT must configure it during the hook prompt flow.
 
 ## Safety contracts
 

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.0.41",
-  "docs-config": "0.0.41",
-  "docs-theme": "0.0.41",
-  "docs-transforms": "0.0.41"
+  "cli": "0.0.42",
+  "docs-config": "0.0.42",
+  "docs-theme": "0.0.42",
+  "docs-transforms": "0.0.42"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/help-snapshots.test.ts
+++ b/packages/cli/src/commands/help-snapshots.test.ts
@@ -31,34 +31,34 @@ describe('help output snapshots', () => {
       Open Agent Toolkit CLI for provider interoperability
 
       Options:
-        -V, --version    output the version number
-        --json           Output a single JSON document
-        --verbose        Enable verbose debug output
-        --scope <scope>  Limit execution scope (choices: "project", "user", "all",
-                         default: "all")
-        --cwd <path>     Override working directory
-        -h, --help       display help for command
+        -V, --version     output the version number
+        --json            Output a single JSON document
+        --verbose         Enable verbose debug output
+        --scope <scope>   Limit execution scope (choices: "project", "user", "all",
+                          default: "all")
+        --cwd <path>      Override working directory
+        -h, --help        display help for command
 
       Commands:
-        backlog          Manage file-backed backlog items and indexes
-        init [options]   Initialize canonical directories, manifest, and tool packs
-        status           Report provider sync and drift status
-        sync [options]   Sync canonical content to provider views
-        config           Read and write OAT config values
-        local            Manage local-only paths (gitignored, worktree-synced)
-        providers        Inspect provider capabilities and paths
-        remove           Remove installed skills and managed provider views
-        repo             Repository-level analysis and insight tools
-        doctor           Run environment and setup diagnostics
-        cleanup          Cleanup OAT project and artifact hygiene issues
-        docs             OAT documentation bootstrap and maintenance commands
-        instructions     Manage AGENTS.md and CLAUDE.md instruction file integrity
-        index            OAT index generation commands
-        project          Manage OAT project workflows
-        state            OAT repo state commands
-        tools            Manage OAT tool packs (install, update, remove, list)
-        internal         Internal OAT maintenance commands
-        help [command]   display help for command
+        backlog           Manage file-backed backlog items and indexes
+        init [options]    Initialize canonical directories, manifest, and tool packs
+        status [options]  Report provider sync and drift status
+        sync [options]    Sync canonical content to provider views
+        config            Read and write OAT config values
+        local             Manage local-only paths (gitignored, worktree-synced)
+        providers         Inspect provider capabilities and paths
+        remove            Remove installed skills and managed provider views
+        repo              Repository-level analysis and insight tools
+        doctor            Run environment and setup diagnostics
+        cleanup           Cleanup OAT project and artifact hygiene issues
+        docs              OAT documentation bootstrap and maintenance commands
+        instructions      Manage AGENTS.md and CLAUDE.md instruction file integrity
+        index             OAT index generation commands
+        project           Manage OAT project workflows
+        state             OAT repo state commands
+        tools             Manage OAT tool packs (install, update, remove, list)
+        internal          Internal OAT maintenance commands
+        help [command]    display help for command
       "
     `);
   });
@@ -156,6 +156,8 @@ describe('help output snapshots', () => {
       Report provider sync and drift status
 
       Options:
+        --hook      Emit a minimal pre-commit message: warn on managed drift, info on
+                    strays
         -h, --help  display help for command
       "
     `);

--- a/packages/cli/src/commands/init/index.test.ts
+++ b/packages/cli/src/commands/init/index.test.ts
@@ -971,12 +971,9 @@ config_file = "agents/reviewer.toml"
     const hookPath = join(root, '.git', 'hooks', 'pre-commit');
     const hookContents = await readFile(hookPath, 'utf8');
 
-    expect(hookContents).toContain(
-      'if ! oat status --scope project >/dev/null 2>&1; then',
-    );
-    expect(hookContents).toContain(
-      "oat: project provider views are out of sync - run 'oat status --scope project' or 'oat sync --scope project'",
-    );
+    expect(hookContents).toContain('oat status --scope project --hook');
+    // Non-blocking: never aborts the commit on a non-zero status exit.
+    expect(hookContents).toContain('|| true');
   });
 
   it('installs hook when .git/hooks is a symlinked directory', async () => {

--- a/packages/cli/src/commands/status/index.test.ts
+++ b/packages/cli/src/commands/status/index.test.ts
@@ -242,7 +242,21 @@ async function runStatusCommand(
 
   program.addCommand(command);
 
-  await program.parseAsync([...argv, 'status'], {
+  // Subcommand-specific flags (e.g. `--hook`) must follow the `status`
+  // subcommand name. Split `argv` into parent-level globals and subcommand
+  // flags so both are routed to the right parser.
+  const subcommandOnlyFlags = new Set(['--hook']);
+  const parentArgs: string[] = [];
+  const subArgs: string[] = [];
+  for (const arg of argv) {
+    if (subcommandOnlyFlags.has(arg)) {
+      subArgs.push(arg);
+    } else {
+      parentArgs.push(arg);
+    }
+  }
+
+  await program.parseAsync([...parentArgs, 'status', ...subArgs], {
     from: 'user',
   });
 }
@@ -640,5 +654,139 @@ describe('createStatusCommand', () => {
     await runStatusCommand(command, ['--scope', 'project']);
 
     expect(process.exitCode).toBe(1);
+  });
+
+  describe('--hook mode', () => {
+    const DRIFT_WARNING =
+      "oat: managed provider views are out of sync - run 'oat sync --scope project'";
+    const STRAY_INFO =
+      "oat: unmanaged provider files detected - run 'oat status --scope project' to review";
+
+    it('is silent and exits 0 when all in sync', async () => {
+      const { capture, command } = createHarness({
+        driftReports: [
+          {
+            canonical: '.agents/skills/skill-one',
+            provider: 'claude',
+            providerPath: '.claude/skills/skill-one',
+            state: { status: 'in_sync' },
+          },
+        ],
+      });
+
+      await runStatusCommand(command, ['--scope', 'project', '--hook']);
+
+      expect(capture.info).toHaveLength(0);
+      expect(capture.warn).toHaveLength(0);
+      expect(process.exitCode).toBe(0);
+    });
+
+    it('warns and exits 1 on managed drift', async () => {
+      const { capture, command } = createHarness({
+        driftReports: [
+          {
+            canonical: '.agents/skills/skill-one',
+            provider: 'claude',
+            providerPath: '.claude/skills/skill-one',
+            state: { status: 'drifted', reason: 'modified' },
+          },
+        ],
+      });
+
+      await runStatusCommand(command, ['--scope', 'project', '--hook']);
+
+      expect(capture.warn).toContain(DRIFT_WARNING);
+      expect(capture.info).toHaveLength(0);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('warns and exits 1 on missing managed entry', async () => {
+      const { capture, command } = createHarness({
+        driftReports: [
+          {
+            canonical: '.agents/skills/skill-one',
+            provider: 'claude',
+            providerPath: '.claude/skills/skill-one',
+            state: { status: 'missing' },
+          },
+        ],
+      });
+
+      await runStatusCommand(command, ['--scope', 'project', '--hook']);
+
+      expect(capture.warn).toContain(DRIFT_WARNING);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('emits info and exits 0 when only strays exist', async () => {
+      const { capture, command } = createHarness({
+        interactive: false,
+        driftReports: [],
+        strayReports: [
+          {
+            canonical: null,
+            provider: 'claude',
+            providerPath: '.claude/skills/stray-skill',
+            state: { status: 'stray' },
+          },
+        ],
+      });
+
+      await runStatusCommand(command, ['--scope', 'project', '--hook']);
+
+      expect(capture.info).toContain(STRAY_INFO);
+      expect(capture.warn).toHaveLength(0);
+      expect(process.exitCode).toBe(0);
+    });
+
+    it('prefers drift warning when both drift and strays exist', async () => {
+      const { capture, command } = createHarness({
+        interactive: false,
+        driftReports: [
+          {
+            canonical: '.agents/skills/skill-one',
+            provider: 'claude',
+            providerPath: '.claude/skills/skill-one',
+            state: { status: 'drifted', reason: 'modified' },
+          },
+        ],
+        strayReports: [
+          {
+            canonical: null,
+            provider: 'claude',
+            providerPath: '.claude/skills/stray-skill',
+            state: { status: 'stray' },
+          },
+        ],
+      });
+
+      await runStatusCommand(command, ['--scope', 'project', '--hook']);
+
+      expect(capture.warn).toContain(DRIFT_WARNING);
+      expect(capture.info).not.toContain(STRAY_INFO);
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('suppresses the status table and adoption prompts', async () => {
+      const { capture, command, selectManyWithAbort } = createHarness({
+        interactive: true,
+        driftReports: [],
+        strayReports: [
+          {
+            canonical: null,
+            provider: 'claude',
+            providerPath: '.claude/skills/stray-one',
+            state: { status: 'stray' },
+          },
+        ],
+      });
+
+      await runStatusCommand(command, ['--scope', 'project', '--hook']);
+
+      // Status table goes via logger.info. In --hook mode we emit exactly
+      // the stray info line — no table, no remediation prompt.
+      expect(capture.info).toEqual([STRAY_INFO]);
+      expect(selectManyWithAbort).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -30,7 +30,12 @@ import {
   detectDrift,
   detectStrays,
 } from '@drift/index';
-import { type CanonicalEntry, scanCanonical } from '@engine/index';
+import {
+  type CanonicalEntry,
+  HOOK_DRIFT_WARNING,
+  HOOK_STRAY_INFO,
+  scanCanonical,
+} from '@engine/index';
 import {
   normalizeToPosixPath,
   resolveProjectRoot,
@@ -474,6 +479,7 @@ async function collectScopeReports(
 async function runStatusCommand(
   context: CommandContext,
   dependencies: StatusDependencies,
+  options: { hook?: boolean } = {},
 ): Promise<void> {
   const reports: DriftReport[] = [];
   const scopeCollections: ScopeReportCollection[] = [];
@@ -490,6 +496,19 @@ async function runStatusCommand(
 
   const summary = summarizeReports(reports);
   const hasIssues = summary.total > 0 && summary.inSync !== summary.total;
+
+  if (options.hook) {
+    if (summary.drifted > 0 || summary.missing > 0) {
+      context.logger.warn(HOOK_DRIFT_WARNING);
+      process.exitCode = 1;
+    } else if (summary.stray > 0) {
+      context.logger.info(HOOK_STRAY_INFO);
+      process.exitCode = 0;
+    } else {
+      process.exitCode = 0;
+    }
+    return;
+  }
 
   if (context.json) {
     const payload: StatusJsonPayload = {
@@ -637,10 +656,16 @@ export function createStatusCommand(
 
   return new Command('status')
     .description('Report provider sync and drift status')
-    .action(async (_options, command: Command) => {
+    .option(
+      '--hook',
+      'Emit a minimal pre-commit message: warn on managed drift, info on strays',
+    )
+    .action(async (options: { hook?: boolean }, command: Command) => {
       const context = dependencies.buildCommandContext(
         readGlobalOptions(command),
       );
-      await runStatusCommand(context, dependencies);
+      await runStatusCommand(context, dependencies, {
+        hook: Boolean(options.hook),
+      });
     });
 }

--- a/packages/cli/src/engine/hook.test.ts
+++ b/packages/cli/src/engine/hook.test.ts
@@ -18,6 +18,7 @@ import {
   HOOK_DRIFT_WARNING,
   HOOK_MARKER_END,
   HOOK_MARKER_START,
+  HOOK_STRAY_INFO,
   installHook,
   isHookInstalled,
   runHookCheck,
@@ -51,6 +52,17 @@ describe('git hook', () => {
     const content = await readFile(hookPath, 'utf8');
     expect(content).toContain(HOOK_MARKER_START);
     expect(content).toContain(HOOK_MARKER_END);
+  });
+
+  it('installHook writes snippet that invokes --hook mode', async () => {
+    const root = await createProjectRoot('oat-hook-snippet-');
+
+    const hookPath = await installHook(root);
+
+    const content = await readFile(hookPath, 'utf8');
+    expect(content).toContain('oat status --scope project --hook');
+    // Snippet must not abort the commit when oat reports issues.
+    expect(content).toContain('|| true');
   });
 
   it('installHook preserves existing hook content', async () => {
@@ -125,28 +137,62 @@ describe('git hook', () => {
     expect(await isHookInstalled(root)).toBe(true);
   });
 
-  it('runHookCheck returns drift warnings', async () => {
+  it('runHookCheck warns on managed drift', async () => {
     const warn = vi.fn();
+    const info = vi.fn();
     const result = await runHookCheck('/tmp/workspace', {
-      runStatusCommand: async () => false,
+      runStatusCommand: async () => 'managed_drift',
       warn,
+      info,
     });
 
-    expect(result.inSync).toBe(false);
+    expect(result.status).toBe('managed_drift');
     expect(warn).toHaveBeenCalledWith(HOOK_DRIFT_WARNING);
+    expect(info).not.toHaveBeenCalled();
   });
 
-  it('runHookCheck does not block when status check fails', async () => {
+  it('runHookCheck emits info for stray-only state', async () => {
     const warn = vi.fn();
+    const info = vi.fn();
+    const result = await runHookCheck('/tmp/workspace', {
+      runStatusCommand: async () => 'stray_only',
+      warn,
+      info,
+    });
+
+    expect(result.status).toBe('stray_only');
+    expect(info).toHaveBeenCalledWith(HOOK_STRAY_INFO);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('runHookCheck is silent when in sync', async () => {
+    const warn = vi.fn();
+    const info = vi.fn();
+    const result = await runHookCheck('/tmp/workspace', {
+      runStatusCommand: async () => 'in_sync',
+      warn,
+      info,
+    });
+
+    expect(result.status).toBe('in_sync');
+    expect(warn).not.toHaveBeenCalled();
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it('runHookCheck falls back to managed_drift when status check fails', async () => {
+    const warn = vi.fn();
+    const info = vi.fn();
     const result = await runHookCheck('/tmp/workspace', {
       runStatusCommand: async () => {
         throw new Error('status failed');
       },
       warn,
+      info,
     });
 
-    expect(result.inSync).toBe(false);
+    expect(result.status).toBe('managed_drift');
     expect(warn).toHaveBeenCalledWith(HOOK_DRIFT_WARNING);
+    expect(info).not.toHaveBeenCalled();
   });
 
   it('installHook resolves symlinked .git directory', async () => {

--- a/packages/cli/src/engine/hook.ts
+++ b/packages/cli/src/engine/hook.ts
@@ -17,8 +17,12 @@ const execFileAsync = promisify(execFile);
 export const HOOK_MARKER_START = '# >>> oat pre-commit hook >>>';
 export const HOOK_MARKER_END = '# <<< oat pre-commit hook <<<';
 export const HOOK_DRIFT_WARNING =
-  "oat: project provider views are out of sync - run 'oat status --scope project' or 'oat sync --scope project'";
+  "oat: managed provider views are out of sync - run 'oat sync --scope project'";
+export const HOOK_STRAY_INFO =
+  "oat: unmanaged provider files detected - run 'oat status --scope project' to review";
 export const REPO_GITHOOKS_PATH = '.githooks';
+
+export type HookStatus = 'in_sync' | 'managed_drift' | 'stray_only';
 
 export interface HookInstallInfo {
   hookPath: string;
@@ -27,8 +31,9 @@ export interface HookInstallInfo {
 }
 
 interface RunHookCheckOptions {
-  runStatusCommand?: (cwd: string) => Promise<boolean>;
+  runStatusCommand?: (cwd: string) => Promise<HookStatus>;
   warn?: (message: string) => void;
+  info?: (message: string) => void;
 }
 
 function escapeRegExp(value: string): string {
@@ -39,9 +44,7 @@ function createHookSnippet(options: { includeShebang?: boolean } = {}): string {
   const lines = [
     HOOK_MARKER_START,
     'if command -v oat >/dev/null 2>&1; then',
-    '  if ! oat status --scope project >/dev/null 2>&1; then',
-    `    echo "${HOOK_DRIFT_WARNING}" >&2`,
-    '  fi',
+    '  oat status --scope project --hook || true',
     'fi',
     HOOK_MARKER_END,
   ];
@@ -305,38 +308,62 @@ export async function uninstallHook(projectRoot: string): Promise<void> {
   await writeFile(hookPath, next, 'utf8');
 }
 
-async function runStatusCommandDefault(cwd: string): Promise<boolean> {
+async function runStatusCommandDefault(cwd: string): Promise<HookStatus> {
   try {
-    await execFileAsync('oat', ['status', '--scope', 'project'], { cwd });
-    return true;
+    const { stdout } = await execFileAsync(
+      'oat',
+      ['status', '--scope', 'project', '--json'],
+      { cwd },
+    );
+    const payload = JSON.parse(stdout) as {
+      summary?: { drifted?: number; missing?: number; stray?: number };
+    };
+    const summary = payload.summary ?? {};
+    const drifted = summary.drifted ?? 0;
+    const missing = summary.missing ?? 0;
+    const stray = summary.stray ?? 0;
+    if (drifted + missing > 0) {
+      return 'managed_drift';
+    }
+    if (stray > 0) {
+      return 'stray_only';
+    }
+    return 'in_sync';
   } catch {
-    return false;
+    // On any failure (oat missing, JSON parse error, unexpected exit), fall
+    // back to treating the state as managed drift so the operator notices.
+    return 'managed_drift';
   }
 }
 
 export async function runHookCheck(
   cwd: string,
   options: RunHookCheckOptions = {},
-): Promise<{ inSync: boolean }> {
+): Promise<{ status: HookStatus }> {
   const runStatusCommand = options.runStatusCommand ?? runStatusCommandDefault;
   const warn =
     options.warn ??
     ((message: string) => {
       process.stderr.write(`${message}\n`);
     });
+  const info =
+    options.info ??
+    ((message: string) => {
+      process.stderr.write(`${message}\n`);
+    });
 
-  let inSync = false;
+  let status: HookStatus;
   try {
-    // Default impl already returns boolean on failures, but this catch
-    // protects custom injected implementations from escaping exceptions.
-    inSync = await runStatusCommand(cwd);
+    status = await runStatusCommand(cwd);
   } catch {
-    inSync = false;
+    status = 'managed_drift';
   }
 
-  if (!inSync) {
+  if (status === 'managed_drift') {
     warn(HOOK_DRIFT_WARNING);
+  } else if (status === 'stray_only') {
+    info(HOOK_STRAY_INFO);
   }
 
-  return { inSync };
+  return { status };
 }

--- a/packages/cli/src/engine/index.ts
+++ b/packages/cli/src/engine/index.ts
@@ -15,13 +15,14 @@ export {
   HOOK_DRIFT_WARNING,
   HOOK_MARKER_END,
   HOOK_MARKER_START,
+  HOOK_STRAY_INFO,
   installHook,
   isHookInstalled,
   REPO_GITHOOKS_PATH,
   runHookCheck,
   uninstallHook,
 } from './hook';
-export type { HookInstallInfo } from './hook';
+export type { HookInstallInfo, HookStatus } from './hook';
 export {
   hasMarker,
   insertMarker,

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -3,8 +3,6 @@ pnpm exec lint-staged
 
 # >>> oat pre-commit hook >>>
 if command -v oat >/dev/null 2>&1; then
-  if ! oat status --scope project >/dev/null 2>&1; then
-    echo "oat: project provider views are out of sync - run 'oat status --scope project' or 'oat sync --scope project'" >&2
-  fi
+  oat status --scope project --hook || true
 fi
 # <<< oat pre-commit hook <<<


### PR DESCRIPTION
## Summary

- The installed pre-commit hook was emitting `oat: project provider views are out of sync - run 'oat status --scope project' or 'oat sync --scope project'` for both true managed drift *and* unmanaged stray provider files. Strays aren't drift, so the message was misleading.
- Adds `oat status --scope project --hook` — a non-blocking hook-only mode that inspects the JSON summary and emits precise output:
  - **managed drift or missing:** warns to stderr with `oat: managed provider views are out of sync - run 'oat sync --scope project'` and exits 1
  - **unmanaged strays only:** info on stderr with `oat: unmanaged provider files detected - run 'oat status --scope project' to review` and exits 0
  - **in sync:** silent, exit 0
- Updates the bundled hook snippet (and this repo's `tools/git-hooks/pre-commit`) to invoke `oat status --scope project --hook || true` so the hook stays non-blocking but now carries the precise classification.
- Keeps the existing `oat status` exit semantics unchanged for external consumers (no regression for anything already scripted against plain `oat status`).

Lockstep bump 0.0.41 → 0.0.42 across the five public packages per release policy (docs prose update under `apps/oat-docs` qualifies as shipped CLI functionality).

Note for existing installs: repos that previously ran `oat init` still have the old inline snippet in their pre-commit file. The install path short-circuits on the existing marker block, so users will want to manually replace the delimited OAT block to pick up the new `--hook` invocation. A follow-up to teach `installHook` to rewrite stale blocks in place is a reasonable next step but out of scope here.

## Test plan

- [x] `pnpm --filter @open-agent-toolkit/cli test` — all 1321 tests pass
- [x] Added unit tests for `runHookCheck` across all four states (in_sync, managed_drift, missing, stray_only, plus fallback-to-drift on error)
- [x] Added status-command `--hook` mode tests covering: silent on in_sync, warn+exit 1 on drifted, warn+exit 1 on missing, info+exit 0 on stray-only, drift wins when both drift and stray present, hook mode suppresses table + prompts
- [x] Updated `installHook` snippet tests to assert new `--hook` invocation + `|| true`
- [x] Regenerated help snapshots (root + `status --help`)
- [x] Docs updated in `apps/oat-docs/docs/contributing/hooks-and-safety.md`
- [x] `pnpm release:validate` passes at 0.0.42
- [ ] After merge: update existing repos (`gizmo-slack-app`, `honeycomb`, `vox-mobile-app`, etc.) by replacing the marked OAT block in their `.git/hooks/pre-commit`