### PR TITLE
fix: correctly resolve S3 archive repo slug on worktrees

### DIFF
--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.0.56",
-  "docs-config": "0.0.56",
-  "docs-theme": "0.0.56",
-  "docs-transforms": "0.0.56"
+  "cli": "0.0.57",
+  "docs-config": "0.0.57",
+  "docs-theme": "0.0.57",
+  "docs-transforms": "0.0.57"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/project/archive/archive-utils.test.ts
+++ b/packages/cli/src/commands/project/archive/archive-utils.test.ts
@@ -12,6 +12,7 @@ import {
   buildProjectArchiveS3Uri,
   ensureS3ArchiveAccess,
   resolveLocalArchiveProjectPath,
+  resolvePrimaryRepoRoot,
 } from './archive-utils';
 
 describe('archive utils', () => {
@@ -44,6 +45,48 @@ describe('archive utils', () => {
     ).toBe(
       's3://example-bucket/oat-archive/open-agent-toolkit/projects/demo-project',
     );
+  });
+
+  it('resolves the primary repo root from a linked git worktree', async () => {
+    const tempRoot = await createRepoRoot();
+    const mainRepoRoot = join(tempRoot, 'stoa');
+    const worktreeRoot = join(tempRoot, 'sc-pinned-cryostat-af7a');
+    await mkdir(join(mainRepoRoot, '.git'), { recursive: true });
+    await mkdir(worktreeRoot, { recursive: true });
+
+    const execFile = vi.fn(async (file: string, args: string[]) => {
+      if (
+        file === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[1] === '--git-common-dir'
+      ) {
+        return {
+          stdout: join(mainRepoRoot, '.git'),
+          stderr: '',
+        };
+      }
+      if (
+        file === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[1] === '--git-dir'
+      ) {
+        return {
+          stdout: join(
+            mainRepoRoot,
+            '.git',
+            'worktrees',
+            'sc-pinned-cryostat-af7a',
+          ),
+          stderr: '',
+        };
+      }
+
+      throw new Error(`Unexpected command: ${file} ${args.join(' ')}`);
+    });
+
+    await expect(
+      resolvePrimaryRepoRoot(worktreeRoot, { gitExecFile: execFile }),
+    ).resolves.toBe(mainRepoRoot);
   });
 
   it('resolves local archived project paths from projects.root', () => {
@@ -311,6 +354,101 @@ describe('archive utils', () => {
     await expect(
       readFile(join(result.archivePath, 'summary.md'), 'utf8'),
     ).resolves.toBe('# summary\n');
+  });
+
+  it('uploads completion archives under the primary repo root slug from a linked worktree', async () => {
+    const tempRoot = await createRepoRoot();
+    const mainRepoRoot = join(tempRoot, 'stoa');
+    const worktreeRoot = join(tempRoot, 'sc-pinned-cryostat-af7a');
+    const projectPath = join(
+      worktreeRoot,
+      '.oat',
+      'projects',
+      'shared',
+      'demo',
+    );
+
+    await mkdir(join(mainRepoRoot, '.git'), { recursive: true });
+    await mkdir(projectPath, { recursive: true });
+    await writeFile(join(projectPath, 'summary.md'), '# summary\n', 'utf8');
+
+    const gitExecFile = vi.fn(async (file: string, args: string[]) => {
+      if (
+        file === 'git' &&
+        args[0] === 'check-ignore' &&
+        args[1] === '--quiet' &&
+        args[2] === '--no-index' &&
+        args[3] === '.oat/projects/archived/demo'
+      ) {
+        return {
+          stdout: '',
+          stderr: '',
+        };
+      }
+      if (
+        file === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[1] === '--git-common-dir'
+      ) {
+        return {
+          stdout: join(mainRepoRoot, '.git'),
+          stderr: '',
+        };
+      }
+      if (
+        file === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[1] === '--git-dir'
+      ) {
+        return {
+          stdout: join(
+            mainRepoRoot,
+            '.git',
+            'worktrees',
+            'sc-pinned-cryostat-af7a',
+          ),
+          stderr: '',
+        };
+      }
+
+      throw new Error(`Unexpected command: ${file} ${args.join(' ')}`);
+    });
+    const execFile = vi.fn(async () => ({ stdout: '', stderr: '' }));
+
+    const result = await archiveProjectOnCompletion(
+      {
+        repoRoot: worktreeRoot,
+        projectPath,
+        projectName: 'demo',
+        projectsRoot: '.oat/projects/shared',
+        s3Uri: 's3://example-bucket/oat-archive',
+        s3SyncOnComplete: true,
+      },
+      {
+        execFile,
+        gitExecFile,
+        ensureS3ArchiveAccess: vi.fn(async () => ({ ok: true, warnings: [] })),
+        timestamp: () => '2026-04-01T12:34:56Z',
+      },
+    );
+
+    expect(result.s3Path).toBe(
+      's3://example-bucket/oat-archive/stoa/projects/20260401-demo',
+    );
+    expect(execFile).toHaveBeenCalledWith(
+      'aws',
+      [
+        's3',
+        'sync',
+        join(mainRepoRoot, '.oat', 'projects', 'archived', 'demo'),
+        's3://example-bucket/oat-archive/stoa/projects/20260401-demo',
+        '--exclude',
+        'reviews/*',
+        '--exclude',
+        'pr/*',
+      ],
+      expect.objectContaining({ cwd: worktreeRoot }),
+    );
   });
 
   it('archives in the current worktree when the archive path is version controlled', async () => {

--- a/packages/cli/src/commands/project/archive/archive-utils.ts
+++ b/packages/cli/src/commands/project/archive/archive-utils.ts
@@ -79,10 +79,18 @@ export interface ArchiveProjectOnCompletionOptions {
   awsRegion?: string | null;
 }
 
-interface ArchiveProjectOnCompletionDependencies extends EnsureS3ArchiveAccessDependencies {
+export interface ResolvePrimaryRepoRootDependencies {
+  gitExecFile?: ExecFileLike;
+  dirExists?: typeof dirExists;
+  env?: NodeJS.ProcessEnv;
+}
+
+interface ArchiveProjectOnCompletionDependencies
+  extends
+    EnsureS3ArchiveAccessDependencies,
+    ResolvePrimaryRepoRootDependencies {
   ensureS3ArchiveAccess?: typeof ensureS3ArchiveAccess;
   execFile?: ExecFileLike;
-  gitExecFile?: ExecFileLike;
   ensureDir?: typeof ensureDir;
   copyDirectory?: typeof copyDirectory;
   removePath?: (
@@ -90,7 +98,6 @@ interface ArchiveProjectOnCompletionDependencies extends EnsureS3ArchiveAccessDe
     options: { recursive: true; force: true },
   ) => Promise<void>;
   copySingleFile?: typeof copySingleFile;
-  dirExists?: typeof dirExists;
   fileExists?: typeof fileExists;
   timestamp?: () => string;
 }
@@ -328,24 +335,10 @@ async function isGitignoredArchivePath(
   }
 }
 
-async function resolveArchiveRepoRoot(
+export async function resolvePrimaryRepoRoot(
   repoRoot: string,
-  archiveProjectPath: string,
-  dependencies: ArchiveProjectOnCompletionDependencies,
+  dependencies: ResolvePrimaryRepoRootDependencies = {},
 ): Promise<string> {
-  try {
-    const archivePathIsGitignored = await isGitignoredArchivePath(
-      repoRoot,
-      archiveProjectPath,
-      dependencies,
-    );
-    if (!archivePathIsGitignored) {
-      return repoRoot;
-    }
-  } catch {
-    return repoRoot;
-  }
-
   const execFile = dependencies.gitExecFile ?? execFileAsync;
 
   try {
@@ -377,6 +370,27 @@ async function resolveArchiveRepoRoot(
   }
 
   return repoRoot;
+}
+
+async function resolveArchiveRepoRoot(
+  repoRoot: string,
+  archiveProjectPath: string,
+  dependencies: ArchiveProjectOnCompletionDependencies,
+): Promise<string> {
+  try {
+    const archivePathIsGitignored = await isGitignoredArchivePath(
+      repoRoot,
+      archiveProjectPath,
+      dependencies,
+    );
+    if (!archivePathIsGitignored) {
+      return repoRoot;
+    }
+  } catch {
+    return repoRoot;
+  }
+
+  return resolvePrimaryRepoRoot(repoRoot, dependencies);
 }
 
 async function resolveUniqueArchivePath(
@@ -446,7 +460,6 @@ export async function archiveProjectOnCompletion(
     archiveProjectPath,
     dependencies,
   );
-
   const archiveBasePath = resolveCompletionArchivePath(
     archiveRepoRoot,
     options.projectsRoot,
@@ -503,9 +516,13 @@ export async function archiveProjectOnCompletion(
     warnings.push(...access.warnings);
 
     if (access.ok) {
+      const remoteRepoRoot = await resolvePrimaryRepoRoot(
+        options.repoRoot,
+        dependencies,
+      );
       s3Path = buildProjectArchiveS3Uri(
         options.s3Uri,
-        options.repoRoot,
+        remoteRepoRoot,
         snapshotName,
       );
 

--- a/packages/cli/src/commands/project/archive/index.test.ts
+++ b/packages/cli/src/commands/project/archive/index.test.ts
@@ -20,6 +20,7 @@ interface HarnessOptions {
   json?: boolean;
   listOutput?: string;
   preflightError?: Error;
+  primaryRepoRoot?: string;
   projectsRoot?: string;
   processEnv?: NodeJS.ProcessEnv;
 }
@@ -77,6 +78,7 @@ function createHarness(options: HarnessOptions = {}): {
     readOatConfig: vi.fn(async () => config),
     resolveProjectsRoot: vi.fn(async () => projectsRoot),
     ensureS3ArchiveAccess,
+    resolvePrimaryRepoRoot: vi.fn(async () => options.primaryRepoRoot ?? cwd),
     execFile,
     removeDirectory,
     ...(options.processEnv ? { processEnv: options.processEnv } : {}),
@@ -224,6 +226,42 @@ describe('oat project archive sync', () => {
       ],
       expect.objectContaining({
         cwd: '/tmp/workspace/open-agent-toolkit',
+      }),
+    );
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('uses the primary repo root slug when syncing from a linked worktree', async () => {
+    const { command, execFile } = createHarness({
+      cwd: '/tmp/worktrees/sc-pinned-cryostat-af7a',
+      primaryRepoRoot: '/tmp/workspace/stoa',
+    });
+
+    await runArchiveSyncCommand(command);
+
+    expect(execFile).toHaveBeenNthCalledWith(
+      1,
+      'aws',
+      ['s3', 'ls', 's3://example-bucket/oat-archive/stoa/projects/'],
+      expect.objectContaining({
+        cwd: '/tmp/worktrees/sc-pinned-cryostat-af7a',
+      }),
+    );
+    expect(execFile).toHaveBeenNthCalledWith(
+      2,
+      'aws',
+      [
+        's3',
+        'sync',
+        's3://example-bucket/oat-archive/stoa/projects/20260401-demo-project',
+        '.oat/projects/archived/demo-project',
+        '--exclude',
+        'reviews/*',
+        '--exclude',
+        'pr/*',
+      ],
+      expect.objectContaining({
+        cwd: '/tmp/worktrees/sc-pinned-cryostat-af7a',
       }),
     );
     expect(process.exitCode).toBe(0);

--- a/packages/cli/src/commands/project/archive/index.ts
+++ b/packages/cli/src/commands/project/archive/index.ts
@@ -21,6 +21,7 @@ import {
   type ExecFileLike,
   parseArchiveSnapshotName,
   resolveLocalArchiveProjectPath,
+  resolvePrimaryRepoRoot,
 } from './archive-utils';
 
 const execFileAsync = promisify(execFileCallback);
@@ -105,6 +106,7 @@ export interface ProjectArchiveCommandDependencies {
   buildRepoArchiveS3Uri: typeof buildRepoArchiveS3Uri;
   buildProjectArchiveS3Uri: typeof buildProjectArchiveS3Uri;
   resolveLocalArchiveProjectPath: typeof resolveLocalArchiveProjectPath;
+  resolvePrimaryRepoRoot: typeof resolvePrimaryRepoRoot;
   execFile: ExecFileLike;
   removeDirectory: typeof rm;
   processEnv: NodeJS.ProcessEnv;
@@ -120,6 +122,7 @@ function defaultDependencies(): ProjectArchiveCommandDependencies {
     buildRepoArchiveS3Uri,
     buildProjectArchiveS3Uri,
     resolveLocalArchiveProjectPath,
+    resolvePrimaryRepoRoot,
     execFile: execFileAsync,
     removeDirectory: rm,
     processEnv: process.env,
@@ -181,7 +184,14 @@ async function listArchiveSnapshots(
   awsEnv: NodeJS.ProcessEnv,
   dependencies: ProjectArchiveCommandDependencies,
 ): Promise<ArchiveSnapshotEntry[]> {
-  const repoPrefix = `${dependencies.buildRepoArchiveS3Uri(s3Uri, repoRoot)}/`;
+  const remoteRepoRoot = await dependencies.resolvePrimaryRepoRoot(repoRoot, {
+    gitExecFile: dependencies.execFile,
+    env: awsEnv,
+  });
+  const repoPrefix = `${dependencies.buildRepoArchiveS3Uri(
+    s3Uri,
+    remoteRepoRoot,
+  )}/`;
   const { stdout } = await dependencies.execFile(
     'aws',
     ['s3', 'ls', repoPrefix],
@@ -201,7 +211,7 @@ async function listArchiveSnapshots(
         ...parsed,
         source: dependencies.buildProjectArchiveS3Uri(
           s3Uri,
-          repoRoot,
+          remoteRepoRoot,
           snapshotName,
         ),
         target: dependencies.resolveLocalArchiveProjectPath(
@@ -440,7 +450,13 @@ export function createProjectArchiveCommand(
               const sourceSummary =
                 appliedSources.length > 0
                   ? appliedSources.join(', ')
-                  : dependencies.buildRepoArchiveS3Uri(s3Uri, repoRoot);
+                  : dependencies.buildRepoArchiveS3Uri(
+                      s3Uri,
+                      await dependencies.resolvePrimaryRepoRoot(repoRoot, {
+                        gitExecFile: dependencies.execFile,
+                        env: awsEnv,
+                      }),
+                    );
 
               if (context.json) {
                 context.logger.json({

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- Resolve the primary git checkout root and use its basename for S3 archive prefixes when commands run from linked worktrees.
- Apply the same primary-root slug resolution to completion uploads and `oat project archive sync` downloads.
- Add coverage for linked-worktree slug resolution and bump the lockstep public package versions to 0.0.57.

## Root Cause

OAT built S3 archive paths from `basename(repoRoot)`. In managed linked worktrees, `repoRoot` is the temporary worktree path, so archive snapshots could be written under unstable prefixes like `sc-pinned-cryostat-af7a/projects` instead of the canonical checkout slug.

## Validation

- `pnpm --filter @open-agent-toolkit/cli exec vitest run src/commands/project/archive/archive-utils.test.ts src/commands/project/archive/index.test.ts`
- `pnpm --filter @open-agent-toolkit/cli type-check`
- `pnpm --filter @open-agent-toolkit/cli exec oxfmt --check src/commands/project/archive/archive-utils.ts src/commands/project/archive/index.ts src/commands/project/archive/archive-utils.test.ts src/commands/project/archive/index.test.ts`
- `pnpm release:validate`
- Push hook also passed `release:check-versions`, skill version validation, workspace `type-check`, `lint`, and `format`.
