### PR TITLE
fix: prefer archive.awsProfile config over shell AWS_PROFILE

### DIFF
--- a/.oat/repo/reference/project-summaries/20260430-aws-profile.md
+++ b/.oat/repo/reference/project-summaries/20260430-aws-profile.md
@@ -11,6 +11,8 @@ oat_summary_includes_revisions: ['p-rev1']
 
 # Summary: aws-profile
 
+> **Amendment (2026-05-02):** Decision #3 (non-clobbering precedence — config does not override parent shell env) was reversed in a follow-up PR after a real-world friction case where `AWS_PROFILE=voxmedia` in the calling shell silently overrode the repo's configured `archive.awsProfile=tkstang-artifact-sync` and the sync ran against the wrong account/bucket. The shipped precedence is now **flag > config > shell env**: explicit `archive.awsProfile` config is treated as deliberate, repo-scoped intent and clobbers ambient `AWS_PROFILE`. The rest of this summary describes the original 2026-04-30 design and is preserved as-is for historical context.
+
 ## Overview
 
 Before this project, the S3 archive sync that runs during `oat-project-complete` (and the standalone `oat project archive sync` command) used whatever ambient AWS credentials happened to be in the shell — there was no way to scope a different AWS profile or region per repo, and no way to override profile/region for a single run. This project added per-repo config keys and per-invocation CLI flags so users can route the archive sync through a specific AWS identity without exporting environment variables in their shell.

--- a/apps/oat-docs/docs/cli-utilities/config-and-local-state.md
+++ b/apps/oat-docs/docs/cli-utilities/config-and-local-state.md
@@ -60,7 +60,7 @@ Archive lifecycle settings live here as shared repo config:
 - `archive.awsProfile`
 - `archive.awsRegion`
 
-`archive.awsProfile` and `archive.awsRegion` are forwarded as `AWS_PROFILE` / `AWS_REGION` env vars into every `aws` spawn that runs during `oat-project-complete` and `oat project archive sync`. The per-invocation `oat project archive sync --profile <profile>` and `--region <region>` flags override the config for a single run; an `AWS_PROFILE` / `AWS_REGION` already set in the parent shell sits between the flag and the config in precedence (flag > shell env > config). Raw access keys (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) remain a shell-environment concern — there is no config plumbing for them.
+`archive.awsProfile` and `archive.awsRegion` are forwarded as `AWS_PROFILE` / `AWS_REGION` env vars into every `aws` spawn that runs during `oat-project-complete` and `oat project archive sync`, and they override any values already set in the parent shell — the repo's archive-scoped declaration wins so users don't have to remember to unset `AWS_PROFILE` per shell. The per-invocation `oat project archive sync --profile <profile>` and `--region <region>` flags then override the config for a single run, giving precedence `flag > config > shell env`. When neither flag nor config is set, the parent shell's `AWS_PROFILE` / `AWS_REGION` pass through unchanged. Raw access keys (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) remain a shell-environment concern — there is no config plumbing for them.
 
 Tool-pack installation state also lives here as shared repo config:
 

--- a/apps/oat-docs/docs/cli-utilities/configuration.md
+++ b/apps/oat-docs/docs/cli-utilities/configuration.md
@@ -114,17 +114,19 @@ With those values configured:
 - completion also copies `summary.md` into `<archive.summaryExportPath>/20260401-my-project.md`
 - `oat project archive sync` can later pull archive data back down from S3 and materialize the latest snapshot into the local bare archive path `.oat/projects/archived/<project>/`
 - `oat-wrap-up` can write tracked reports into `<archive.wrapUpExportPath>/YYYY-MM-DD-wrap-up-<label>.md`; if the key is unset, the skill uses `.oat/repo/reference/wrap-ups/`
-- every `aws` spawn (preflight `aws sts get-caller-identity`, `aws s3 ls`, `aws s3 sync`) inherits `AWS_PROFILE` / `AWS_REGION` from `archive.awsProfile` / `archive.awsRegion` when the parent shell does not already set them
+- every `aws` spawn (preflight `aws sts get-caller-identity`, `aws s3 ls`, `aws s3 sync`) runs with `AWS_PROFILE` / `AWS_REGION` set from `archive.awsProfile` / `archive.awsRegion` when configured, overriding any value already in the parent shell
 
 ### Credential resolution
 
 Profile and region resolve with the following precedence per `aws` invocation, highest first:
 
 1. CLI flag passed to `oat project archive sync` (`--profile <profile>`, `--region <region>`)
-2. The parent shell's existing `AWS_PROFILE` / `AWS_REGION` env vars
-3. The repo's shared `archive.awsProfile` / `archive.awsRegion` config
+2. The repo's shared `archive.awsProfile` / `archive.awsRegion` config
+3. The parent shell's existing `AWS_PROFILE` / `AWS_REGION` env vars
 
 If none of the three are present for a given var, OAT does not inject it — the AWS CLI's own resolution chain takes over.
+
+`archive.awsProfile` is treated as deliberate, OAT-archive-scoped intent: if the repo declares the identity it wants to archive under, that value wins over whatever profile happens to be in the calling shell. Use `--profile` for one-off overrides; clear `archive.awsProfile` (set it to an empty string) to fall back to shell `AWS_PROFILE`.
 
 The `oat project archive sync` flags only override for that single invocation:
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/project/archive/archive-utils.test.ts
+++ b/packages/cli/src/commands/project/archive/archive-utils.test.ts
@@ -753,7 +753,7 @@ describe('archive utils', () => {
       expect(env.AWS_PROFILE).toBe('parent-profile');
     });
 
-    it('preserves parent-process AWS_PROFILE when both parent env and config supply a value (parent env wins)', async () => {
+    it('clobbers parent-process AWS_PROFILE when config supplies a value (config wins)', async () => {
       const execFile = vi.fn(async () => ({ stdout: '', stderr: '' }));
 
       await ensureS3ArchiveAccess(
@@ -773,10 +773,10 @@ describe('archive utils', () => {
         (call) => call[0] === 'aws' && call[1][0] === '--version',
       );
       const env = versionCall?.[2]?.env as NodeJS.ProcessEnv;
-      expect(env.AWS_PROFILE).toBe('parent-profile');
+      expect(env.AWS_PROFILE).toBe('config-profile');
     });
 
-    it('preserves parent-process AWS_REGION when both parent env and config supply a value (parent env wins)', async () => {
+    it('clobbers parent-process AWS_REGION when config supplies a value (config wins)', async () => {
       const execFile = vi.fn(async () => ({ stdout: '', stderr: '' }));
 
       await ensureS3ArchiveAccess(
@@ -796,7 +796,7 @@ describe('archive utils', () => {
         (call) => call[0] === 'aws' && call[1][0] === '--version',
       );
       const env = versionCall?.[2]?.env as NodeJS.ProcessEnv;
-      expect(env.AWS_REGION).toBe('eu-west-2');
+      expect(env.AWS_REGION).toBe('us-east-1');
     });
 
     it('does not inject AWS_PROFILE when neither config nor parent env supplies one', async () => {

--- a/packages/cli/src/commands/project/archive/archive-utils.ts
+++ b/packages/cli/src/commands/project/archive/archive-utils.ts
@@ -30,20 +30,17 @@ export interface EnsureS3ArchiveAccessOptions {
   s3Uri?: string | null;
   syncOnComplete: boolean;
   /**
-   * Config-only fallback AWS profile (e.g., `archive.awsProfile`). This helper
-   * applies the value only when the parent env does not already provide
-   * `AWS_PROFILE`, matching discovery decision #3 ("config does not clobber an
-   * explicit shell env"). Callers that override via flags must layer the
-   * override into `dependencies.env` (the helper's second argument) —
-   * `buildAwsEnv` is non-clobbering and will not overwrite a value already
-   * present in the parent env. Passing a flag value through this option alone
-   * is not sufficient.
+   * AWS profile to apply for this archive op (typically resolved from
+   * `archive.awsProfile` config or a `--profile` flag). When non-empty, this
+   * value clobbers any `AWS_PROFILE` already present in the parent env: an
+   * explicit OAT-archive-scoped profile is treated as deliberate intent and
+   * wins over ambient shell state. An empty/unset value leaves the parent env
+   * untouched.
    */
   awsProfile?: string | null;
   /**
-   * Config-only fallback AWS region. Same non-clobbering semantics as
-   * `awsProfile`: flag-style overrides must be layered into
-   * `dependencies.env`, not passed through this option.
+   * AWS region to apply for this archive op. Same clobber-on-explicit-value
+   * semantics as `awsProfile`.
    */
   awsRegion?: string | null;
 }
@@ -68,13 +65,14 @@ export interface ArchiveProjectOnCompletionOptions {
   summaryExportPath?: string | null;
   /**
    * Config-only AWS profile (`archive.awsProfile`). The completion path has no
-   * flag override; this value is forwarded as-is into the env merge, where the
-   * parent env wins if it already supplies `AWS_PROFILE`. Discovery decision #3.
+   * flag override. When non-empty, this value clobbers any parent-env
+   * `AWS_PROFILE` — repo-scoped archive config is treated as deliberate intent
+   * and wins over ambient shell state.
    */
   awsProfile?: string | null;
   /**
-   * Config-only AWS region (`archive.awsRegion`). Same non-clobbering semantics
-   * as `awsProfile`.
+   * Config-only AWS region (`archive.awsRegion`). Same clobber-on-explicit-value
+   * semantics as `awsProfile`.
    */
   awsRegion?: string | null;
 }
@@ -129,23 +127,19 @@ function normalizeS3Uri(s3Uri: string): string {
 /**
  * Build the env passed to every `aws` spawn in this module.
  *
- * Non-clobbering merge: a non-empty value in `opts` is applied only when
- * `parentEnv` does not already provide that key (treating empty/whitespace
- * parent values as unset). If parent env has a non-empty value, it is left
- * untouched even when `opts` supplies a non-empty value. Callers that need
- * flag-style overrides must set the env entry themselves before calling this
- * helper. This matches discovery decision #3 — config does not clobber an
- * explicit shell env.
- *
- * An empty/whitespace value in `opts` is also treated as unset, and we never
- * inject a key when neither source supplies one — so the spawned process sees
- * the same "unset" signal it would have seen without this plumbing.
+ * Clobber-on-explicit-value merge: a non-empty value in `opts` overwrites the
+ * parent env entry. The merge treats an explicitly supplied profile/region as
+ * deliberate OAT-archive-scoped intent that wins over ambient shell state —
+ * setting `archive.awsProfile` (or passing `--profile`) means "use this for
+ * archive ops, regardless of what AWS_PROFILE is in the shell." Empty or
+ * whitespace-only values in `opts` are treated as unset and leave the parent
+ * env entry alone, so the AWS CLI's own resolution chain (incl. shell
+ * AWS_PROFILE) takes over when neither config nor flag has spoken.
  *
  * Exported as a package-internal helper so the archive sync command (which
- * also spawns `aws`) can layer flag/env/config precedence and produce the same
- * env shape without duplicating this logic. This symbol is **not** part of the
- * public package surface — keep usage limited to files inside
- * `commands/project/archive/`.
+ * also spawns `aws`) can produce the same env shape without duplicating this
+ * logic. This symbol is **not** part of the public package surface — keep
+ * usage limited to files inside `commands/project/archive/`.
  */
 export function buildAwsEnv(
   parentEnv: NodeJS.ProcessEnv,
@@ -153,20 +147,15 @@ export function buildAwsEnv(
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...parentEnv };
 
-  const parentHas = (key: 'AWS_PROFILE' | 'AWS_REGION'): boolean => {
-    const value = parentEnv[key];
-    return typeof value === 'string' && value.trim().length > 0;
-  };
-
   const profile =
     typeof opts.awsProfile === 'string' ? opts.awsProfile.trim() : '';
-  if (profile.length > 0 && !parentHas('AWS_PROFILE')) {
+  if (profile.length > 0) {
     env.AWS_PROFILE = profile;
   }
 
   const region =
     typeof opts.awsRegion === 'string' ? opts.awsRegion.trim() : '';
-  if (region.length > 0 && !parentHas('AWS_REGION')) {
+  if (region.length > 0) {
     env.AWS_REGION = region;
   }
 

--- a/packages/cli/src/commands/project/archive/index.test.ts
+++ b/packages/cli/src/commands/project/archive/index.test.ts
@@ -623,7 +623,7 @@ describe('oat project archive sync', () => {
       expect(process.exitCode).toBe(0);
     });
 
-    it('parent env beats config when no flag', async () => {
+    it('config beats parent env when no flag', async () => {
       const { command, ensureS3ArchiveAccess, execFile } = createHarness({
         config: {
           version: 1,
@@ -643,12 +643,48 @@ describe('oat project archive sync', () => {
 
       await runArchiveSyncCommand(command);
 
-      // ensureS3ArchiveAccess receives the config values; the helper internally
-      // applies non-clobbering merge so parent env wins.
+      // ensureS3ArchiveAccess receives the config values; the helper clobbers
+      // the parent env entry with the resolved value so config wins.
       expect(ensureS3ArchiveAccess).toHaveBeenCalledWith(
         expect.objectContaining({
           awsProfile: 'config-profile',
           awsRegion: 'config-region',
+        }),
+        expect.any(Object),
+      );
+
+      const lsCall = execFile.mock.calls.find(
+        (call) => call[1][0] === 's3' && call[1][1] === 'ls',
+      );
+      const syncCall = execFile.mock.calls.find(
+        (call) => call[1][0] === 's3' && call[1][1] === 'sync',
+      );
+      expect(lsCall?.[2]?.env).toMatchObject({
+        AWS_PROFILE: 'config-profile',
+        AWS_REGION: 'config-region',
+      });
+      expect(syncCall?.[2]?.env).toMatchObject({
+        AWS_PROFILE: 'config-profile',
+        AWS_REGION: 'config-region',
+      });
+      expect(process.exitCode).toBe(0);
+    });
+
+    it('parent env passes through when neither flag nor config is set', async () => {
+      const { command, ensureS3ArchiveAccess, execFile } = createHarness({
+        processEnv: {
+          PATH: '/usr/bin',
+          AWS_PROFILE: 'env-profile',
+          AWS_REGION: 'env-region',
+        },
+      });
+
+      await runArchiveSyncCommand(command);
+
+      expect(ensureS3ArchiveAccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          awsProfile: undefined,
+          awsRegion: undefined,
         }),
         expect.any(Object),
       );

--- a/packages/cli/src/commands/project/archive/index.ts
+++ b/packages/cli/src/commands/project/archive/index.ts
@@ -34,14 +34,19 @@ interface ArchiveSyncOptions {
 }
 
 /**
- * Resolve effective AWS profile/region for an archive sync invocation, honoring
- * the discovery decision #3 precedence: flag > parent shell env > config.
+ * Resolve effective AWS profile/region for an archive sync invocation.
+ *
+ * Precedence (highest first): `--profile`/`--region` flag > `archive.awsProfile`/`archive.awsRegion`
+ * config > parent shell `AWS_PROFILE`/`AWS_REGION` env. Repo config is treated
+ * as deliberate, OAT-archive-scoped intent and wins over ambient shell state —
+ * users who explicitly set `archive.awsProfile` for the repo don't have to
+ * remember to unset `AWS_PROFILE` in every shell. Flag still beats config for
+ * one-off overrides.
  *
  * The returned `env` is suitable for passing into every `aws` spawn in this
- * command. The returned `awsProfile`/`awsRegion` are forwarded to
- * `ensureS3ArchiveAccess` so its non-clobbering merge sees the same source of
- * truth (parent env wins inside the helper, so injecting the flag value into
- * the env up-front is what makes "flag > parent env" hold end-to-end).
+ * command. The returned `awsProfile`/`awsRegion` are also forwarded to
+ * `ensureS3ArchiveAccess` so its preflight `aws sts get-caller-identity` runs
+ * against the same identity.
  */
 function resolveSyncAwsEnv(
   processEnv: NodeJS.ProcessEnv,
@@ -61,30 +66,17 @@ function resolveSyncAwsEnv(
       ? options.region.trim()
       : undefined;
 
-  // Layer the flag onto the parent env BEFORE delegating to buildAwsEnv. The
-  // helper's non-clobbering rule treats parent env as authoritative, so this
-  // is how the flag wins over both parent env and config.
-  const effectiveParent: NodeJS.ProcessEnv = { ...processEnv };
-  if (flagProfile !== undefined) {
-    effectiveParent.AWS_PROFILE = flagProfile;
-  }
-  if (flagRegion !== undefined) {
-    effectiveParent.AWS_REGION = flagRegion;
-  }
-
   const configProfile = config.archive?.awsProfile;
   const configRegion = config.archive?.awsRegion;
 
-  // Forward the same precedence into `awsProfile`/`awsRegion` for downstream
-  // helpers: prefer flag, fall back to config. Parent env is *not* substituted
-  // here because callers will pass the returned `env` (which already has the
-  // flag layered onto a clone of the parent env) as `dependencies.env` to the
-  // helper, so `buildAwsEnv`'s non-clobbering rule preserves "flag > parent
-  // env > config" against `effectiveParent` rather than the raw `process.env`.
+  // Flag beats config; either is forwarded to buildAwsEnv, which clobbers the
+  // parent env entry with the resolved value. When neither flag nor config is
+  // set, awsProfile/awsRegion stay undefined and the parent env passes through
+  // untouched — letting the AWS CLI's own resolution chain take over.
   const awsProfile = flagProfile ?? configProfile ?? undefined;
   const awsRegion = flagRegion ?? configRegion ?? undefined;
 
-  const env = buildAwsEnv(effectiveParent, {
+  const env = buildAwsEnv(processEnv, {
     awsProfile,
     awsRegion,
   });

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- Reverses the non-clobbering AWS env precedence shipped in #67. When a repo sets `archive.awsProfile` / `archive.awsRegion`, that value now overrides any `AWS_PROFILE` / `AWS_REGION` inherited from the calling shell.
- New precedence per archive op: **`--profile`/`--region` flag > `archive.awsProfile`/`awsRegion` config > shell env**.
- Updates docs (`configuration.md`, `config-and-local-state.md`), inverts the two precedence tests in `archive-utils.test.ts` + `index.test.ts`, adds a passthrough test for "no flag, no config", and amends the original `aws-profile` project summary in `.oat/repo/reference/project-summaries/` with a reversal note.
- Lockstep public packages bumped 0.0.57 → 0.0.58.

## Motivation

Hit a real-world friction case: a shell with `AWS_PROFILE=voxmedia` silently overrode a repo's configured `archive.awsProfile=tkstang-artifact-sync`, causing `oat project archive sync` to run against the wrong account/bucket without warning. The previous model put the burden on the user to remember to `unset AWS_PROFILE` per shell.

`archive.awsProfile` is scoped specifically to OAT archive ops (not shell-wide), so treating it as deliberate, repo-scoped intent — and having it win over ambient shell state — matches what setting it in `oat.config` actually means.

## Test plan

- [x] `pnpm --filter @open-agent-toolkit/cli test` — 1417 passing
- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm format` — clean
- [x] `pnpm release:validate` — passes for all 5 public packages at 0.0.58
- [ ] Manual: `oat project archive sync` with `archive.awsProfile` set in oat.config and a different `AWS_PROFILE` in shell — confirm config wins
- [ ] Manual: same as above with `--profile` flag — confirm flag wins over both
- [ ] Manual: no flag, no config, only shell `AWS_PROFILE` — confirm shell env passes through