### PR TITLE
fix: rules fix for Copilot always-on rule activation

### DIFF
--- a/apps/oat-docs/docs/provider-sync/providers.md
+++ b/apps/oat-docs/docs/provider-sync/providers.md
@@ -25,6 +25,7 @@ description: 'Provider-specific path mappings for Claude, Cursor, Copilot, Gemin
     - Project: `.agents/skills` -> `.github/skills`, `.agents/agents` -> `.github/agents`, `.agents/rules` -> `.github/instructions`
     - User: `~/.agents/skills` -> `~/.copilot/skills`, `~/.agents/agents` -> `~/.copilot/agents`
     - Rule files render as `.github/instructions/*.instructions.md`
+    - Canonical always-on rules render with `applyTo: "**"` so Copilot activates them repo-wide; provider rules with exactly `applyTo: "**"` adopt back to `activation: always`
     - Comma-containing globs are not supported for Copilot rule sync because Copilot uses a comma-separated `applyTo` field
 
 === "Gemini"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/providers/copilot/rule-transform.test.ts
+++ b/packages/cli/src/providers/copilot/rule-transform.test.ts
@@ -48,7 +48,7 @@ activation: agent-requested
     );
   });
 
-  it('renders always activation without applyTo and round-trips to always', () => {
+  it('renders always activation with repo-wide applyTo and round-trips to always', () => {
     const canonical = `---
 description: Always apply
 activation: always
@@ -61,8 +61,43 @@ activation: always
       '.agents/rules/always-rule.md',
     );
 
-    expect(rendered).not.toContain('applyTo:');
+    expect(rendered).toContain('description: Always apply');
+    expect(rendered).toContain('applyTo: "**"');
     expect(parseCopilotRuleToCanonical(rendered)).toBe(canonical);
+  });
+
+  it('parses repo-wide applyTo as always activation', () => {
+    const provider = `---
+description: General rules
+applyTo: "**"
+---
+
+# General Rules`;
+
+    expect(parseCopilotRuleToCanonical(provider)).toBe(`---
+description: General rules
+activation: always
+---
+
+# General Rules`);
+  });
+
+  it('keeps non-repo-wide applyTo as glob activation', () => {
+    const provider = `---
+description: Frontend rules
+applyTo: src/**/*.tsx
+---
+
+# Frontend Rules`;
+
+    expect(parseCopilotRuleToCanonical(provider)).toBe(`---
+description: Frontend rules
+globs:
+  - src/**/*.tsx
+activation: glob
+---
+
+# Frontend Rules`);
   });
 
   it('rejects canonical comma-containing globs that Copilot cannot represent', () => {

--- a/packages/cli/src/providers/copilot/rule-transform.ts
+++ b/packages/cli/src/providers/copilot/rule-transform.ts
@@ -48,6 +48,10 @@ function parseApplyTo(value: unknown): string[] | undefined {
   return globs.length > 0 ? globs : undefined;
 }
 
+function isRepoWideApplyTo(globs: string[] | undefined): boolean {
+  return globs?.length === 1 && globs[0] === '**';
+}
+
 export function transformCanonicalToCopilotRule(
   canonicalContent: string,
   canonicalPath?: string,
@@ -64,9 +68,16 @@ export function transformCanonicalToCopilotRule(
             : {}),
           applyTo: rule.globs.join(','),
         }
-      : rule.description !== undefined
-        ? { description: rule.description }
-        : null;
+      : rule.activation === 'always'
+        ? {
+            ...(rule.description !== undefined
+              ? { description: rule.description }
+              : {}),
+            applyTo: '**',
+          }
+        : rule.description !== undefined
+          ? { description: rule.description }
+          : null;
 
   return appendGeneratedMarker(
     renderMarkdownWithFrontmatter(frontmatter, rule.body),
@@ -82,8 +93,8 @@ export function parseCopilotRuleToCanonical(providerContent: string): string {
   return renderCanonicalRuleMarkdown(
     {
       ...(description !== undefined ? { description } : {}),
-      ...(globs !== undefined ? { globs } : {}),
-      activation: globs ? 'glob' : 'always',
+      ...(globs !== undefined && !isRepoWideApplyTo(globs) ? { globs } : {}),
+      activation: globs && !isRepoWideApplyTo(globs) ? 'glob' : 'always',
     },
     body,
   );

--- a/packages/cli/src/providers/cursor/rule-transform.test.ts
+++ b/packages/cli/src/providers/cursor/rule-transform.test.ts
@@ -20,6 +20,7 @@ activation: always
     );
 
     expect(rendered).toContain('alwaysApply: true');
+    expect(rendered).not.toContain('globs:');
     expect(parseCursorRuleToCanonical(rendered)).toBe(canonical);
   });
 

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

Fixes the provider rule transform mismatch where OAT canonical always-on rules could either stay Cursor always-on or get deterministic Copilot activation, but not both from the same `.agents/rules/*.md` source.

This changes the Copilot adapter so canonical `activation: always` renders scoped Copilot instructions with `applyTo: "**"`, while Cursor continues to render the same canonical rule as `alwaysApply: true` with no `globs`. Copilot provider adoption now treats exactly `applyTo: "**"` as canonical `activation: always`; other `applyTo` values still adopt as `activation: glob`.

## Why

In downstream agent-instructions apply runs, repo-wide rules need to remain general/always-on in Cursor while also being explicit enough for Copilot scoped instructions to activate deterministically. Modeling repo-wide Copilot activation as canonical `activation: glob` with `globs: ["**"]` forced Cursor to degrade to a scoped rule shape (`alwaysApply: false` plus `globs`), which is not the intended canonical behavior.

## Changes

- Render Copilot always-on canonical rules with `applyTo: "**"`.
- Parse Copilot provider rules with exactly `applyTo: "**"` back to canonical `activation: always` without preserving a glob.
- Preserve existing Copilot glob behavior for non-`**` scopes and comma-containing glob validation.
- Add tests for Copilot always render/adoption, non-repo-wide glob adoption, and Cursor always-on output staying unscoped.
- Document the Copilot repo-wide `applyTo: "**"` behavior in provider sync docs.
- Rebase onto current `main` and bump the lockstep public package versions to `0.0.60` for the shipped CLI/docs change.

## Validation

- `pnpm run worktree:init`
- `pnpm --filter @open-agent-toolkit/cli exec vitest run src/providers/copilot/rule-transform.test.ts src/providers/cursor/rule-transform.test.ts src/providers/claude/rule-transform.test.ts`
- `pnpm --filter @open-agent-toolkit/cli lint`
- `pnpm --filter @open-agent-toolkit/cli type-check`
- `pnpm format`
- `pnpm release:validate`
- `git diff --check`
- Rebase fix validation: `pnpm release:validate` passed with `0.0.60`
- Pre-push hook after rebase: `pnpm release:check-versions`, skill version validation, full `pnpm type-check`, `pnpm lint`, and `pnpm format`
- GitHub Actions after rebase: `ci` passed, `release-dry-run` passed
