### PR TITLE
docs(skills): require ID + title in backlog-review output

### DIFF
--- a/.agents/skills/oat-pjm-review-backlog/SKILL.md
+++ b/.agents/skills/oat-pjm-review-backlog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-pjm-review-backlog
-version: 1.0.0
+version: 1.1.0
 description: Use when prioritizing the file-backed repo backlog or evaluating roadmap alignment. Produces value-effort ratings, dependency mapping, and execution recommendations.
 argument-hint: '[backlog-root] [--roadmap=<path>] [--output=<path>]'
 disable-model-invocation: true
@@ -17,6 +17,25 @@ Analyze the file-backed backlog under `.oat/repo/reference/backlog/` to produce 
 **OAT MODE: Backlog Review**
 
 **Purpose:** Review active backlog item files, evaluate roadmap alignment, and recommend a practical execution order.
+
+## Reference Format Convention
+
+Whenever a backlog item is referenced — in the written review document, in chat output, or in the inline summary at the end — it **must include both the ID and a human-readable title**. Bare IDs like `bl-281c` are not acceptable in user-facing output, because readers do not have a board lookup in front of them.
+
+Use one of these formats:
+
+- **Inline / prose:** `` `bl-281c` (control-plane state-read migration) ``
+- **Tables / lists:** `**bl-281c** — Control-plane state-read migration`
+- **Compact lists where space is tight (e.g., dependency graphs):** an ID-only token is acceptable **only if** a legend in the same section maps every ID to its title.
+
+This convention applies equally to:
+
+- The "Top recommended next actions" summary
+- Risks, gaps, and quick-wins callouts
+- Any chat-level commentary about specific items
+- All tables and item references in the written review document
+
+If a title is missing from frontmatter, derive a short noun phrase from the item filename or `## Description` heading rather than falling back to a bare ID.
 
 ## Progress Indicators (User-Facing)
 
@@ -162,6 +181,8 @@ After writing the review, provide:
 - Top 3 recommended next actions
 - Key risks or gaps discovered
 
+When listing specific items in this summary, follow the **Reference Format Convention** above — every backlog item must appear as `` `bl-XXXX` (human-readable title) `` (or the bold-with-em-dash variant in tables). Do not emit bare IDs.
+
 ## Success Criteria
 
 - Every active backlog item file has a value-effort rating with rationale
@@ -169,3 +190,4 @@ After writing the review, provide:
 - Parallel lanes and execution waves are actionable
 - Roadmap alignment gaps are surfaced when roadmap input is present
 - Output document follows the review template structure
+- Every user-facing reference to a backlog item pairs the ID with a human-readable title (per the Reference Format Convention)

--- a/.agents/skills/oat-pjm-review-backlog/references/backlog-review-template.md
+++ b/.agents/skills/oat-pjm-review-backlog/references/backlog-review-template.md
@@ -78,11 +78,18 @@ The backlog contains **{N} items** ({breakdown by section}) spanning {N} themes:
 Legend:  ──▶  hard dependency (must complete first)
          - -▶  soft dependency (beneficial but not required)
 
-{Render the full dependency graph here}
+{Render the full dependency graph here using bare IDs}
 
 {Group independent items at the bottom}
 {item} [independent]
 ```
+
+**ID legend** (every ID used above must appear here):
+
+| ID    | Title        |
+| ----- | ------------ |
+| {BNN} | {Item Title} |
+| ...   | ...          |
 
 ---
 
@@ -95,8 +102,13 @@ These are independent work streams that can be tackled concurrently without conf
 {Brief description of this work stream}
 
 ```
-{Item sequence with arrows showing internal ordering}
+{Item sequence with arrows showing internal ordering — bare IDs OK inside the diagram}
 ```
+
+**Items in this lane:**
+
+- **{BNN}** — {Title}
+- ...
 
 **Total estimated effort:** {Low/Medium/High}
 **Cross-lane dependencies:** {Any connections to other lanes}
@@ -132,10 +144,10 @@ These are independent work streams that can be tackled concurrently without conf
 
 ### How backlog items map to roadmap phases
 
-| Roadmap Phase | Status   | Backlog Items   | Notes   |
-| ------------- | -------- | --------------- | ------- |
-| {Phase name}  | {Status} | {BNN, BNN, ...} | {Notes} |
-| ...           | ...      | ...             | ...     |
+| Roadmap Phase | Status   | Backlog Items                            | Notes   |
+| ------------- | -------- | ---------------------------------------- | ------- |
+| {Phase name}  | {Status} | **{BNN}** — {Title}; **{BNN}** — {Title} | {Notes} |
+| ...           | ...      | ...                                      | ...     |
 
 ### Gaps: Roadmap items without backlog coverage
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- `oat-pjm-review-backlog` now requires every backlog reference in user-facing output (chat summaries, the inline recap at the end, and the written review) to pair the `bl-XXXX` ID with a human-readable title. Bare IDs left readers without a board lookup unable to interpret recommendations.
- Updated the review template so the dependency graph carries an ID legend, parallel lanes call out item titles explicitly, and the roadmap-alignment table uses `**bl-XXXX** — Title` instead of bare IDs.
- Bumped the skill `version: 1.0.0 → 1.1.0` and the lockstep public packages (`cli`, `control-plane`, `docs-config`, `docs-theme`, `docs-transforms`) `0.0.60 → 0.0.61` per the AGENTS.md release policy for `.agents/skills` changes.

## Test plan

- [x] `pnpm release:validate` passes for all five public packages.
- [ ] Run `oat-pjm-review-backlog` on the live backlog and confirm the inline summary uses `` `bl-XXXX` (title) `` formatting throughout.