### PR TITLE
Add subagent capability guidance to skill creators

### DIFF
--- a/.agents/skills/create-agnostic-skill/SKILL.md
+++ b/.agents/skills/create-agnostic-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-agnostic-skill
-version: 1.2.1
+version: 1.3.0
 description: Use when adding a reusable workflow skill for AI coding agents. Scaffolds a new .agents/skills skill using the Agent Skills open standard.
 argument-hint: '[skill-name]'
 disable-model-invocation: true
@@ -60,6 +60,7 @@ If not provided in arguments, ask for:
 - **Model invocation**: Should the agent be able to invoke this automatically? (default: no)
 - **User invocable**: (Claude Code only) Should this appear in the `/` menu? (default: yes)
 - **Tool restrictions**: (Claude Code only) Which tools should the skill be allowed to use?
+- **Delegation**: Will the skill dispatch subagents or require a fresh-context worker/reviewer? If yes, define the capability probe, authorization gate, fallback tier, and approval scope.
 - **Supporting files**: Does the skill need templates, scripts, or reference files?
 
 ### Step 2: Apply Progressive Disclosure
@@ -295,8 +296,61 @@ Do **not** hard-code a specific Codex question tool name in skill prose unless t
 
 **When NOT to:**
 
-- Autonomous/subagent skills — use argument defaults or flags to drive decisions instead of prompting mid-execution
+- Long-running autonomous skills after work has started — resolve required decisions in a pre-work gate, then lock the choice for the run
 - Questions with open-ended answers — just ask conversationally in the skill prose
+
+### Delegation and Subagent Capability
+
+Skills that dispatch subagents, reviewers, workers, or fresh-context helper sessions must define a pre-work capability model. Do not let generated skills assume delegation is available, silently downgrade because authorization is required, or ask repeated approval questions mid-run.
+
+**When to include this section:**
+
+- The skill uses provider subagents, task workers, reviewers, or multi-agent execution
+- The skill's quality depends on fresh context or isolated review/implementation
+- The skill has a fallback mode when delegation is unavailable
+
+**Required guidance for delegation-capable skills:**
+
+1. **Probe before work starts.** Check whether the host can dispatch the needed worker/reviewer and whether dispatch requires user authorization.
+2. **Separate capability states.** Report `available`, `authorization required`, or `not resolved`; do not treat authorization-required as unavailable.
+3. **Ask once when authorization is required.** Use a concise question that names the delegation scope for the run. Approval should cover the stated worker roles and phases; a decline should select the documented fallback.
+4. **Lock the tier.** Once selected, keep the execution mode for the run unless the user explicitly changes it.
+5. **Fail closed before side effects.** If delegation is required for correctness and authorization is unresolved, stop before edits, writes, external side effects, or long-running work.
+6. **Document fallback behavior.** If inline or single-agent execution is acceptable, explain when it applies. If it changes quality, artifact freshness, or review independence, say so.
+
+**Portable provider wording:**
+
+- Claude Code: use Task/subagent dispatch when available; if the skill benefits from structured prompts, include `AskUserQuestion` in `allowed-tools`.
+- Cursor: use the provider's explicit agent invocation or natural-language agent handoff when supported.
+- Codex: use multi-agent spawning when available; if the host requires explicit user authorization before spawning, ask before falling back.
+- Fallback: use inline/single-agent execution only when the user declines delegation or the runtime truly cannot dispatch the required agent.
+
+**Good pre-work pattern:**
+
+```markdown
+### Step 0.5: Capability Detection
+
+Before edits, writes, external side effects, or long-running work, detect whether the required helper agents are available.
+
+- Available without authorization → Tier 1: delegated execution.
+- Authorization required → ask once: "Authorize `{worker/reviewer}` delegation for this run?"
+  - Approved → Tier 1.
+  - Declined → Tier 2: documented fallback.
+- Not resolved / unsupported → Tier 2: documented fallback.
+
+Report:
+
+`Selected: Tier {1|2} — {Delegated|Fallback}; Reason: {available|authorized|user declined delegation|dispatch unavailable|required role unresolved}`
+
+Lock the selected tier for the run.
+```
+
+**Anti-patterns:**
+
+- Selecting inline fallback just because the user did not pre-mention subagents, when the skill itself requires delegation and authorization can be requested
+- Asking for authorization after implementation or review has already started
+- Re-asking for each phase when the first approval explicitly covered the run
+- Hiding fallback quality differences from the user
 
 ### Progress Feedback
 

--- a/.agents/skills/create-agnostic-skill/references/skill-template.md
+++ b/.agents/skills/create-agnostic-skill/references/skill-template.md
@@ -13,11 +13,12 @@ Adjust based on complexity—not all sections are required:
 5. **Arguments** - Parameters parsed from `$ARGUMENTS`
 6. **Prerequisites** - Required setup or context (if applicable)
 7. **Workflow/Steps** - Numbered steps using "Step 1, 2, 3..." naming
-8. **Quality Standards** - Checklist format for docs skills (if applicable)
-9. **Examples** - Both "Basic Usage" and "Conversational" styles
-10. **Reference** - Links to relevant documentation
-11. **Troubleshooting** - Common issues and solutions
-12. **Success Criteria** - Checklist of completion conditions
+8. **Capability Detection** - Required before work starts if the skill dispatches subagents/workers/reviewers
+9. **Quality Standards** - Checklist format for docs skills (if applicable)
+10. **Examples** - Both "Basic Usage" and "Conversational" styles
+11. **Reference** - Links to relevant documentation
+12. **Troubleshooting** - Common issues and solutions
+13. **Success Criteria** - Checklist of completion conditions
 
 ## Annotated Template
 
@@ -86,6 +87,24 @@ Parse from `$ARGUMENTS`:
 - **--optional-flag**: (optional) Description with default value noted
 
 ## Workflow
+
+<!-- Include this Step 0.5 only if the skill dispatches subagents, workers, reviewers, or fresh-context helpers. -->
+
+### Step 0.5: Capability Detection
+
+Before edits, writes, external side effects, or long-running work, detect whether required helper agents are available.
+
+- Available without authorization → Tier 1: delegated execution.
+- Authorization required → ask once: "Authorize `{worker/reviewer}` delegation for this run?"
+  - Approved → Tier 1.
+  - Declined → Tier 2: documented fallback.
+- Not resolved / unsupported → Tier 2: documented fallback.
+
+Report the selected tier and reason before starting work:
+
+`Selected: Tier {1|2} — {Delegated|Fallback}; Reason: {available|authorized|user declined delegation|dispatch unavailable|required role unresolved}`
+
+Lock the selected tier for the run unless the user explicitly changes it.
 
 ### Step 1: First Step Title
 

--- a/.agents/skills/create-oat-skill/SKILL.md
+++ b/.agents/skills/create-oat-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-oat-skill
-version: 1.2.1
+version: 1.3.0
 description: Use when adding a new oat-* workflow skill or lifecycle action. Scaffolds the skill with OAT conventions like mode assertions, progress banners, and project-root resolution.
 argument-hint: '[skill-name]'
 disable-model-invocation: true
@@ -51,6 +51,7 @@ If not provided, ask the user for:
 - Description using the create-agnostic-skill formula: `Use when [trigger condition]. [What it does for disambiguation].`
 - Whether this is `oat-*` (should be for this skill)
 - Whether it needs project context (`activeProject` in `.oat/config.local.json`) or is repo-level
+- Whether it dispatches OAT subagents/workers/reviewers, and if so which roles, what fallback is acceptable, and whether authorization covers the full run or only a narrower checkpoint
 
 ### Step 2: Draft the Skill Using the OAT Template
 
@@ -61,6 +62,7 @@ Use `.agents/skills/create-oat-skill/references/oat-skill-template.md` as the ba
 - `## Mode Assertion`
 - `## Progress Indicators (User-Facing)` (with separator banner)
 - `### Step 0: Resolve Active Project` (if project-scoped)
+- `### Step 0.5: Capability Detection and Tier Selection` (if the skill dispatches subagents/workers/reviewers)
 - `## Success Criteria`
 
 **Required frontmatter metadata:**
@@ -103,6 +105,19 @@ Use `.agents/skills/create-oat-skill/references/oat-skill-template.md` as the ba
   - Codex: use structured user-input tooling when available in the current host/runtime
   - Fallback: ask in plain conversational text
 - Do not hard-code a specific Codex question tool name in the skill text unless the host/runtime contract is guaranteed.
+
+**Subagent/worker availability (required when the skill delegates):**
+
+- Follow the delegation guidance from `.agents/skills/create-agnostic-skill/SKILL.md`.
+- Add a pre-work capability step before any edits, artifact writes, external side effects, test runs, or long-running work.
+- Distinguish `available`, `authorization required`, and `not resolved`; authorization-required is not the same as unavailable.
+- If authorization is required, ask once at skill start and state the approval scope:
+  - Which roles are authorized (for example, `oat-phase-implementer`, `oat-reviewer`, or generic workers)
+  - Whether approval applies to the whole run, one phase, one review, or one checkpoint
+  - What fallback is selected if the user declines
+- Lock the selected tier for the run unless the user explicitly changes execution mode.
+- Fail closed before side effects if delegation is required for correctness and authorization remains unresolved.
+- For Codex, mention multi-agent spawning generically. Do not pin a custom `agent_type` unless the role is guaranteed by the active host config or the skill instructs the agent how to fall back to built-in roles/self-contained prompts.
 
 ### Step 4: Create Files
 

--- a/.agents/skills/create-oat-skill/references/oat-skill-template.md
+++ b/.agents/skills/create-oat-skill/references/oat-skill-template.md
@@ -78,6 +78,37 @@ If `PROJECT_PATH` is missing/invalid:
 - Persist with `oat config set activeProject "$PROJECT_PATH"`.
 - TODO(back-compat): validate `oat config` exists on older target branches before relying on this snippet.
 
+<!-- Include this step only if the skill dispatches subagents, workers, reviewers, or fresh-context helpers. -->
+
+### Step 0.5: Capability Detection and Tier Selection
+
+Before edits, artifact writes, external side effects, test runs, or long-running work, detect whether required helper agents are available.
+
+Detection logic:
+
+- If the host can dispatch the required role(s) without extra authorization → Tier 1.
+- If the host can dispatch the required role(s) but requires user authorization, ask once before continuing:
+
+  ```
+  This skill normally delegates {implementation/review/analysis} to {role list}. Authorize delegated execution for this run?
+  ```
+
+  - Approved → Tier 1.
+  - Declined → Tier 2.
+
+- If the host cannot dispatch the required role(s), or a required role is unresolved → Tier 2.
+
+Report:
+
+```
+[preflight] Checking subagent availability…
+  → {role list}: {available | authorization required | not resolved}
+  → Selected: Tier {1 | 2} — {Subagents | Inline}
+  → Reason: {available without auth | authorized | user declined delegation | dispatch unavailable | required role unresolved}
+```
+
+Lock the selected tier for the run unless the user explicitly changes execution mode. If delegation is required for correctness and authorization is unresolved, stop before side effects instead of silently falling back.
+
 ### Step 1: {First Step}
 
 {Instructions…}

--- a/apps/oat-docs/docs/contributing/skills.md
+++ b/apps/oat-docs/docs/contributing/skills.md
@@ -21,6 +21,7 @@ Skill behavior is defined by frontmatter plus the process contract in each `SKIL
 - Keep prerequisites and expected artifacts concrete.
 - Spell out blocked vs allowed activities for state-advancing skills.
 - Define user-facing progress indicators for longer workflows.
+- Define a pre-work capability and authorization gate for skills that delegate to subagents, workers, or reviewers.
 - Keep output obligations explicit so downstream skills and users know what changed.
 
 ## Contract components
@@ -28,6 +29,7 @@ Skill behavior is defined by frontmatter plus the process contract in each `SKIL
 - Mode assertion (purpose, blocked/allowed activities)
 - Preconditions and required artifacts
 - User-facing progress indicator expectations
+- Delegation capability detection and fallback behavior, when the skill dispatches helper agents
 - Output obligations
 - Escalation/guardrail behavior
 
@@ -58,6 +60,21 @@ Skill behavior is defined by frontmatter plus the process contract in each `SKIL
 - Use `create-oat-skill` when the new skill belongs to an OAT lifecycle or maintenance flow.
 - Use `create-agnostic-skill` when you want a reusable workflow skill that is not OAT-specific.
 - Use existing lifecycle skills as examples for progress banners, prerequisites, and artifact updates.
+
+## Delegation-Capable Skills
+
+Skills that dispatch subagents, workers, reviewers, or fresh-context helper sessions need a capability model before work starts. Do not assume delegation is available, and do not silently downgrade just because the runtime needs user authorization.
+
+At minimum, the skill contract should:
+
+- Probe whether the host can dispatch the required helper role(s).
+- Distinguish `available`, `authorization required`, and `not resolved`.
+- Ask once at skill start when authorization is required, with the approval scope stated clearly.
+- Lock the selected tier for the run unless the user explicitly changes execution mode.
+- Stop before side effects if delegation is required for correctness and authorization remains unresolved.
+- Document the fallback path and any quality or independence tradeoff.
+
+Use `create-agnostic-skill` or `create-oat-skill` as the starting point; both include the current delegation guidance and optional capability-detection template.
 
 ## Reading project state
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- Add reusable delegation/subagent capability guidance to `create-agnostic-skill`.
- Extend the agnostic and OAT skill templates with an optional pre-work capability detection and tier-selection step.
- Document the delegation-capable skill contract in the public Writing Skills contributor page.
- Bump the changed skill versions and the lockstep public package versions to `0.0.69`.

## Validation

- `pnpm format`
- `pnpm oat:validate-skills`
- `pnpm build`
- `pnpm build:docs`
- `pnpm release:validate`
- Push hook: `release:check-versions`, `validate-skill-version-bumps`, `pnpm type-check`, `pnpm lint`, `pnpm format`