### PR TITLE
fix(cli): emit single-quoted YAML frontmatter from oat sync

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/providers/copilot/rule-transform.test.ts
+++ b/packages/cli/src/providers/copilot/rule-transform.test.ts
@@ -62,7 +62,7 @@ activation: always
     );
 
     expect(rendered).toContain('description: Always apply');
-    expect(rendered).toContain('applyTo: "**"');
+    expect(rendered).toContain("applyTo: '**'");
     expect(parseCopilotRuleToCanonical(rendered)).toBe(canonical);
   });
 

--- a/packages/cli/src/rules/canonical/render.ts
+++ b/packages/cli/src/rules/canonical/render.ts
@@ -21,7 +21,12 @@ export function renderMarkdownWithFrontmatter(
     return normalizedBody;
   }
 
-  const frontmatterYaml = YAML.stringify(frontmatter).trimEnd();
+  // singleQuote keeps generated YAML frontmatter aligned with oxfmt/Prettier
+  // formatting (singleQuote: true) so consumer repos don't see drift between
+  // `oat sync` output and their markdown formatter on each commit.
+  const frontmatterYaml = YAML.stringify(frontmatter, {
+    singleQuote: true,
+  }).trimEnd();
   return `---\n${frontmatterYaml}\n---\n\n${normalizedBody}`;
 }
 

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Problem

`oat sync` serializes generated rule frontmatter with the `yaml` library's
default quote style, which double-quotes any scalar that needs escaping —
e.g. `applyTo: "**"` (a leading `*` is YAML's alias indicator, so `**` must
be quoted).

Consumer repos that format markdown with oxfmt / Prettier (`singleQuote:
true`) rewrite that line to `applyTo: '**'` on every commit. The result is a
deadlock on a single line of every `.github/instructions/*.instructions.md`:

- Commit `'**'` → the formatter is happy, but `oat sync` reports drift (file ≠ generated).
- Commit `"**"` → `oat sync` is happy, but `oxfmt --check` fails in CI.

This is a generator bug, not a config preference: OAT's own Copilot
frontmatter template (`copilot-instruction.md`) and `rules-files.md` already
document single-quoted `applyTo`. The serializer was the only thing emitting
double quotes.

## Fix

Pass `{ singleQuote: true }` to `YAML.stringify` in the shared
`renderMarkdownWithFrontmatter`, so generated frontmatter matches both the
common formatter default and OAT's documented templates. Applied at the
shared render function, it covers Copilot instructions, canonical rules,
Claude rules, and Cursor rules consistently.

Parsing is quote-agnostic, so round-trips are unaffected and downstream
files still parse while mid-migration.

**Downstream effect:** the next `oat sync` in each consumer repo rewrites
existing `"**"` → `'**'` once; after that diff lands the file is stable
under both `oat sync` and the markdown formatter.

## Changes

- `render.ts` — `YAML.stringify(frontmatter, { singleQuote: true })`
- `copilot/rule-transform.test.ts` — assertion updated to expect `'**'`
- Five public packages bumped `0.1.0 → 0.1.1` in lockstep (ships CLI functionality)

## Verification

- `vitest` copilot transform: TDD red on test edit → green after fix
- Full CLI test suite: **1474 passed** (163 files)
- `type-check`, `lint` (oxlint): clean
- `release:validate`: passed for all 5 public packages
- `oxfmt --check` on edited files: clean