### PR TITLE
fix(skills): allow autonomous worktree bootstrap invocation

### DIFF
--- a/.agents/skills/oat-worktree-bootstrap-auto/SKILL.md
+++ b/.agents/skills/oat-worktree-bootstrap-auto/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: oat-worktree-bootstrap-auto
-version: 1.3.0
+version: 1.4.0
 description: Use when an orchestrator/subagent needs autonomous worktree bootstrap. Non-interactive companion to oat-worktree-bootstrap.
 argument-hint: '<branch-name> [--base <ref>] [--path <root>] [--baseline-policy <strict|allow-failing>]'
-disable-model-invocation: true
+disable-model-invocation: false
 user-invocable: false
 allowed-tools: Read, Write, Bash, Glob, Grep
 ---
@@ -11,6 +11,8 @@ allowed-tools: Read, Write, Bash, Glob, Grep
 # Autonomous Worktree Bootstrap
 
 Non-interactive worktree bootstrap for orchestrator and subagent execution flows. Creates or reuses a worktree, runs baseline checks, and reports structured status — all without user prompts.
+
+This skill is **model-invocable** (`disable-model-invocation: false`): orchestrators such as `oat-project-implement` invoke it programmatically when a parallel phase group needs autonomous worktree bootstrap. It is **not** user-invocable (`user-invocable: false`) — it has no interactive surface and is never offered as a slash command.
 
 > ⚠️ **When not to substitute.** This skill is the **only** supported mechanism for orchestrator-driven worktree creation in OAT skills. Host-native isolation primitives — Claude Code's `Agent({ isolation: "worktree" })`, Cursor's worktree-isolated agent invocations, and equivalents in other hosts — are **not** substitutes. They may use the primary repo's checkout (often `main`) as the base regardless of the caller's current branch, silently producing a worktree at the wrong base. OAT orchestrators dispatching mid-run from a feature branch MUST go through this skill with an explicit `--base` so the resulting worktree contains the orchestrator's prior commits.
 


### PR DESCRIPTION
## Summary

`oat-worktree-bootstrap-auto` declared `disable-model-invocation: true`. Combined with `user-invocable: false`, the helper was invocable by **nobody** — so `oat-project-implement` degraded declared parallel phase groups to sequential because the helper "is not model-invokable", even though the skill is explicitly the autonomous orchestrator/subagent companion.

## Changes

- **`disable-model-invocation: false`** on `oat-worktree-bootstrap-auto/SKILL.md` — orchestrators can now model-invoke it for parallel groups. The key is kept (not removed): `validate-oat-skills` requires it to be present. The skill stays `user-invocable: false`.
- Short `SKILL.md` note documenting that the skill is model-invocable but not user-invocable.
- Version bumps: `oat-worktree-bootstrap-auto` SKILL.md `1.3.0 -> 1.4.0`; lockstep public-package bump `0.1.2 -> 0.1.3` across all 5 public packages (bundled-skill asset change per `AGENTS.md` release policy).

## Verification

- `oat internal validate-oat-skills` -> OK (48 skills)
- `oat internal validate-skill-version-bumps --base-ref origin/main` -> OK (1 changed skill)
- `oat sync --scope project --dry-run` -> no drift
- `pnpm release:validate` -> passed for 5 public packages (all `0.1.3`)