### PR TITLE
feat: capture accepted design drift in OAT lifecycle artifacts

### DIFF
--- a/.agents/agents/oat-reviewer.md
+++ b/.agents/agents/oat-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: oat-reviewer
-version: 1.0.1
+version: 1.0.2
 description: Unified reviewer for OAT projects - mode-aware verification of requirements/design alignment and code quality. Writes review artifact to disk.
 tools: Read, Bash, Grep, Glob, Write
 color: yellow
@@ -31,6 +31,8 @@ Reviews catch issues before they ship:
 - Maintainability issues that slow future changes
 
 Your review artifact feeds into `oat-project-review-receive`, which converts findings into plan tasks for systematic gap closure.
+
+Some findings are artifact drift rather than implementation defects. If shipped implementation is defensible but `spec.md`, `design.md`, or `plan.md` is stale, frame the issue as artifact alignment and say which artifact should change. Do not require a code fix solely because the design artifact lagged behind implementation.
 
 ## Inputs
 
@@ -161,6 +163,11 @@ For each design decision relevant to scope:
    - Do endpoints match the design?
    - Are error responses as specified?
 
+4. **Artifact drift classification**
+   - If implementation diverges from design/spec/plan, decide whether the implementation is wrong or the artifact is stale.
+   - When the implementation is defensible, write the finding as stale-artifact alignment guidance instead of a code defect.
+   - Include enough rationale for `oat-project-review-receive` to convert the finding into an artifact-alignment task or explicit deferral.
+
 ### Step 6: Verify Code Quality
 
 This step applies to **code reviews** only.
@@ -204,6 +211,7 @@ Group findings by severity:
 - Missing error handling
 - Significant maintainability issues
 - Missing tests for important paths
+- Stale spec/design/plan artifact that conflicts with a defensible implementation and should be aligned before closeout
 
 **Minor** (fix if time permits)
 
@@ -211,6 +219,7 @@ Group findings by severity:
 - Style issues
 - Minor refactoring opportunities
 - Documentation gaps
+- Low-impact artifact wording drift where implementation is defensible and the stale wording is unlikely to mislead near-term work
 
 ### Step 8: Write Review Artifact
 

--- a/.agents/skills/oat-project-implement/SKILL.md
+++ b/.agents/skills/oat-project-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-implement
-version: 2.0.16
+version: 2.0.17
 description: Use when plan.md is ready for execution. Dispatches phase-level subagents with bounded fix loops; supports plan-declared parallel phase groups with worktree-isolated execution and ordered fan-in.
 argument-hint: '[--retry-limit <N>] [--dry-run]'
 disable-model-invocation: true
@@ -27,6 +27,9 @@ After every code commit and after every phase/review-fix completion, you MUST co
 
 **CRITICAL — Review boundaries require a committed artifact baseline.**
 Do not enter checkpoint review, final review, revise, or PR-final handoff with dirty core project artifacts (`discovery.md`, `spec.md`, `design.md`, `plan.md`, `implementation.md`, `state.md`, plus `.oat/state.md` when refreshed). If one of those boundaries is next and artifact bookkeeping is still uncommitted, stop and create the bookkeeping commit first.
+
+**CRITICAL — Intentional artifact divergence must be recorded.**
+If implementation intentionally diverges from `spec.md`, `design.md`, or `plan.md`, record the delta in `implementation.md` before the next phase/review boundary. Include what diverged, why it diverged, whether the implementation or original artifact is now source of truth, and any follow-up artifact updates or explicit deferral. Do not leave accepted design drift only in chat, a review artifact, or code comments; final summary generation depends on `implementation.md` preserving the delta.
 
 ## Progress Indicators (User-Facing)
 
@@ -557,6 +560,7 @@ For each phase `pNN` in the plan (or each phase in the current parallel group), 
      spec: {PROJECT_PATH}/spec.md
      implementation: {PROJECT_PATH}/implementation.md
      discovery: {PROJECT_PATH}/discovery.md
+   delta_recording: record any intentional divergence from spec/design/plan in implementation.md with rationale, source of truth, and follow-up artifact disposition
    commit_convention: {from plan.md header}
    workflow_mode: {from state.md or plan.md frontmatter}
    model_axis: {selected:<value> | inherited | not-applicable | host-auto; omit if unknown}
@@ -793,6 +797,14 @@ Append a new entry to the `## Orchestration Runs` section between the `<!-- orch
 #### Outstanding Items
 
 - {None | list of excluded phases with review paths and worktree paths}
+
+#### Artifact / Design Deltas
+
+Run-scoped snapshot only. The durable record is `## Deviations from Plan / Design`; consolidate any non-`None` entries there at the next phase boundary.
+
+| Task / Review                 | Source Artifact                     | Planned / Documented            | Actual / Accepted                      | Reason                       | Source of Truth           | Follow-up                                   |
+| ----------------------------- | ----------------------------------- | ------------------------------- | -------------------------------------- | ---------------------------- | ------------------------- | ------------------------------------------- |
+| {task_id/review_id or `None`} | {spec.md/design.md/plan.md section} | {planned behavior/taxonomy/API} | {actual shipped behavior/taxonomy/API} | {why divergence is accepted} | {implementation/artifact} | {artifact update task or explicit deferral} |
 ```
 
 Append only — never overwrite prior run entries.
@@ -886,6 +898,14 @@ When pausing:
   - Key files touched (paths)
   - Verification run
   - Notable decisions/deviations
+
+**Design/artifact deltas (required when present):**
+
+- If a completed task intentionally diverged from `spec.md`, `design.md`, or `plan.md`, update the `## Deviations from Plan / Design` table in `implementation.md`.
+- For existing project artifacts, treat any `## Deviations...` heading as the deviations section; migrate to the preferred `## Deviations from Plan / Design` heading and table shape when already touching the section.
+- Each delta must include: the affected source artifact/section, the planned/documented expectation, the actual shipped implementation, the reason the divergence is accepted, the current source of truth, and any follow-up artifact update task or explicit deferral.
+- If the implementation is now source of truth and the design/spec/plan is stale, write that directly. Do not treat the stale artifact as a no-op just because code is correct.
+- If no deltas exist for the phase, do not invent one; leave the table unchanged.
 
 **Bookkeeping commit (required):**
 

--- a/.agents/skills/oat-project-review-provide/SKILL.md
+++ b/.agents/skills/oat-project-review-provide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-review-provide
-version: 1.3.3
+version: 1.3.4
 description: Use when completed work in an active OAT project needs a quality gate before merge. Performs a lifecycle-scoped review after a task, phase, or full implementation, unlike oat-review-provide.
 disable-model-invocation: true
 user-invocable: true
@@ -14,6 +14,8 @@ Request and execute a code or artifact review for the current project scope.
 ## Purpose
 
 Produce an independent review artifact that verifies requirements/design alignment (mode-aware) and code quality.
+
+Reviewers should distinguish implementation defects from artifact drift. If code is defensible but `spec.md`, `design.md`, or `plan.md` is stale, frame the finding as artifact alignment rather than a required code change.
 
 ## Prerequisites
 
@@ -481,6 +483,12 @@ Build the "Review Scope" metadata for the reviewer:
 - Deferred Medium count: {DEFERRED_MEDIUM_COUNT}
 - Deferred Minor count: {DEFERRED_MINOR_COUNT}
   {DEFERRED_LEDGER}
+
+**Design Drift Review Guidance:**
+
+- If implementation differs from `spec.md`, `design.md`, or `plan.md`, decide whether the code should change or whether the artifact is stale.
+- Use artifact-alignment framing when shipped implementation is defensible and the lifecycle artifact should be updated.
+- Do not force a code-defect framing for accepted design drift; `oat-project-review-receive` can convert artifact drift into alignment tasks or explicit deferrals.
 ```
 
 ### Step 6: Execute Review (3-Tier Capability Model)

--- a/.agents/skills/oat-project-review-receive/SKILL.md
+++ b/.agents/skills/oat-project-review-receive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-review-receive
-version: 1.4.1
+version: 1.4.2
 description: Use when review findings from oat-project-review-provide need closure. Converts review artifacts into actionable plan tasks.
 disable-model-invocation: true
 user-invocable: true
@@ -52,6 +52,7 @@ When executing this skill, provide lightweight progress feedback so the user can
 - No re-reviewing
 - For `artifact` reviews: no converting findings into plan tasks
 - For `artifact` reviews: no deferring findings by default
+- No treating accepted design/code drift as a no-op; accepted drift must be converted to an artifact-alignment task or explicitly deferred, with an `implementation.md` note
 
 **ALLOWED Activities:**
 
@@ -167,6 +168,10 @@ For each finding, build a structured register entry:
 - Agent analysis (agree/disagree + why)
 - Recommendation (convert to task now vs defer with rationale)
 - Task Scope (`Large` | `Moderate` | `Minor` | `Negligible`)
+- Drift disposition, when applicable:
+  - `code_fix_required` — implementation should change
+  - `artifact_alignment_required` — shipped implementation is defensible; design/docs/plan should be aligned
+  - `explicit_deferral` — drift is accepted for now with a concrete rationale and follow-up trigger
 - For `artifact` reviews, use dispositions:
   - `resolve_in_artifact`
   - `rejected_with_rationale` (invalid/not applicable)
@@ -386,6 +391,10 @@ Add a note to implementation.md:
 
 **New tasks added:** {task_ids}
 
+**Design drift / artifact alignment notes:**
+
+- {finding_id}: {review found stale design/spec/plan relative to shipped implementation; why the implementation is accepted; source of truth; artifact-alignment task ID or explicit deferral}
+
 **Next:** Execute fix tasks via the `oat-project-implement` skill.
 
 After the fix tasks are complete:
@@ -399,6 +408,10 @@ After the fix tasks are complete:
 - If `{PROJECT_PATH}/implementation.md` exists, ensure it will resume correctly after this skill:
   - If `oat_current_task_id` is `null` (or points at already-completed work), set it to the **first newly-added review-fix task ID** (or the next incomplete task in plan order).
   - Update the Progress Overview table totals (tasks + completed) if they are present and depend on task counts.
+  - If any finding is resolved by accepting the shipped implementation and aligning stale artifacts instead of changing code, add an explicit review note under the current "Review Received" section and update `## Deviations from Plan / Design` when that table exists.
+    - For existing project artifacts, treat any `## Deviations...` heading as the deviations section; migrate to the preferred `## Deviations from Plan / Design` heading and table shape when already touching the section.
+    - The note must say the review found design/spec/plan drift, why the shipped implementation is accepted, which source is now authoritative, and which artifact-alignment task will update the stale artifact.
+    - If the artifact update is intentionally deferred, record the deferral rationale and follow-up trigger in `implementation.md`.
   - Update `{PROJECT_PATH}/state.md` frontmatter so routing/UI is accurate:
     - `oat_phase: implement`
     - `oat_phase_status: in_progress`
@@ -502,6 +515,13 @@ If any Medium is proposed for deferral:
 - Ask user explicitly for approval per finding.
 - If user declines deferral, convert that Medium to a fix task now.
 - If user approves deferral, record rationale in `implementation.md` under "Deferred Findings (Medium)".
+
+Design drift handling applies before Medium/Minor convenience deferrals:
+
+- If a review finding reveals that the design artifact is stale relative to a defensible implementation, do not treat this as a no-op.
+- Either convert the finding to an artifact-alignment task or record an explicit deferral.
+- In both cases, add an `implementation.md` review note so final summary generation can preserve the design delta.
+- The note must include what drift was found, why the implementation is accepted, whether implementation or artifact is source of truth, and the artifact task or deferral that will align the lifecycle record.
 
 Minor findings handling is scope-aware:
 

--- a/.agents/skills/oat-project-summary/SKILL.md
+++ b/.agents/skills/oat-project-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-summary
-version: 1.1.1
+version: 1.1.2
 description: Use when the user requests or confirms summarizing an active OAT project — e.g. "summarize the project", "generate the summary", "run oat-project-summary", or confirms a previously offered summary run. Do NOT auto-invoke when implementation completes. Generates summary.md from project artifacts as institutional memory.
 disable-model-invocation: false
 user-invocable: true
@@ -149,6 +149,8 @@ For each section, synthesize content from the relevant artifacts. Apply these ru
 
 **Grounding rule:** Prefer implementation.md outcomes over design.md plans. If the implementation diverged from the design, reflect what actually happened.
 
+**Design delta rule:** Populate `Design Deltas` from both direct implementation deviations and review-received design drift decisions recorded in `implementation.md`. A review finding may decide that shipped implementation is defensible and the artifact is stale; when `implementation.md` records that acceptance, carry it forward as a design delta with the rationale and follow-up artifact disposition.
+
 **Section omission rule:** If a section would have no meaningful content, omit it entirely (remove the heading). Do not leave empty sections or "N/A" placeholders.
 
 **Conciseness constraint (NFR3):** Target under 200 lines total. If a draft exceeds this, trim narrative sections (What Was Implemented, Notable Challenges) to essential points. Revision History entries: 2-3 sentences per round max.
@@ -157,18 +159,18 @@ For each section, synthesize content from the relevant artifacts. Apply these ru
 
 **Section sources:**
 
-| Section              | Primary Sources                                             |
-| -------------------- | ----------------------------------------------------------- |
-| Overview             | discovery.md initial request, spec.md problem statement     |
-| What Was Implemented | implementation.md task outcomes, plan.md phase structure    |
-| Key Decisions        | design.md decisions, implementation.md notes/decisions      |
-| Design Deltas        | implementation.md deviations table                          |
-| Notable Challenges   | implementation.md issues/blockers in task notes             |
-| Tradeoffs Made       | implementation.md decisions, design.md tradeoff sections    |
-| Integration Notes    | implementation.md notes about cross-cutting concerns        |
-| Revision History     | plan.md p-revN phases, implementation.md revision notes     |
-| Follow-up Items      | implementation.md deferred findings, plan.md deferred items |
-| Associated Issues    | state.md `associated_issues` field                          |
+| Section              | Primary Sources                                                        |
+| -------------------- | ---------------------------------------------------------------------- |
+| Overview             | discovery.md initial request, spec.md problem statement                |
+| What Was Implemented | implementation.md task outcomes, plan.md phase structure               |
+| Key Decisions        | design.md decisions, implementation.md notes/decisions                 |
+| Design Deltas        | implementation.md deviations table; review-received design drift notes |
+| Notable Challenges   | implementation.md issues/blockers in task notes                        |
+| Tradeoffs Made       | implementation.md decisions, design.md tradeoff sections               |
+| Integration Notes    | implementation.md notes about cross-cutting concerns                   |
+| Revision History     | plan.md p-revN phases, implementation.md revision notes                |
+| Follow-up Items      | implementation.md deferred findings, plan.md deferred items            |
+| Associated Issues    | state.md `associated_issues` field                                     |
 
 **For incremental updates (re-run):**
 

--- a/.codex/agents/oat-reviewer.toml
+++ b/.codex/agents/oat-reviewer.toml
@@ -28,6 +28,8 @@ Reviews catch issues before they ship:
 
 Your review artifact feeds into `oat-project-review-receive`, which converts findings into plan tasks for systematic gap closure.
 
+Some findings are artifact drift rather than implementation defects. If shipped implementation is defensible but `spec.md`, `design.md`, or `plan.md` is stale, frame the issue as artifact alignment and say which artifact should change. Do not require a code fix solely because the design artifact lagged behind implementation.
+
 ## Inputs
 
 You will be given a "Review Scope" block including:
@@ -157,6 +159,11 @@ For each design decision relevant to scope:
    - Do endpoints match the design?
    - Are error responses as specified?
 
+4. **Artifact drift classification**
+   - If implementation diverges from design/spec/plan, decide whether the implementation is wrong or the artifact is stale.
+   - When the implementation is defensible, write the finding as stale-artifact alignment guidance instead of a code defect.
+   - Include enough rationale for `oat-project-review-receive` to convert the finding into an artifact-alignment task or explicit deferral.
+
 ### Step 6: Verify Code Quality
 
 This step applies to **code reviews** only.
@@ -200,6 +207,7 @@ Group findings by severity:
 - Missing error handling
 - Significant maintainability issues
 - Missing tests for important paths
+- Stale spec/design/plan artifact that conflicts with a defensible implementation and should be aligned before closeout
 
 **Minor** (fix if time permits)
 
@@ -207,6 +215,7 @@ Group findings by severity:
 - Style issues
 - Minor refactoring opportunities
 - Documentation gaps
+- Low-impact artifact wording drift where implementation is defensible and the stale wording is unlikely to mislead near-term work
 
 ### Step 8: Write Review Artifact
 

--- a/.oat/repo/reference/current-state.md
+++ b/.oat/repo/reference/current-state.md
@@ -2,7 +2,7 @@
 
 This document is a birdseye view of where OAT is _right now_ in `open-agent-toolkit`: what exists, where it lives, how to run it, and what’s next.
 
-**Last Updated:** 2026-05-22 (`oat-project-split` shipped as a standalone workflow skill with discover/brainstorm integration hooks, coordination-only decomposition parents, flat child project scaffolding/seeding, persisted split-plan resume, coordination-aware list/dashboard behavior, and lockstep public packages bumped to 0.1.6. Recent runtime dispatch selection also landed: two-axis `model_axis`/`effort_axis` logging in structured `OAT Dispatch` blocks, Codex effort-specific implementer role variants, host-conditional review dispatch, and `oat status`/`oat init` recognition of generated Codex roles as managed. Final split review passed with only two deferred Minor follow-ups: post-run `validate-plan` semantics and active detected-parent conversion logging.)
+**Last Updated:** 2026-05-24 (Lifecycle skill guidance now preserves accepted design drift explicitly: `oat-project-implement` records intentional spec/design/plan deltas in `implementation.md`, `oat-project-review-receive` converts defensible implementation vs stale artifact findings into artifact-alignment tasks or explicit deferrals, and `oat-project-summary` carries those review-received decisions into Design Deltas. The implementation and summary templates now include structured plan/design delta guidance, review-provide/reviewer guidance frames defensible implementation drift as artifact alignment, and lockstep public packages are bumped to 0.1.7. Previous 2026-05-22 updates shipped `oat-project-split`, runtime dispatch selection, generated Codex role recognition, and final split-review closeout.)
 
 ## Canonical References
 

--- a/.oat/templates/implementation.md
+++ b/.oat/templates/implementation.md
@@ -165,13 +165,13 @@ Chronological log of implementation progress.
 
 ---
 
-## Deviations from Plan
+## Deviations from Plan / Design
 
-Document any deviations from the original plan.
+Document any intentional deviations from the original plan, spec, or design. Include accepted review findings where the shipped implementation is source of truth and a lifecycle artifact needs alignment.
 
-| Task | Planned | Actual | Reason |
-| ---- | ------- | ------ | ------ |
-| -    | -       | -      | -      |
+| Task / Review | Source Artifact | Planned / Documented | Actual / Accepted | Reason | Source of Truth | Follow-up |
+| ------------- | --------------- | -------------------- | ----------------- | ------ | --------------- | --------- |
+| -             | -               | -                    | -                 | -      | -               | -         |
 
 ## Test Results
 

--- a/.oat/templates/summary.md
+++ b/.oat/templates/summary.md
@@ -37,7 +37,8 @@ where decisions were made or changed during implementation.}
 <!-- Omit this section if there were no deviations from the original design. -->
 
 {Where the final result diverged from the original design and why.
-Pull from implementation.md deviations table.}
+Pull from implementation.md deviations table and review-received design drift notes.
+Include accepted cases where shipped implementation became source of truth and a stale lifecycle artifact needs alignment or was explicitly deferred.}
 
 ## Notable Challenges
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- require implementation and review-receive flows to record accepted spec/design/plan drift in `implementation.md`
- align summary and implementation templates so Design Deltas preserve review-received artifact drift decisions
- teach reviewer/review-provide guidance to frame defensible implementation drift as artifact alignment, plus sync the Codex reviewer role
- bump touched skill versions and lockstep public packages to `0.1.7`

## Validation

- `pnpm run cli -- sync --scope all`
- `pnpm format`
- `pnpm release:validate`
- `git diff --check`
- push hook: `release:check-versions`, skill version validation, `pnpm type-check`, `pnpm lint`, `pnpm format`
