### PR TITLE
fix: handle gitignored provider stray status

### DIFF
--- a/apps/oat-docs/docs/contributing/hooks-and-safety.md
+++ b/apps/oat-docs/docs/contributing/hooks-and-safety.md
@@ -14,6 +14,8 @@ The hook distinguishes two states so unmanaged files are not reported the same a
 - **Warning (managed drift or missing):** a manifest-tracked provider entry has drifted or is missing. Emits `oat: managed provider views are out of sync - run 'oat sync --scope project'` to stderr.
 - **Info (unmanaged strays only):** provider files exist inside a managed directory but are not in the manifest. Emits `oat: unmanaged provider files detected - run 'oat status --scope project' to review` to stderr. Not treated as drift.
 
+Gitignored provider files are intentionally skipped by status and hook checks, including entries ignored through `.gitignore`, `.git/info/exclude`, or standard Git exclude configuration.
+
 The hook is non-blocking: it never fails the commit, even when managed drift is detected.
 
 OAT installs the hook into Git's currently active hook directory. When a consumer repo keeps hooks in a repo-managed folder such as `.githooks/`, Git must be configured to use that path before install, or OAT must configure it during the hook prompt flow.

--- a/apps/oat-docs/docs/provider-sync/manifest-and-drift.md
+++ b/apps/oat-docs/docs/provider-sync/manifest-and-drift.md
@@ -51,6 +51,8 @@ Rendered rule files participate in the same drift states as other managed copies
 
 `oat init` and `oat status` can offer adoption of unmanaged provider entries into canonical `.agents`.
 
+Provider files ignored by Git are treated as intentionally local runtime files and are not reported as strays. This includes files covered by tracked `.gitignore`, repo-local `.git/info/exclude`, or other standard Git exclude mechanisms.
+
 For rules, adoption maps provider-native files back into `.agents/rules/*.md`:
 
 - Claude: `.claude/rules/*.md`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/drift/strays.test.ts
+++ b/packages/cli/src/drift/strays.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
@@ -24,6 +25,10 @@ async function seedProviderFile(
 ): Promise<void> {
   await mkdir(providerDir, { recursive: true });
   await writeFile(join(providerDir, name), content, 'utf8');
+}
+
+function initGitRepo(root: string): void {
+  execFileSync('git', ['init', '-q'], { cwd: root });
 }
 
 function createRuleMapping(
@@ -247,6 +252,76 @@ describe('detectStrays', () => {
       canonical: null,
       provider: 'cursor',
       providerPath: '.cursor/rules/stray-rule.mdc',
+      state: { status: 'stray' },
+    });
+  });
+
+  it('does not flag unmanaged provider files ignored by git info exclude', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-strays-'));
+    tempDirs.push(root);
+    initGitRepo(root);
+    await writeFile(
+      join(root, '.git', 'info', 'exclude'),
+      '.cursor/rules/superconductor-managed.mdc\n',
+      'utf8',
+    );
+    const providerDir = join(root, '.cursor', 'rules');
+    await seedProviderFile(providerDir, 'superconductor-managed.mdc');
+
+    const reports = await detectStrays(
+      'cursor',
+      providerDir,
+      createEmptyManifest(),
+      [],
+      createRuleMapping('.cursor/rules', '.mdc'),
+    );
+
+    expect(reports).toEqual([]);
+  });
+
+  it('does not flag unmanaged provider files ignored by tracked gitignore', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-strays-'));
+    tempDirs.push(root);
+    initGitRepo(root);
+    await writeFile(
+      join(root, '.gitignore'),
+      '.cursor/rules/local-only.mdc\n',
+      'utf8',
+    );
+    const providerDir = join(root, '.cursor', 'rules');
+    await seedProviderFile(providerDir, 'local-only.mdc');
+
+    const reports = await detectStrays(
+      'cursor',
+      providerDir,
+      createEmptyManifest(),
+      [],
+      createRuleMapping('.cursor/rules', '.mdc'),
+    );
+
+    expect(reports).toEqual([]);
+  });
+
+  it('reports non-ignored unmanaged provider files in a git repo', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-strays-'));
+    tempDirs.push(root);
+    initGitRepo(root);
+    const providerDir = join(root, '.cursor', 'rules');
+    await seedProviderFile(providerDir, 'local-rule.mdc');
+
+    const reports = await detectStrays(
+      'cursor',
+      providerDir,
+      createEmptyManifest(),
+      [],
+      createRuleMapping('.cursor/rules', '.mdc'),
+    );
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0]).toMatchObject({
+      canonical: null,
+      provider: 'cursor',
+      providerPath: '.cursor/rules/local-rule.mdc',
       state: { status: 'stray' },
     });
   });

--- a/packages/cli/src/drift/strays.ts
+++ b/packages/cli/src/drift/strays.ts
@@ -1,5 +1,7 @@
+import { execFile as execFileCallback } from 'node:child_process';
 import { readdir, readFile } from 'node:fs/promises';
 import { basename, join, relative, resolve } from 'node:path';
+import { promisify } from 'node:util';
 
 import { OAT_MARKER_PREFIX } from '@engine/markers';
 import type { CanonicalEntry } from '@engine/scanner';
@@ -10,6 +12,8 @@ import type { PathMapping } from '@providers/shared/adapter.types';
 import { canonicalRuleNameForProviderEntry } from '@rules/canonical';
 
 import type { DriftReport } from './drift.types';
+
+const execFile = promisify(execFileCallback);
 
 function inferContentType(providerDir: string): CanonicalEntry['type'] | null {
   const dirName = basename(toPosixPath(providerDir));
@@ -161,6 +165,36 @@ async function readProviderEntries(resolvedProviderDir: string) {
   }
 }
 
+function isGitExitCode(error: unknown, code: number): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    Number(error.code) === code
+  );
+}
+
+async function isGitIgnored(
+  pathRelative: string,
+  scopeRoot: string,
+): Promise<boolean> {
+  try {
+    await execFile(
+      'git',
+      ['check-ignore', '--quiet', '--no-index', '--', pathRelative],
+      { cwd: scopeRoot },
+    );
+    return true;
+  } catch (error) {
+    // Outside a Git repository, preserve the pre-existing behavior: files that
+    // are not manifest, canonical, or generated entries are still strays.
+    if (isGitExitCode(error, 1) || isGitExitCode(error, 128)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 export async function detectStrays(
   provider: string,
   providerDir: string,
@@ -190,6 +224,10 @@ export async function detectStrays(
     const providerPath = join(resolvedProviderDir, entry.name);
     const providerPathRelative = toScopeRelative(providerPath, scopeRoot);
     if (isManifestTracked(providerPathRelative, manifest)) {
+      continue;
+    }
+
+    if (await isGitIgnored(providerPathRelative, scopeRoot)) {
       continue;
     }
 

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

Fixes OAT provider stray detection so intentionally local provider files that Git ignores are not reported as unmanaged strays by `oat status` or the provider-status hook.

## Root Cause

`detectStrays` enumerated unmanaged provider entries directly from provider directories and classified any non-manifest/non-canonical file as `stray`. It did not consult Git ignore state, so local runtime files excluded through `.git/info/exclude`, `.gitignore`, or other Git ignore mechanisms still caused nonzero provider status.

## Changes

- Checks unmanaged provider candidates with `git check-ignore --quiet --no-index` before reporting them as strays.
- Preserves existing behavior for manifest-owned files and for non-Git contexts.
- Adds regression coverage for `.git/info/exclude`, tracked `.gitignore`, and non-ignored unmanaged Cursor rule files.
- Documents that gitignored provider files are intentionally skipped by status and hook checks.
- Bumps lockstep public packages to `0.1.9` for shipped CLI behavior.

## Validation

- `pnpm run worktree:init`
- `pnpm --filter @open-agent-toolkit/cli test -- src/drift/strays.test.ts src/commands/status/index.test.ts` (ran all CLI tests: 180 files, 1571 tests)
- `pnpm --filter @open-agent-toolkit/cli exec vitest run src/drift/strays.test.ts`
- `pnpm run cli -- status --scope project`
- `pnpm format`
- `pnpm lint`
- `pnpm --filter @open-agent-toolkit/cli build`
- `pnpm release:validate`
