### PR TITLE
feat: add worktree bootstrap with S3 archive sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "test": "turbo run test",
     "type-check": "turbo run type-check",
     "cli:link": "pnpm run build --filter=@open-agent-toolkit/cli && cd packages/cli && pnpm link --global",
-    "worktree:init": "pnpm install && pnpm hooks setup && pnpm run build && pnpm run cli -- sync --scope project"
+    "projects:sync-archived-from-s3": "bash scripts/sync-archived-projects-from-s3.sh",
+    "worktree:init": "bash scripts/worktree/init.sh",
+    "worktree:validate": "bash scripts/worktree/validate.sh"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/scripts/sync-archived-projects-from-s3.sh
+++ b/scripts/sync-archived-projects-from-s3.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Sync archived OAT projects from S3 into .oat/projects/archived/.
+#
+# Completed projects upload to S3 on another machine (or the main worktree) via
+# oat-project-complete. Worktree init copies archived projects from the main
+# checkout only — this script fills gaps for archives that exist on S3 but not
+# locally (other machines, or archives completed after the last local copy).
+#
+# Delegates to the OAT CLI: oat project archive sync
+# Requires archive.s3Uri in .oat/config.json and AWS credentials (see
+# archive.awsProfile / archive.awsRegion).
+#
+# Usage:
+#   scripts/sync-archived-projects-from-s3.sh
+#     Sync the latest remote snapshot for every archived project.
+#
+#   scripts/sync-archived-projects-from-s3.sh <project-name>
+#     Sync one project (matches slug or YYYYMMDD-slug snapshot prefix).
+#
+#   scripts/sync-archived-projects-from-s3.sh --dry-run [project-name]
+#     Preview what would download without writing files.
+#
+#   scripts/sync-archived-projects-from-s3.sh --force <project-name>
+#     Replace the local archive even when the snapshot name already matches.
+#
+#   scripts/sync-archived-projects-from-s3.sh --warn-only [args...]
+#     Print warnings and exit 0 on failure (for worktree init; does not abort bootstrap).
+#
+# Examples:
+#   pnpm run projects:sync-archived-from-s3
+#   pnpm run projects:sync-archived-from-s3 -- inbox-noop-llm-guard
+#   pnpm run projects:sync-archived-from-s3 -- --dry-run
+
+set -euo pipefail
+
+warn_only=0
+
+warn() {
+  echo "warning: $*" >&2
+}
+
+fail_or_warn() {
+  if [[ "$warn_only" -eq 1 ]]; then
+    warn "$*"
+    exit 0
+  fi
+  echo "error: $*" >&2
+  exit 1
+}
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root"
+
+project_name=""
+oat_args=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --warn-only)
+      warn_only=1
+      ;;
+    --dry-run | --force)
+      oat_args+=("$arg")
+      ;;
+    --help | -h)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*)
+      fail_or_warn "unknown option: $arg"
+      ;;
+    *)
+      if [[ -n "$project_name" ]]; then
+        fail_or_warn "unexpected extra argument: $arg"
+      fi
+      project_name="$arg"
+      ;;
+  esac
+done
+
+# Prefer the locally-built CLI so worktrees don't depend on a globally
+# linked `oat` binary. Falls back to `oat` on PATH for environments where
+# `pnpm run cli` is unavailable (e.g., post-clean repo states).
+oat_cli=(pnpm run --silent cli --)
+if ! pnpm --version >/dev/null 2>&1; then
+  if command -v oat >/dev/null 2>&1; then
+    oat_cli=(oat)
+  else
+    fail_or_warn "neither pnpm nor oat CLI is available on PATH"
+  fi
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  fail_or_warn "aws CLI not found on PATH (required for archive sync)"
+fi
+
+s3_uri="$("${oat_cli[@]}" config get archive.s3Uri 2>/dev/null || true)"
+if [[ -z "$s3_uri" ]]; then
+  fail_or_warn "archive.s3Uri is not configured in .oat/config.json"
+fi
+
+echo "Syncing archived projects from S3"
+echo "  s3: ${s3_uri}"
+if [[ -n "$project_name" ]]; then
+  echo "  project: ${project_name}"
+else
+  echo "  project: (all — latest snapshot per slug)"
+fi
+
+if [[ ${#oat_args[@]} -gt 0 ]]; then
+  echo "  options: ${oat_args[*]}"
+fi
+
+sync_cmd=("${oat_cli[@]}" project archive sync)
+if [[ ${#oat_args[@]} -gt 0 ]]; then
+  sync_cmd+=("${oat_args[@]}")
+fi
+if [[ -n "$project_name" ]]; then
+  sync_cmd+=("$project_name")
+fi
+
+if ! "${sync_cmd[@]}"; then
+  if [[ -n "$project_name" ]]; then
+    fail_or_warn "S3 archived-project sync failed for ${project_name} (profile, auth, or network)"
+  else
+    fail_or_warn "S3 archived-project sync failed (profile, auth, or network)"
+  fi
+fi

--- a/scripts/worktree/init.sh
+++ b/scripts/worktree/init.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Bootstrap a git worktree for OAT development.
+#
+# Copies local-only files from the main worktree (env, config.local.json,
+# MCP configs, local + archived projects), then fills gaps from S3 for
+# archived projects that exist on other machines. Finally installs deps,
+# builds, syncs OAT localPaths into the worktree, and refreshes provider
+# views via `oat sync`.
+#
+# Idempotent — safe to re-run in an existing worktree.
+#
+# Usage:
+#   pnpm run worktree:init
+#   SKIP_S3_ARCHIVE_SYNC=1 pnpm run worktree:init   # skip remote archive sync
+
+set -euo pipefail
+
+current_root="$(git rev-parse --show-toplevel)"
+common_git_dir="$(git rev-parse --path-format=absolute --git-common-dir)"
+main_root="$(cd "${common_git_dir}/.." && pwd -P)"
+
+copy_file() {
+  local src="$1"
+  local dest="$2"
+
+  if [[ ! -f "$src" ]]; then
+    echo "skip (missing): ${src}"
+    return 0
+  fi
+
+  if [[ "$src" == "$dest" ]]; then
+    echo "skip (already present): ${dest}"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$dest")"
+  cp "$src" "$dest"
+  echo "copied: ${dest#"${current_root}/"}"
+}
+
+copy_env_files() {
+  while IFS= read -r -d '' src; do
+    local rel_path="${src#"${main_root}/"}"
+    local dest="${current_root}/${rel_path}"
+    copy_file "$src" "$dest"
+  done < <(
+    find "$main_root" -type f \
+      \( -name ".env" -o -name ".env.local" -o -name ".env.*.local" \) \
+      -not -path "*/.git/*" \
+      -not -path "*/node_modules/*" \
+      -not -path "*/.turbo/*" \
+      -not -path "*/dist/*" \
+      -not -path "*/build/*" \
+      -not -path "*/.worktrees/*" \
+      -not -path "*/.claude/worktrees/*" \
+      -print0
+  )
+}
+
+copy_directory_tree() {
+  local rel_path="$1"
+  local src="${main_root}/${rel_path}"
+  local dest="${current_root}/${rel_path}"
+
+  if [[ ! -d "$src" ]]; then
+    echo "skip (missing): ${rel_path}"
+    return 0
+  fi
+
+  if [[ "$src" == "$dest" ]]; then
+    echo "skip (already present): ${rel_path}"
+    return 0
+  fi
+
+  mkdir -p "$dest"
+  cp -R "${src}/." "${dest}/"
+  echo "copied: ${rel_path}"
+}
+
+copy_matching_files() {
+  local pattern_args=("$@")
+
+  while IFS= read -r -d '' src; do
+    local rel_path="${src#"${main_root}/"}"
+    local dest="${current_root}/${rel_path}"
+    copy_file "$src" "$dest"
+  done < <(
+    find "$main_root" \
+      -path "*/.git" -prune -o \
+      -path "*/node_modules" -prune -o \
+      -path "*/.turbo" -prune -o \
+      -path "*/dist" -prune -o \
+      -path "*/build" -prune -o \
+      -path "*/.worktrees" -prune -o \
+      -path "*/.claude/worktrees" -prune -o \
+      -type f \( "${pattern_args[@]}" \) \
+      -print0
+  )
+}
+
+echo "main worktree: ${main_root}"
+echo "target worktree: ${current_root}"
+
+echo "copying local environment files from main worktree"
+copy_env_files
+
+echo "copying local config files from main worktree"
+copy_file "${main_root}/.oat/config.local.json" "${current_root}/.oat/config.local.json"
+copy_matching_files \
+  -name ".mcp.json" \
+  -o -path "*/.claude/settings.local.json" \
+  -o -path "*/.cursor/mcp.json"
+
+echo "copying local and archived projects from main worktree"
+copy_directory_tree ".oat/projects/local"
+copy_directory_tree ".oat/projects/archived"
+
+echo "installing dependencies"
+pnpm install
+
+echo "configuring git hooks"
+pnpm run hooks setup
+
+# Build before any `pnpm run cli` call. Workspace packages (e.g.,
+# @open-agent-toolkit/control-plane) export from dist/ via package.json
+# `main`, so tsx cannot resolve them until they are built.
+echo "building workspace"
+pnpm run build
+
+if [[ "${SKIP_S3_ARCHIVE_SYNC:-}" == "1" ]]; then
+  echo "skip S3 archived-project sync: SKIP_S3_ARCHIVE_SYNC=1"
+else
+  echo "syncing archived projects from S3 (cross-machine archives)"
+  bash "${current_root}/scripts/sync-archived-projects-from-s3.sh" --warn-only
+fi
+
+if [[ "$current_root" != "$main_root" ]]; then
+  echo "syncing OAT local paths into worktree"
+  pnpm run --silent cli -- local sync "$current_root"
+else
+  echo "skip local path sync: already in main worktree"
+fi
+
+echo "syncing OAT canonical content to provider views"
+pnpm run --silent cli -- sync

--- a/scripts/worktree/validate.sh
+++ b/scripts/worktree/validate.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Worktree validation gate.
+#
+# Runs the same checks CI runs locally so contributors can confirm a
+# worktree is ready to push. Fails if the worktree is dirty before or
+# after validation (catches generators that leave uncommitted output).
+#
+# Usage:
+#   pnpm run worktree:validate
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+run_step() {
+  local label="$1"
+  shift
+
+  echo "==> ${label}"
+  "$@"
+}
+
+assert_clean_worktree() {
+  local phase="$1"
+  local status
+
+  status="$(git status --short)"
+  if [[ -n "$status" ]]; then
+    echo "worktree is not clean ${phase}:"
+    echo "$status"
+    exit 1
+  fi
+}
+
+assert_clean_worktree "before validation"
+run_step "build" pnpm run build
+run_step "lint" pnpm run lint
+run_step "type-check" pnpm run type-check
+run_step "format check" pnpm run format
+run_step "test" pnpm run test
+
+assert_clean_worktree "after validation"
+echo "worktree validation passed"


### PR DESCRIPTION
## Summary

- New `scripts/worktree/init.sh` replaces the inline `pnpm run worktree:init` chain. Copies local-only files (env, `.oat/config.local.json`, MCP configs, `.oat/projects/{local,archived}`) from the main worktree, then fills gaps from S3 for archived projects completed on other machines, then installs / configures hooks / builds / syncs OAT `localPaths` / refreshes provider views.
- New `scripts/sync-archived-projects-from-s3.sh` wraps `oat project archive sync` with a `--warn-only` mode so worktree bootstrap doesn't abort on auth/network gaps. Also usable standalone via `pnpm run projects:sync-archived-from-s3` for ad-hoc backfill.
- New `scripts/worktree/validate.sh` runs the clean-tree + build/lint/type-check/format/test gate (clean assertion on both sides catches generators that leave uncommitted output).
- Three new `package.json` scripts: `worktree:init`, `worktree:validate`, `projects:sync-archived-from-s3`. The existing `worktree:init` is replaced.

## Motivation

Lifecycle skills like `oat-wrap-up` depend on the local archive directory being current — but archives completed on other machines only exist in S3 until someone runs `oat project archive sync`. This bundles the sync into worktree bootstrap so the local view stays whole without a manual step, and adds the standalone script for the cases where you want to refresh mid-session.

Adapted from sibling tooling in the Stoa repo, with OAT-specific adaptations: uses `pnpm run cli --` rather than a global `oat` (so worktrees don't depend on a globally-linked CLI), and builds before invoking the CLI because workspace packages export from `dist/` via `package.json#main`.

## Test plan

- [x] `bash -n` syntax check on all three scripts
- [x] `pnpm run projects:sync-archived-from-s3 -- --dry-run` lists 18 S3 archives
- [x] `pnpm run projects:sync-archived-from-s3` hydrated 18 archived projects into `.oat/projects/archived/`
- [ ] Reviewer: run `pnpm run worktree:init` in a fresh worktree and confirm clean exit
- [ ] Reviewer: run `pnpm run worktree:validate` and confirm gate passes