### PR TITLE
fix: accept trailing commas in config files

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",
@@ -46,6 +46,7 @@
     "@open-agent-toolkit/control-plane": "workspace:*",
     "chalk": "^5.6.2",
     "commander": "^12.1.0",
+    "jsonc-parser": "3.2.1",
     "ora": "^9.0.0",
     "yaml": "2.8.2",
     "zod": "^3.25.76"

--- a/packages/cli/src/config/json.ts
+++ b/packages/cli/src/config/json.ts
@@ -1,0 +1,46 @@
+import {
+  parse as parseJsonc,
+  printParseErrorCode,
+  type ParseError,
+  type ParseOptions,
+} from 'jsonc-parser';
+
+const JSON_CONFIG_PARSE_OPTIONS: ParseOptions = {
+  allowTrailingComma: true,
+  disallowComments: true,
+};
+
+export function parseJsonConfig(raw: string, configPath: string): unknown {
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(raw, errors, JSON_CONFIG_PARSE_OPTIONS) as unknown;
+
+  if (errors.length > 0) {
+    const details = errors
+      .map((error) => formatParseError(raw, error))
+      .join('; ');
+    throw new SyntaxError(
+      `Config at ${configPath} is not valid JSON: ${details}`,
+    );
+  }
+
+  return parsed;
+}
+
+function formatParseError(raw: string, error: ParseError): string {
+  const location = offsetToLineColumn(raw, error.offset);
+  return `${printParseErrorCode(error.error)} at ${location.line}:${location.column}`;
+}
+
+function offsetToLineColumn(
+  raw: string,
+  offset: number,
+): { line: number; column: number } {
+  const prefix = raw.slice(0, offset);
+  const lines = prefix.split('\n');
+  const lastLine = lines[lines.length - 1] ?? '';
+
+  return {
+    line: lines.length,
+    column: lastLine.length + 1,
+  };
+}

--- a/packages/cli/src/config/oat-config.test.ts
+++ b/packages/cli/src/config/oat-config.test.ts
@@ -78,6 +78,57 @@ describe('oat-config', () => {
     });
   });
 
+  it('accepts trailing commas in shared, local, and user config files', async () => {
+    const repoRoot = await createRepoRoot();
+    const userConfigDir = await mkdtemp(join(tmpdir(), 'oat-user-config-'));
+    tempDirs.push(userConfigDir);
+
+    await writeFile(
+      join(repoRoot, '.oat', 'config.json'),
+      `{
+  "version": 1,
+  "worktrees": { "root": ".worktrees", },
+  "localPaths": [".env",],
+}
+`,
+      'utf8',
+    );
+    await writeFile(
+      join(repoRoot, '.oat', 'config.local.json'),
+      `{
+  "version": 1,
+  "activeIdea": "repo-idea",
+  "workflow": { "designMode": "draft", },
+}
+`,
+      'utf8',
+    );
+    await writeFile(
+      join(userConfigDir, 'config.json'),
+      `{
+  "version": 1,
+  "activeIdea": "user-idea",
+}
+`,
+      'utf8',
+    );
+
+    await expect(readOatConfig(repoRoot)).resolves.toEqual({
+      version: 1,
+      worktrees: { root: '.worktrees' },
+      localPaths: ['.env'],
+    });
+    await expect(readOatLocalConfig(repoRoot)).resolves.toEqual({
+      version: 1,
+      activeIdea: 'repo-idea',
+      workflow: { designMode: 'draft' },
+    });
+    await expect(readUserConfig(userConfigDir)).resolves.toEqual({
+      version: 1,
+      activeIdea: 'user-idea',
+    });
+  });
+
   it('normalizes archive.awsProfile and archive.awsRegion (trim, drop empty, ignore non-string)', async () => {
     const repoRoot = await createRepoRoot();
     const configPath = join(repoRoot, '.oat', 'config.json');

--- a/packages/cli/src/config/oat-config.ts
+++ b/packages/cli/src/config/oat-config.ts
@@ -5,6 +5,8 @@ import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { atomicWriteJson, dirExists, fileExists } from '@fs/io';
 import { normalizeToPosixPath } from '@fs/paths';
 
+import { parseJsonConfig } from './json';
+
 export interface OatDocumentationConfig {
   root?: string;
   tooling?: string;
@@ -521,7 +523,7 @@ export async function readOatConfig(repoRoot: string): Promise<OatConfig> {
 
   try {
     const raw = await readFile(configPath, 'utf8');
-    return normalizeOatConfig(JSON.parse(raw));
+    return normalizeOatConfig(parseJsonConfig(raw, configPath));
   } catch (error) {
     if (isMissingFileError(error)) {
       return { ...DEFAULT_OAT_CONFIG };
@@ -538,7 +540,7 @@ export async function readOatLocalConfig(
 
   try {
     const raw = await readFile(configPath, 'utf8');
-    return normalizeOatLocalConfig(repoRoot, JSON.parse(raw));
+    return normalizeOatLocalConfig(repoRoot, parseJsonConfig(raw, configPath));
   } catch (error) {
     if (isMissingFileError(error)) {
       return { ...DEFAULT_OAT_LOCAL_CONFIG };
@@ -655,7 +657,7 @@ export async function readUserConfig(
 
   try {
     const raw = await readFile(configPath, 'utf8');
-    return normalizeUserConfig(JSON.parse(raw));
+    return normalizeUserConfig(parseJsonConfig(raw, configPath));
   } catch (error) {
     if (isMissingFileError(error)) {
       return { ...DEFAULT_USER_CONFIG };

--- a/packages/cli/src/config/sync-config.test.ts
+++ b/packages/cli/src/config/sync-config.test.ts
@@ -60,6 +60,30 @@ describe('loadSyncConfig', () => {
     });
   });
 
+  it('loads config with trailing commas', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oat-config-'));
+    tempDirs.push(root);
+    const configPath = join(root, '.oat', 'sync', 'config.json');
+    await mkdir(join(root, '.oat', 'sync'), { recursive: true });
+    await writeFile(
+      configPath,
+      `{
+  "version": 1,
+  "defaultStrategy": "copy",
+  "providers": {
+    "cursor": { "enabled": true, },
+  },
+}
+`,
+      'utf8',
+    );
+
+    const config = await loadSyncConfig(configPath);
+
+    expect(config.defaultStrategy).toBe('copy');
+    expect(config.providers.cursor).toEqual({ enabled: true });
+  });
+
   it('merges per-provider overrides', async () => {
     const root = await mkdtemp(join(tmpdir(), 'oat-config-'));
     tempDirs.push(root);

--- a/packages/cli/src/config/sync-config.ts
+++ b/packages/cli/src/config/sync-config.ts
@@ -5,6 +5,8 @@ import { atomicWriteJson } from '@fs/io';
 import { SyncStrategySchema } from '@shared/types';
 import { z } from 'zod';
 
+import { parseJsonConfig } from './json';
+
 const ProviderConfigSchema = z.object({
   strategy: SyncStrategySchema.optional(),
   enabled: z.boolean().optional(),
@@ -61,7 +63,7 @@ function parseSyncConfig(
 ): z.infer<typeof SyncConfigSchema> {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = parseJsonConfig(raw, configPath);
   } catch {
     throw new CliError(
       `Sync config at ${configPath} is not valid JSON. Fix the file and retry.`,

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      jsonc-parser:
+        specifier: 3.2.1
+        version: 3.2.1
       ora:
         specifier: ^9.0.0
         version: 9.3.0


### PR DESCRIPTION
## Summary

- Add a shared config parser that accepts trailing commas while keeping comments invalid for JSON config files.
- Route shared, local, user, and provider sync config reads through the parser.
- Add regression coverage for trailing commas and bump the lockstep public package versions to 0.1.13.

## Root Cause

OAT config loading used JSON.parse directly, so a trailing comma in .oat/config.json caused the CLI to fail before schema normalization or defaults could apply.

## Validation

- pnpm --filter @open-agent-toolkit/cli exec vitest run src/config/oat-config.test.ts src/config/sync-config.test.ts
- temp git repo CLI repro: config get worktrees.root --json with a trailing comma in .oat/config.json
- pnpm --filter @open-agent-toolkit/cli format
- pnpm --filter @open-agent-toolkit/cli lint
- pnpm --filter @open-agent-toolkit/cli type-check
- pnpm release:check-versions
- pnpm release:validate
- git diff --check
- pre-push gates: release:check-versions, validate-skill-version-bumps, workspace type-check, lint, format
