### PR TITLE
feat(oat): commit scaffold baseline on `oat project new` + review-output trackability

### DIFF
--- a/.agents/skills/oat-review-provide/SKILL.md
+++ b/.agents/skills/oat-review-provide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-review-provide
-version: 1.2.0
+version: 1.2.1
 description: Use when you need an ad-hoc review outside an active OAT project lifecycle. Reviews code or artifacts without project phase state, unlike oat-project-review-provide.
 argument-hint: '[unstaged|staged|base_branch=<branch>|base_sha=<sha>|<sha1>..<sha2>|--files <path1,path2,...>] [--output <path>] [--mode auto|local|tracked|inline]'
 disable-model-invocation: true
@@ -137,7 +137,7 @@ bash .agents/skills/oat-review-provide/scripts/resolve-review-output.sh --mode a
 
 Policy:
 
-- If `.oat/repo/reviews` exists and is not gitignored, assume user wants tracked active artifacts there.
+- If `.oat/repo/reviews` exists and new review artifacts under it are not gitignored, assume user wants tracked active artifacts there.
 - Otherwise default to active local `.oat/projects/local/orphan-reviews`.
 - Do **not** write new review artifacts directly into any `archived/` directory; those are historical locations used after `oat-review-receive` processes a review.
 - If user preference is unclear, ask and recommend local-only.

--- a/.agents/skills/oat-review-provide/scripts/resolve-review-output.sh
+++ b/.agents/skills/oat-review-provide/scripts/resolve-review-output.sh
@@ -18,7 +18,7 @@ Policy:
 - If --output is provided, use it directly.
 - If mode=inline, no artifact file is written.
 - In auto mode:
-  - If .oat/repo/reviews exists and is NOT gitignored, use it (tracked convention).
+  - If .oat/repo/reviews exists and new review artifacts under it are NOT gitignored, use it (tracked convention).
   - Otherwise, use .oat/projects/local/orphan-reviews (local-only default).
 USAGE
 }
@@ -67,12 +67,22 @@ is_gitignored() {
   fi
 }
 
+artifact_probe_path() {
+  local output_dir="$1"
+  printf '%s/%s\n' "${output_dir%/}" "ad-hoc-review-gitignore-probe.md"
+}
+
+is_output_gitignored() {
+  local output_dir="$1"
+  is_gitignored "$(artifact_probe_path "$output_dir")"
+}
+
 # Resolve explicit output first
 if [[ -n "$OUTPUT" ]]; then
   echo "review_mode=file"
   echo "output_dir=$OUTPUT"
   echo "output_kind=custom"
-  echo "output_gitignored=$(is_gitignored "$OUTPUT")"
+  echo "output_gitignored=$(is_output_gitignored "$OUTPUT")"
   echo "reason=explicit_output"
   exit 0
 fi
@@ -93,7 +103,7 @@ if [[ "$MODE" == "tracked" ]]; then
   echo "review_mode=file"
   echo "output_dir=$TRACKED_DIR"
   echo "output_kind=tracked"
-  echo "output_gitignored=$(is_gitignored "$TRACKED_DIR")"
+  echo "output_gitignored=$(is_output_gitignored "$TRACKED_DIR")"
   echo "reason=forced_tracked"
   exit 0
 fi
@@ -102,13 +112,13 @@ if [[ "$MODE" == "local" ]]; then
   echo "review_mode=file"
   echo "output_dir=$LOCAL_DIR"
   echo "output_kind=local"
-  echo "output_gitignored=$(is_gitignored "$LOCAL_DIR")"
+  echo "output_gitignored=$(is_output_gitignored "$LOCAL_DIR")"
   echo "reason=forced_local"
   exit 0
 fi
 
 # auto mode
-if [[ -d "$TRACKED_DIR" ]] && [[ "$(is_gitignored "$TRACKED_DIR")" == "false" ]]; then
+if [[ -d "$TRACKED_DIR" ]] && [[ "$(is_output_gitignored "$TRACKED_DIR")" == "false" ]]; then
   echo "review_mode=file"
   echo "output_dir=$TRACKED_DIR"
   echo "output_kind=tracked"
@@ -120,5 +130,5 @@ fi
 echo "review_mode=file"
 echo "output_dir=$LOCAL_DIR"
 echo "output_kind=local"
-echo "output_gitignored=$(is_gitignored "$LOCAL_DIR")"
+echo "output_gitignored=$(is_output_gitignored "$LOCAL_DIR")"
 echo "reason=default_local_only"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/commands.integration.test.ts
+++ b/packages/cli/src/commands/commands.integration.test.ts
@@ -374,6 +374,7 @@ describe('CLI command integration', () => {
       '--mode',
       'quick',
       '--no-dashboard',
+      '--no-commit',
     ]);
 
     expect(result.exitCode).toBe(0);

--- a/packages/cli/src/commands/help-snapshots.test.ts
+++ b/packages/cli/src/commands/help-snapshots.test.ts
@@ -666,6 +666,7 @@ describe('help output snapshots', () => {
         --force          Non-destructive scaffold; create missing files only
         --no-set-active  Do not update active project in local config
         --no-dashboard   Do not refresh .oat/state.md after scaffold
+        --no-commit      Do not git-commit the scaffolded project directory
         -h, --help       display help for command
       "
     `);

--- a/packages/cli/src/commands/init/tools/shared/review-output-helper.test.ts
+++ b/packages/cli/src/commands/init/tools/shared/review-output-helper.test.ts
@@ -1,0 +1,111 @@
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+const repoRoot = join(import.meta.dirname, '../../../../../../../');
+const helperPath = join(
+  repoRoot,
+  '.agents',
+  'skills',
+  'oat-review-provide',
+  'scripts',
+  'resolve-review-output.sh',
+);
+
+async function initGitRepo(root: string): Promise<void> {
+  await execFileAsync('git', ['init', '-q'], { cwd: root });
+}
+
+async function runHelper(
+  root: string,
+  args: readonly string[] = ['--mode', 'auto'],
+): Promise<Record<string, string>> {
+  const { stdout } = await execFileAsync('bash', [helperPath, ...args], {
+    cwd: root,
+  });
+
+  return Object.fromEntries(
+    stdout
+      .trim()
+      .split('\n')
+      .map((line) => {
+        const [key, ...valueParts] = line.split('=');
+        return [key, valueParts.join('=')];
+      }),
+  );
+}
+
+describe('resolve-review-output.sh', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+    tempDirs.length = 0;
+  });
+
+  async function createRepo(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'oat-review-output-'));
+    tempDirs.push(root);
+    await initGitRepo(root);
+    return root;
+  }
+
+  it('uses tracked review output when new files in .oat/repo/reviews are trackable', async () => {
+    const root = await createRepo();
+    await mkdir(join(root, '.oat', 'repo', 'reviews'), { recursive: true });
+
+    await expect(runHelper(root)).resolves.toMatchObject({
+      review_mode: 'file',
+      output_dir: '.oat/repo/reviews',
+      output_kind: 'tracked',
+      output_gitignored: 'false',
+      reason: 'existing_tracked_dir',
+    });
+  });
+
+  it('falls back to local review output when files under .oat/repo/reviews are ignored', async () => {
+    const root = await createRepo();
+    await mkdir(join(root, '.oat', 'repo', 'reviews'), { recursive: true });
+    await writeFile(
+      join(root, '.gitignore'),
+      ['.oat/repo/reviews/**', '.oat/projects/local/**', ''].join('\n'),
+      'utf8',
+    );
+
+    await expect(runHelper(root)).resolves.toMatchObject({
+      review_mode: 'file',
+      output_dir: '.oat/projects/local/orphan-reviews',
+      output_kind: 'local',
+      output_gitignored: 'true',
+      reason: 'default_local_only',
+    });
+  });
+
+  it('reports ignored status for forced tracked review output without overriding it', async () => {
+    const root = await createRepo();
+    await mkdir(join(root, '.oat', 'repo', 'reviews'), { recursive: true });
+    await writeFile(
+      join(root, '.gitignore'),
+      ['.oat/repo/reviews/**', ''].join('\n'),
+      'utf8',
+    );
+
+    await expect(runHelper(root, ['--mode', 'tracked'])).resolves.toMatchObject(
+      {
+        review_mode: 'file',
+        output_dir: '.oat/repo/reviews',
+        output_kind: 'tracked',
+        output_gitignored: 'true',
+        reason: 'forced_tracked',
+      },
+    );
+  });
+});

--- a/packages/cli/src/commands/project/new/index.test.ts
+++ b/packages/cli/src/commands/project/new/index.test.ts
@@ -8,6 +8,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createProjectNewCommand } from './index';
 
+type CommitScaffoldStatus =
+  | 'committed'
+  | 'skipped_disabled'
+  | 'skipped_no_worktree'
+  | 'skipped_nothing'
+  | 'failed';
+
 interface HarnessOptions {
   result?: {
     mode: 'spec-driven' | 'quick' | 'import';
@@ -17,6 +24,10 @@ interface HarnessOptions {
     skippedFiles: string[];
     activePointerUpdated: boolean;
     dashboardRefreshed: boolean;
+    committed: boolean;
+    commitSha?: string;
+    commitStatus: CommitScaffoldStatus;
+    commitError?: string;
   };
   throwError?: boolean;
 }
@@ -40,6 +51,8 @@ function createHarness(options: HarnessOptions = {}): {
         skippedFiles: [],
         activePointerUpdated: true,
         dashboardRefreshed: true,
+        committed: false,
+        commitStatus: 'skipped_disabled',
       }
     );
   });
@@ -114,6 +127,20 @@ describe('createProjectNewCommand', () => {
         force: true,
         setActive: false,
         refreshDashboard: false,
+        commit: true,
+      }),
+    );
+  });
+
+  it('forwards commit: false when --no-commit is passed', async () => {
+    const { command, scaffoldProject } = createHarness();
+
+    await runCommand(command, ['demo', '--no-commit']);
+
+    expect(scaffoldProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectName: 'demo',
+        commit: false,
       }),
     );
   });
@@ -128,6 +155,9 @@ describe('createProjectNewCommand', () => {
         skippedFiles: [],
         activePointerUpdated: true,
         dashboardRefreshed: true,
+        committed: true,
+        commitSha: 'abcdef1234567890',
+        commitStatus: 'committed',
       },
     });
 
@@ -140,6 +170,112 @@ describe('createProjectNewCommand', () => {
     expect(capture.info[2]).toContain(
       'Active project updated in local config: .oat/config.local.json',
     );
+    expect(capture.info[3]).toContain('Scaffold commit: abcdef1');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('reports skipped commit when --no-commit is passed', async () => {
+    const { command, capture } = createHarness({
+      result: {
+        mode: 'spec-driven',
+        projectPath: '.oat/projects/shared/demo',
+        projectsRoot: '.oat/projects/shared',
+        createdFiles: ['state.md'],
+        skippedFiles: [],
+        activePointerUpdated: true,
+        dashboardRefreshed: true,
+        committed: false,
+        commitStatus: 'skipped_disabled',
+      },
+    });
+
+    await runCommand(command, ['demo', '--no-commit']);
+
+    expect(
+      capture.info.some((line) =>
+        line.includes('Scaffold commit: skipped (--no-commit)'),
+      ),
+    ).toBe(true);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('reports a distinct message when the work tree is missing', async () => {
+    const { command, capture } = createHarness({
+      result: {
+        mode: 'quick',
+        projectPath: '.oat/projects/shared/demo',
+        projectsRoot: '.oat/projects/shared',
+        createdFiles: ['state.md'],
+        skippedFiles: [],
+        activePointerUpdated: true,
+        dashboardRefreshed: true,
+        committed: false,
+        commitStatus: 'skipped_no_worktree',
+      },
+    });
+
+    await runCommand(command, ['demo']);
+
+    expect(
+      capture.info.some((line) =>
+        line.includes('Scaffold commit: skipped (not a git work tree)'),
+      ),
+    ).toBe(true);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('reports a distinct message when there is nothing to commit', async () => {
+    const { command, capture } = createHarness({
+      result: {
+        mode: 'quick',
+        projectPath: '.oat/projects/shared/demo',
+        projectsRoot: '.oat/projects/shared',
+        createdFiles: [],
+        skippedFiles: ['state.md'],
+        activePointerUpdated: true,
+        dashboardRefreshed: true,
+        committed: false,
+        commitStatus: 'skipped_nothing',
+      },
+    });
+
+    await runCommand(command, ['demo']);
+
+    expect(
+      capture.info.some((line) =>
+        line.includes('Scaffold commit: skipped (nothing to commit)'),
+      ),
+    ).toBe(true);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('warns on commit failure without changing the exit code', async () => {
+    const { command, capture } = createHarness({
+      result: {
+        mode: 'quick',
+        projectPath: '.oat/projects/shared/demo',
+        projectsRoot: '.oat/projects/shared',
+        createdFiles: ['state.md'],
+        skippedFiles: [],
+        activePointerUpdated: true,
+        dashboardRefreshed: true,
+        committed: false,
+        commitStatus: 'failed',
+        commitError: 'fatal: empty ident name not allowed',
+      },
+    });
+
+    await runCommand(command, ['demo']);
+
+    expect(
+      capture.warn.some(
+        (line) =>
+          line.includes('scaffold commit failed') &&
+          line.includes('fatal: empty ident name not allowed') &&
+          line.includes('NOT committed'),
+      ),
+    ).toBe(true);
+    // The scaffold succeeded, so a commit failure must not fail the command.
     expect(process.exitCode).toBe(0);
   });
 
@@ -153,6 +289,8 @@ describe('createProjectNewCommand', () => {
         skippedFiles: ['plan.md'],
         activePointerUpdated: false,
         dashboardRefreshed: false,
+        committed: false,
+        commitStatus: 'skipped_no_worktree',
       },
     });
 
@@ -165,6 +303,35 @@ describe('createProjectNewCommand', () => {
       projectPath: '.oat/projects/shared/demo',
       activePointerUpdated: false,
       dashboardRefreshed: false,
+      committed: false,
+      commitStatus: 'skipped_no_worktree',
+    });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('includes commitStatus and commitError in json on commit failure', async () => {
+    const { command, capture } = createHarness({
+      result: {
+        mode: 'quick',
+        projectPath: '.oat/projects/shared/demo',
+        projectsRoot: '.oat/projects/shared',
+        createdFiles: ['state.md'],
+        skippedFiles: [],
+        activePointerUpdated: true,
+        dashboardRefreshed: true,
+        committed: false,
+        commitStatus: 'failed',
+        commitError: 'fatal: empty ident name not allowed',
+      },
+    });
+
+    await runCommand(command, ['demo'], ['--json']);
+
+    expect(capture.jsonPayloads[0]).toMatchObject({
+      status: 'ok',
+      committed: false,
+      commitStatus: 'failed',
+      commitError: 'fatal: empty ident name not allowed',
     });
     expect(process.exitCode).toBe(0);
   });

--- a/packages/cli/src/commands/project/new/index.ts
+++ b/packages/cli/src/commands/project/new/index.ts
@@ -12,11 +12,18 @@ import {
   type ScaffoldProjectResult,
 } from './scaffold';
 
+const COMMIT_STATUS_MESSAGES = {
+  skipped_disabled: 'Scaffold commit: skipped (--no-commit)',
+  skipped_no_worktree: 'Scaffold commit: skipped (not a git work tree)',
+  skipped_nothing: 'Scaffold commit: skipped (nothing to commit)',
+} as const;
+
 interface ProjectNewCommandOptions {
   mode: ProjectScaffoldMode;
   force: boolean;
   setActive: boolean;
   dashboard: boolean;
+  commit: boolean;
 }
 
 interface ProjectNewDependencies {
@@ -28,6 +35,7 @@ interface ProjectNewDependencies {
     force: boolean;
     setActive: boolean;
     refreshDashboard: boolean;
+    commit: boolean;
   }) => Promise<ScaffoldProjectResult>;
 }
 
@@ -52,6 +60,10 @@ function reportSuccess(
       skippedFiles: result.skippedFiles,
       activePointerUpdated: result.activePointerUpdated,
       dashboardRefreshed: result.dashboardRefreshed,
+      committed: result.committed,
+      commitSha: result.commitSha,
+      commitStatus: result.commitStatus,
+      commitError: result.commitError,
     });
     return;
   }
@@ -62,6 +74,20 @@ function reportSuccess(
     context.logger.info(
       'Active project updated in local config: .oat/config.local.json',
     );
+  }
+  if (result.commitStatus === 'committed') {
+    context.logger.info(
+      `Scaffold commit: ${result.commitSha?.slice(0, 7) ?? 'committed'}`,
+    );
+  } else if (result.commitStatus === 'failed') {
+    // The scaffold itself succeeded, so this is a warning, not an error: do not
+    // change the process exit code. Make clear the baseline was NOT committed.
+    const detail = result.commitError ? `: ${result.commitError}` : '';
+    context.logger.warn(
+      `Warning: scaffold commit failed${detail}. The scaffolded files were written but NOT committed.`,
+    );
+  } else {
+    context.logger.info(COMMIT_STATUS_MESSAGES[result.commitStatus]);
   }
 }
 
@@ -79,6 +105,7 @@ async function runProjectNew(
       force: options.force,
       setActive: options.setActive,
       refreshDashboard: options.dashboard,
+      commit: options.commit,
     });
 
     reportSuccess(context, projectName, result);
@@ -113,6 +140,7 @@ export function createProjectNewCommand(
     .option('--force', 'Non-destructive scaffold; create missing files only')
     .option('--no-set-active', 'Do not update active project in local config')
     .option('--no-dashboard', 'Do not refresh .oat/state.md after scaffold')
+    .option('--no-commit', 'Do not git-commit the scaffolded project directory')
     .action(
       async (
         name: string,

--- a/packages/cli/src/commands/project/new/scaffold.test.ts
+++ b/packages/cli/src/commands/project/new/scaffold.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -5,6 +6,15 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { scaffoldProject } from './scaffold';
+
+function initGitRepo(root: string): void {
+  execFileSync('git', ['init', '-q'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'scaffold@example.com'], {
+    cwd: root,
+  });
+  execFileSync('git', ['config', 'user.name', 'scaffolder'], { cwd: root });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: root });
+}
 
 async function seedTemplates(repoRoot: string): Promise<void> {
   const templatesDir = join(repoRoot, '.oat', 'templates');
@@ -621,5 +631,256 @@ describe('scaffoldProject', () => {
 
     expect(stateTemplate).toContain('oat_pr_status: null');
     expect(stateTemplate).toContain('oat_pr_url: null');
+  });
+
+  it('does not commit by default', async () => {
+    const repoRoot = await createRepoRoot();
+    tempDirs.push(repoRoot);
+    initGitRepo(repoRoot);
+
+    const result = await scaffoldProject({
+      repoRoot,
+      projectName: 'no-commit-default',
+      mode: 'quick',
+      refreshDashboard: false,
+      setActive: false,
+      today: '2026-02-16',
+    });
+
+    expect(result.committed).toBe(false);
+    expect(result.commitSha).toBeUndefined();
+    expect(result.commitStatus).toBe('skipped_disabled');
+
+    // No commit was created, so HEAD does not resolve. Capture stderr so the
+    // expected `git fatal:` probe output does not leak to the test terminal.
+    expect(() =>
+      execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: repoRoot,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+    ).toThrow();
+  });
+
+  it('commits only the scaffolded directory when commit:true (scoped staging)', async () => {
+    const repoRoot = await createRepoRoot();
+    tempDirs.push(repoRoot);
+    initGitRepo(repoRoot);
+
+    // An unrelated untracked file elsewhere in the repo must remain untracked.
+    await writeFile(join(repoRoot, 'unrelated.txt'), 'do not stage me', 'utf8');
+
+    const result = await scaffoldProject({
+      repoRoot,
+      projectName: 'commit-demo',
+      mode: 'quick',
+      refreshDashboard: false,
+      setActive: false,
+      commit: true,
+      today: '2026-02-16',
+    });
+
+    expect(result.committed).toBe(true);
+    expect(result.commitStatus).toBe('committed');
+    expect(result.commitSha).toMatch(/^[0-9a-f]{40}$/);
+
+    // The scaffolded artifacts are tracked at HEAD.
+    const tracked = execFileSync(
+      'git',
+      ['ls-tree', '-r', '--name-only', 'HEAD'],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+    expect(tracked).toContain('.oat/projects/shared/commit-demo/state.md');
+    expect(tracked).toContain('.oat/projects/shared/commit-demo/plan.md');
+
+    // The unrelated file was NOT swept into the scaffold commit.
+    expect(tracked).not.toContain('unrelated.txt');
+    const status = execFileSync(
+      'git',
+      ['status', '--porcelain', '--', 'unrelated.txt'],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+    expect(status).toContain('?? unrelated.txt');
+  });
+
+  it('skips commit safely when not inside a git work tree', async () => {
+    const repoRoot = await createRepoRoot();
+    tempDirs.push(repoRoot);
+
+    const result = await scaffoldProject({
+      repoRoot,
+      projectName: 'no-git',
+      mode: 'quick',
+      refreshDashboard: false,
+      setActive: false,
+      commit: true,
+      today: '2026-02-16',
+    });
+
+    expect(result.committed).toBe(false);
+    expect(result.commitStatus).toBe('skipped_no_worktree');
+    expect(result.commitSha).toBeUndefined();
+
+    // Files were still scaffolded despite the skipped commit.
+    await expect(
+      readFile(
+        join(repoRoot, '.oat', 'projects', 'shared', 'no-git', 'state.md'),
+        'utf8',
+      ),
+    ).resolves.toContain('# Project State: no-git');
+  });
+
+  it('skips committing without error when there is nothing new to create', async () => {
+    const repoRoot = await createRepoRoot();
+    tempDirs.push(repoRoot);
+    initGitRepo(repoRoot);
+
+    // First run scaffolds and commits the project.
+    await scaffoldProject({
+      repoRoot,
+      projectName: 'idempotent-demo',
+      mode: 'quick',
+      refreshDashboard: false,
+      setActive: false,
+      commit: true,
+      today: '2026-02-16',
+    });
+
+    // A second run creates nothing (all files already exist), so there is
+    // nothing for the scoped commit to do.
+    const second = await scaffoldProject({
+      repoRoot,
+      projectName: 'idempotent-demo',
+      mode: 'quick',
+      refreshDashboard: false,
+      setActive: false,
+      commit: true,
+      today: '2026-02-16',
+    });
+
+    expect(second.createdFiles).toHaveLength(0);
+    expect(second.committed).toBe(false);
+    expect(second.commitStatus).toBe('skipped_nothing');
+    expect(second.commitSha).toBeUndefined();
+  });
+
+  it('classifies a genuine commit failure and captures git stderr without leaking it', async () => {
+    const repoRoot = await createRepoRoot();
+    tempDirs.push(repoRoot);
+    // Init a work tree but deliberately omit user identity so `git commit`
+    // fails with a fatal error. The helper must classify this as `failed` and
+    // capture the stderr instead of letting `git fatal:` leak to the terminal.
+    execFileSync('git', ['init', '-q'], { cwd: repoRoot });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], {
+      cwd: repoRoot,
+    });
+    execFileSync('git', ['config', 'user.email', ''], { cwd: repoRoot });
+    execFileSync('git', ['config', 'user.name', ''], { cwd: repoRoot });
+
+    const result = await scaffoldProject({
+      repoRoot,
+      projectName: 'commit-fail',
+      mode: 'quick',
+      refreshDashboard: false,
+      setActive: false,
+      commit: true,
+      env: {
+        // Strip any ambient git identity so the commit truly cannot resolve one.
+        GIT_AUTHOR_NAME: '',
+        GIT_AUTHOR_EMAIL: '',
+        GIT_COMMITTER_NAME: '',
+        GIT_COMMITTER_EMAIL: '',
+      },
+      today: '2026-02-16',
+    });
+
+    expect(result.committed).toBe(false);
+    expect(result.commitStatus).toBe('failed');
+    expect(result.commitError).toBeTruthy();
+
+    // The scaffold itself still succeeded.
+    await expect(
+      readFile(
+        join(repoRoot, '.oat', 'projects', 'shared', 'commit-fail', 'state.md'),
+        'utf8',
+      ),
+    ).resolves.toContain('# Project State: commit-fail');
+  });
+
+  it('does not sweep pre-existing dirty edits inside the project dir on a re-run', async () => {
+    const repoRoot = await createRepoRoot();
+    tempDirs.push(repoRoot);
+    initGitRepo(repoRoot);
+
+    // First run scaffolds and commits the project baseline.
+    const first = await scaffoldProject({
+      repoRoot,
+      projectName: 'dirty-rerun',
+      mode: 'quick',
+      refreshDashboard: false,
+      setActive: false,
+      commit: true,
+      today: '2026-02-16',
+    });
+    expect(first.committed).toBe(true);
+
+    const projectDir = join(
+      repoRoot,
+      '.oat',
+      'projects',
+      'shared',
+      'dirty-rerun',
+    );
+
+    // Introduce unrelated working-tree changes INSIDE the project directory:
+    // (a) a dirty edit to an already-committed file, and
+    // (b) a brand-new untracked file this re-run will NOT create.
+    const planPath = join(projectDir, 'plan.md');
+    await writeFile(planPath, 'manual unrelated edit to plan', 'utf8');
+    const notesPath = join(projectDir, 'unrelated-notes.md');
+    await writeFile(notesPath, 'untracked notes do not commit me', 'utf8');
+
+    // Re-run with commit:true. Since every template already exists, this run
+    // creates nothing, so the scoped commit must touch nothing.
+    const second = await scaffoldProject({
+      repoRoot,
+      projectName: 'dirty-rerun',
+      mode: 'quick',
+      refreshDashboard: false,
+      setActive: false,
+      commit: true,
+      today: '2026-02-16',
+    });
+
+    expect(second.createdFiles).toHaveLength(0);
+    expect(second.committed).toBe(false);
+    expect(second.commitStatus).toBe('skipped_nothing');
+
+    // The unrelated edits remain in the working tree, uncommitted.
+    const status = execFileSync('git', ['status', '--porcelain'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    expect(status).toContain('.oat/projects/shared/dirty-rerun/plan.md');
+    expect(status).toContain(
+      '?? .oat/projects/shared/dirty-rerun/unrelated-notes.md',
+    );
+
+    // And they were NOT included in HEAD.
+    const headFiles = execFileSync(
+      'git',
+      ['ls-tree', '-r', '--name-only', 'HEAD'],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+    expect(headFiles).not.toContain(
+      '.oat/projects/shared/dirty-rerun/unrelated-notes.md',
+    );
+    // plan.md is tracked (committed by the first run), but HEAD must still hold
+    // the original scaffolded content, not the manual edit.
+    const headPlan = execFileSync(
+      'git',
+      ['show', 'HEAD:.oat/projects/shared/dirty-rerun/plan.md'],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+    expect(headPlan).not.toContain('manual unrelated edit to plan');
   });
 });

--- a/packages/cli/src/commands/project/new/scaffold.ts
+++ b/packages/cli/src/commands/project/new/scaffold.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -16,11 +17,30 @@ export interface ScaffoldProjectOptions {
   force?: boolean;
   setActive?: boolean;
   refreshDashboard?: boolean;
+  /**
+   * Commit the freshly scaffolded project directory so the artifact baseline is
+   * git-tracked from t=0. Opt-in (default false) so library callers that manage
+   * their own commits (e.g. the project-split flow) are unaffected; only the
+   * `oat project new` command enables it by default.
+   */
+  commit?: boolean;
   env?: NodeJS.ProcessEnv;
   today?: string;
   nowUtc?: string;
   refreshDashboardCallback?: (repoRoot: string) => void | Promise<void>;
 }
+
+/**
+ * Classified outcome of the scoped scaffold commit. Distinguishing the skip
+ * reasons (and `failed`) lets the CLI surface accurate, distinct messaging
+ * instead of collapsing every non-commit into a single benign "skipped" line.
+ */
+export type CommitScaffoldStatus =
+  | 'committed'
+  | 'skipped_disabled'
+  | 'skipped_no_worktree'
+  | 'skipped_nothing'
+  | 'failed';
 
 export interface ScaffoldProjectResult {
   mode: ProjectScaffoldMode;
@@ -30,6 +50,10 @@ export interface ScaffoldProjectResult {
   skippedFiles: string[];
   activePointerUpdated: boolean;
   dashboardRefreshed: boolean;
+  committed: boolean;
+  commitSha?: string;
+  commitStatus: CommitScaffoldStatus;
+  commitError?: string;
 }
 
 const TEMPLATES_BY_MODE: Record<ProjectScaffoldMode, string[]> = {
@@ -171,6 +195,82 @@ async function defaultRefreshDashboard(repoRoot: string): Promise<void> {
   await generateStateDashboard({ repoRoot });
 }
 
+interface CommitScaffoldResult {
+  status: CommitScaffoldStatus;
+  committed: boolean;
+  commitSha?: string;
+  error?: string;
+}
+
+/**
+ * Scoped, fail-safe commit of just the files this run created.
+ *
+ * Stages and commits only the pathspecs derived from `createdFiles` (under
+ * `projectPath`) so unrelated working-tree changes — including pre-existing
+ * dirty edits inside the same project directory on a re-run, and the
+ * `.oat/state.md` dashboard outside it — are never swept in. The returned
+ * status distinguishes a clean commit from each skip reason and from a genuine
+ * git failure; on failure the captured git stderr is surfaced via `error`. This
+ * never throws: any git error is classified as `failed`, not propagated.
+ */
+function commitScaffold(
+  cwd: string,
+  projectPath: string,
+  projectName: string,
+  createdFiles: string[],
+): CommitScaffoldResult {
+  const run = (args: string[]): string =>
+    execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      // Capture stderr instead of inheriting it so deliberate skip/failure
+      // probes (e.g. tests) do not leak raw `git fatal:` lines to the terminal.
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+
+  try {
+    run(['rev-parse', '--is-inside-work-tree']);
+  } catch {
+    return { status: 'skipped_no_worktree', committed: false };
+  }
+
+  // Only commit files this run created. Nothing created => nothing to commit,
+  // which guarantees a re-run never touches unrelated working-tree edits.
+  if (createdFiles.length === 0) {
+    return { status: 'skipped_nothing', committed: false };
+  }
+  const pathspecs = createdFiles.map((file) => join(projectPath, file));
+
+  try {
+    run(['add', '--', ...pathspecs]);
+
+    const staged = run(['diff', '--cached', '--name-only', '--', ...pathspecs]);
+    if (staged.length === 0) {
+      return { status: 'skipped_nothing', committed: false };
+    }
+
+    run([
+      'commit',
+      '-m',
+      `chore(oat): scaffold ${projectName}`,
+      '--',
+      ...pathspecs,
+    ]);
+
+    const commitSha = run(['rev-parse', 'HEAD']);
+    return { status: 'committed', committed: true, commitSha };
+  } catch (error) {
+    const stderr =
+      error && typeof error === 'object' && 'stderr' in error
+        ? (error as { stderr?: Buffer | string }).stderr
+        : undefined;
+    const message =
+      (stderr != null ? stderr.toString().trim() : '') ||
+      (error instanceof Error ? error.message : String(error));
+    return { status: 'failed', committed: false, error: message };
+  }
+}
+
 async function scaffoldModeTemplates(
   repoRoot: string,
   projectPath: string,
@@ -276,6 +376,25 @@ export async function scaffoldProject(
     }
   }
 
+  let committed = false;
+  let commitSha: string | undefined;
+  let commitStatus: CommitScaffoldStatus = 'skipped_disabled';
+  let commitError: string | undefined;
+  if (options.commit) {
+    // `projectPath` is relative to `repoRoot`, so git must run there for the
+    // pathspecs to resolve to the scaffolded files.
+    const commitResult = commitScaffold(
+      options.repoRoot,
+      projectPath,
+      options.projectName,
+      createdFiles,
+    );
+    committed = commitResult.committed;
+    commitSha = commitResult.commitSha;
+    commitStatus = commitResult.status;
+    commitError = commitResult.error;
+  }
+
   return {
     mode,
     projectsRoot,
@@ -284,5 +403,9 @@ export async function scaffoldProject(
     skippedFiles,
     activePointerUpdated: setActive,
     dashboardRefreshed,
+    committed,
+    commitSha,
+    commitStatus,
+    commitError,
   };
 }

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
Two related fixes that make OAT scaffold/review bookkeeping git-aware, eliminating the recurring `oat-project-review-provide` committed-baseline false positive.

### 1. Commit the scaffolded project baseline (`oat project new`)
`oat project new` now git-commits the files it scaffolds by default (`--no-commit` to opt out). Previously, scaffolded template artifacts (`plan.md`, `implementation.md`, …) stayed untracked until a late, skippable skill step, so a reviewer (often a different provider) running `oat-project-review-provide artifact design` before planning hit a hard stop on untracked pristine templates. Committing at scaffold time makes the project tracked from t=0.
- Scoped, fail-safe: stages only the files this run created (never `git add -A`); the gitignored `.oat/state.md` dashboard is never swept in.
- Library-level opt-in (`commit` defaults false) so the project-split flow is unaffected; only the CLI command enables it by default.
- Classified commit status (`committed | skipped_disabled | skipped_no_worktree | skipped_nothing | failed`) in text + `--json`, with a real warning (not a silent skip) on failure; git stderr captured so skip probes don't leak.

### 2. Review-output auto-mode trackability gate (`oat-review-provide`)
`resolve-review-output.sh` probes a review-artifact path inside the output dir, so auto mode only chooses `.oat/repo/reviews` when new files there are actually trackable. Forced `--mode tracked` stays tracked but reports `output_gitignored=true` so the caller can warn instead of pretending bookkeeping is available.

## Verification
`pnpm test`, `pnpm type-check`, `pnpm lint`, `pnpm format`, `pnpm release:validate`, `git diff --check` — all green. New regression tests cover scaffold scoped-staging (unrelated dirty edits inside the project dir are not swept in), commit-status classification, and review-output trackability.

## Versioning
- Lockstep public packages 0.1.14 → 0.1.15.
- `oat-review-provide` skill `version:` 1.2.0 → 1.2.1.
