### PR TITLE
fix(oat): split children resume at discovery for revalidation

### DIFF
--- a/.agents/skills/oat-project-split/SKILL.md
+++ b/.agents/skills/oat-project-split/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-split
-version: 1.0.0
+version: 1.1.0
 description: Use when a discovery or brainstorm should split one broad scope into coordinated OAT child projects.
 argument-hint: '--plan-file <path>'
 disable-model-invocation: true
@@ -73,10 +73,25 @@ The run command marks the parent `oat_phase: decomposition` and `oat_phase_statu
 
 If a previous split wrote a coordination parent but did not finish all children, the run command resumes from `references/split-plan.json`. Do not reconstruct missing child seed data from slugs alone.
 
+## Children Resume At Discovery (Revalidation Contract)
+
+A split seeds children with inherited context, but that context is only a **starting point**. By the time an agent resumes a child it may be stale, so children must never be treated as discovered, planned, or implementation-ready just because the split wrote their files.
+
+What the run command guarantees, and what reviewers should expect:
+
+- **Child `state.md` routes to discovery.** Each child is written with `oat_phase: discovery` and `oat_phase_status: in_progress`, plus preserved `oat_parent`, `oat_siblings`, and `oat_depends_on` links. Resume, progress, and quick-start all key off `state.md`, so they pick the child back up at discovery — not at plan or implementation.
+- **Child `discovery.md` is in progress with an unmet revalidation gate.** It carries `oat_status: in_progress` and `oat_inherited_context_revalidated: false`, an explicit "Inherited Context Revalidation Gate" section, and language stating that parent-derived scope is a seed, not a final decision. The discovery-completion gate blocks marking discovery complete until `oat_inherited_context_revalidated: true`.
+- **Child discovery is never marked complete during split generation.** Seeding only provides a provisional starting point.
+- **Placeholder `plan.md` cannot be mistaken for a real plan.** The seeded `plan.md` is re-marked as a not-started template (`oat_template: true`, `oat_template_name: plan`). Routing decisions read `state.md` (`oat_phase: discovery`), and `oat-project-next` treats `oat_template: true` as a still-a-template signal, so the placeholder never reads as plan-ready.
+
+A child sitting at `discovery` / `in_progress` after a split is **expected work-in-progress**, not stale bookkeeping. Do not flag it as drift or "skipped discovery" — revalidating inherited context is the next intended step.
+
 ## Success Criteria
 
 - Coordination parent exists and has no `spec.md`, `design.md`, `plan.md`, or `implementation.md`.
 - Parent `state.md` records `oat_kind: coordination`, ordered `oat_children`, and terminal decomposition status.
 - `references/split-plan.json` contains the full `SplitPlanDocument`.
-- Every child has seeded discovery content, parent/sibling/dependency links, and `oat_inherited_context_revalidated: false`.
+- Every child `state.md` records `oat_phase: discovery` and `oat_phase_status: in_progress` so resume/progress/quick-start route it back to discovery.
+- Every child has seeded discovery content, parent/sibling/dependency links, `oat_inherited_context_revalidated: false`, and an explicit revalidation gate; no child discovery is marked complete by the split.
+- Every child `plan.md` is a not-started template placeholder (`oat_template: true`) that never reads as plan-ready.
 - `.oat/config.local.json.activeProject` points at the repo-relative initial child path.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/projects/split/__tests__/seed-children.test.ts
+++ b/packages/cli/src/projects/split/__tests__/seed-children.test.ts
@@ -110,4 +110,53 @@ describe('seedChildren', () => {
       previousIndex = index;
     }
   });
+
+  it('routes every child to discovery with inherited context awaiting revalidation', async () => {
+    const repoRoot = await mkdtemp(join(tmpdir(), 'oat-split-resume-'));
+    tempDirs.push(repoRoot);
+    await seedTemplates(repoRoot);
+
+    await seedChildren(plan, {
+      repoRoot,
+      today: '2026-05-20',
+      nowUtc: '2026-05-20T12:00:00.000Z',
+    });
+
+    for (const child of plan.children) {
+      const childRoot = join(
+        repoRoot,
+        '.oat',
+        'projects',
+        'shared',
+        child.slug,
+      );
+
+      // state.md routes resume/progress/quick-start back to discovery.
+      const state = readFrontmatter(
+        await readFile(join(childRoot, 'state.md'), 'utf8'),
+      );
+      expect(state['oat_phase']).toBe('discovery');
+      expect(state['oat_phase_status']).toBe('in_progress');
+      expect(state['oat_workflow_mode']).toBe('quick');
+
+      // discovery.md is in progress with an explicit, unmet revalidation gate.
+      const discovery = await readFile(join(childRoot, 'discovery.md'), 'utf8');
+      const discoveryFrontmatter = readFrontmatter(discovery);
+      expect(discoveryFrontmatter['oat_status']).toBe('in_progress');
+      expect(discoveryFrontmatter['oat_inherited_context_revalidated']).toBe(
+        false,
+      );
+      expect(discovery).toContain('## Inherited Context Revalidation Gate');
+      expect(discovery).toContain('resumes at **discovery**');
+      expect(discovery).toContain('starting point, not a final scope decision');
+
+      // plan.md is a not-started template placeholder, never plan-ready.
+      const planFrontmatter = readFrontmatter(
+        await readFile(join(childRoot, 'plan.md'), 'utf8'),
+      );
+      expect(planFrontmatter['oat_template']).toBe(true);
+      expect(planFrontmatter['oat_plan_source']).toBe('quick');
+      expect(planFrontmatter['oat_status']).not.toBe('complete');
+    }
+  });
 });

--- a/packages/cli/src/projects/split/seed-children.ts
+++ b/packages/cli/src/projects/split/seed-children.ts
@@ -12,6 +12,7 @@ import type { SplitProjectContext } from './write-parent';
 const SEEDED_SECTIONS = [
   'Origin',
   'Inherited Context',
+  'Inherited Context Revalidation Gate',
   'Child Scope',
   'Known Dependencies',
   'Assumptions To Revalidate',
@@ -71,16 +72,38 @@ function renderSeededDiscovery(
     .map((candidate) => candidate.slug)
     .filter((slug) => slug !== child.slug);
   const sections = [
-    ['Origin', `Split from coordination parent \`${plan.parentSlug}\`.`],
+    [
+      'Origin',
+      `Split from coordination parent \`${plan.parentSlug}\`. This child was seeded by \`oat-project-split\`; it is **not** discovered, planned, or implementation-ready yet and resumes at discovery.`,
+    ],
     [
       'Inherited Context',
-      child.inheritedContext || 'No inherited context provided.',
+      [
+        child.inheritedContext || 'No inherited context provided.',
+        '',
+        '> Provisional seed. This context was inherited from the parent split decision. It is a **starting point, not a final scope decision** — treat every inherited claim as an assumption until it is revalidated below.',
+      ].join('\n'),
+    ],
+    [
+      'Inherited Context Revalidation Gate',
+      [
+        'This project resumes at **discovery**, not planning or implementation. Inherited context may be stale by the time work resumes, so it must be revalidated before this discovery is completed.',
+        '',
+        '- [ ] Re-read the inherited context against the current codebase and sibling progress.',
+        '- [ ] Confirm or correct the child scope, dependencies, and assumptions below.',
+        '- [ ] When revalidation is complete, set `oat_inherited_context_revalidated: true` in this file.',
+        '',
+        'Discovery cannot be marked complete — and planning must not begin — while `oat_inherited_context_revalidated: false`. A child left in this state is expected work-in-progress, not stale bookkeeping.',
+      ].join('\n'),
     ],
     ['Child Scope', child.description ?? child.slug],
     ['Known Dependencies', bulletList(child.knownDependencies)],
     [
       'Assumptions To Revalidate',
-      '- Revalidate inherited context before completing discovery.',
+      [
+        '- Revalidate inherited context before completing discovery.',
+        '- Confirm the child scope still matches reality before generating a plan.',
+      ].join('\n'),
     ],
     ['Likely Workflow Mode', 'quick'],
     ['Sibling Projects', bulletList(siblingSlugs)],
@@ -141,8 +164,16 @@ export async function seedChildren(
       oat_siblings: siblings,
       oat_depends_on: child.knownDependencies,
     });
+    // Children resume at discovery, so their scaffolded plan.md is a
+    // placeholder only. Re-mark it as a not-started template (the scaffold
+    // strips these markers when rendering) so neither tooling nor agents can
+    // mistake the seed for an active or validated plan; routing keys off
+    // state.md (oat_phase: discovery) and oat-project-next treats
+    // oat_template: true as a still-a-template signal.
     await updateFrontmatter(join(childRoot, 'plan.md'), {
       oat_plan_source: 'quick',
+      oat_template: true,
+      oat_template_name: 'plan',
     });
     await writeFile(
       join(childRoot, 'discovery.md'),

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

`oat-project-split` seeds child projects with context inherited from the coordination parent, but that context is only a **starting point** — by the time an agent resumes a child it may be stale. This PR ensures split-generated children always resume at **discovery** and treat inherited scope as a provisional seed requiring revalidation, never as discovered / planned / implementation-ready just because the split wrote their files.

Much of the contract was already in place (parent → `decomposition`/`complete`; children → `oat_phase: discovery`; state.md-driven routing that ignores `plan.md`; a discovery-completion gate). This PR closes the remaining gaps and makes the behavior explicit and tested.

## Changes

- **`seed-children.ts`**
  - Add an explicit **"Inherited Context Revalidation Gate"** section to each child `discovery.md`, plus provisional-seed language ("starting point, not a final scope decision", "resumes at discovery", "expected work-in-progress, not stale bookkeeping"). Keeps `oat_status: in_progress` and `oat_inherited_context_revalidated: false`.
  - Re-mark the placeholder child `plan.md` as a **not-started template** (`oat_template: true`, `oat_template_name: plan`). The scaffold strips template markers, which left the seed looking like a real in-progress plan; restoring the marker means neither tooling nor `oat-project-next` (which treats `oat_template: true` as still-a-template) can mistake it for a validated plan. Routing still keys off `state.md` (`oat_phase: discovery`).
- **`seed-children.test.ts`** — new regression test: every child resumes at discovery (`oat_phase: discovery` / `oat_phase_status: in_progress`), `discovery.md` is in progress with an unmet revalidation gate, and `plan.md` is a template-only placeholder that is never plan-ready.
- **`.agents/skills/oat-project-split/SKILL.md`** — new "Children Resume At Discovery (Revalidation Contract)" section and updated success criteria so reviewers do not flag discovery-in-progress children as stale bookkeeping; bump skill `version: 1.0.0 → 1.1.0`.
- **Lockstep public-package bump** `0.1.15 → 0.1.16` (`cli`, `control-plane`, `docs-config`, `docs-theme`, `docs-transforms`) — required because `.agents/skills` and `packages/cli/src` changed.

## Acceptance criteria

- ✅ A newly split child is discoverable as active at discovery.
- ✅ Resume/progress/quick-start route the agent to revalidate child discovery first (state.md routing + revalidation gate; documented in SKILL).
- ✅ Placeholder plan content cannot make a child read as plan-ready.
- ✅ Docs/skill instructions explain the behavior so discovery-in-progress children are not mistaken for stale bookkeeping.

## Verification

- Split tests: 54/54 pass (incl. new regression test)
- Full CLI suite: 1755/1755 pass
- `type-check`, `oxlint`, `oxfmt --check`: clean
- `pnpm run oat:validate-skills`: OK (51 skills)
- `pnpm release:validate`: passed for all 5 public packages at 0.1.16