### PR TITLE
fix(docs): promote admonition titles to bold body lines on migrate

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/docs/e2e-pipeline.test.ts
+++ b/packages/cli/src/commands/docs/e2e-pipeline.test.ts
@@ -120,7 +120,7 @@ describe('docs pipeline e2e', () => {
       join(docsDir, 'guides', 'getting-started.md'),
       'utf8',
     );
-    expect(migratedGuide).toContain('> [!NOTE] Prerequisites');
+    expect(migratedGuide).toContain('> [!NOTE]\n> **Prerequisites**');
     expect(migratedGuide).toContain('> [!TIP]');
     expect(migratedGuide).not.toContain('!!! note');
     expect(migratedGuide).not.toContain('!!! tip');
@@ -143,7 +143,7 @@ describe('docs pipeline e2e', () => {
       join(docsDir, 'api', 'auth.md'),
       'utf8',
     );
-    expect(migratedAuth).toContain('> [!CAUTION] Security');
+    expect(migratedAuth).toContain('> [!CAUTION]\n> **Security**');
     expect(migratedAuth).toContain('title: Authentication');
 
     // Step 2: Generate index

--- a/packages/cli/src/commands/docs/migrate/codemod.test.ts
+++ b/packages/cli/src/commands/docs/migrate/codemod.test.ts
@@ -10,10 +10,19 @@ describe('convertAdmonitions', () => {
     expect(result.admonitionsConverted).toBe(1);
   });
 
-  it('converts an admonition with a custom title', () => {
+  it('promotes a custom title to a bold first body line', () => {
     const input = '!!! warning "Watch out"\n    Be careful here.\n';
     const result = convertAdmonitions(input);
-    expect(result.content).toBe('> [!WARNING] Watch out\n> Be careful here.\n');
+    expect(result.content).toBe(
+      '> [!WARNING]\n> **Watch out**\n>\n> Be careful here.\n',
+    );
+    expect(result.admonitionsConverted).toBe(1);
+  });
+
+  it('promotes a custom title even when the admonition has no body', () => {
+    const input = '!!! note "Just a title"\n';
+    const result = convertAdmonitions(input);
+    expect(result.content).toBe('> [!NOTE]\n> **Just a title**\n');
     expect(result.admonitionsConverted).toBe(1);
   });
 
@@ -65,7 +74,7 @@ describe('convertAdmonitions', () => {
       '!!! note\n    First note.\n\n!!! warning "Title"\n    Second warning.\n';
     const result = convertAdmonitions(input);
     expect(result.content).toBe(
-      '> [!NOTE]\n> First note.\n\n> [!WARNING] Title\n> Second warning.\n',
+      '> [!NOTE]\n> First note.\n\n> [!WARNING]\n> **Title**\n>\n> Second warning.\n',
     );
     expect(result.admonitionsConverted).toBe(2);
   });
@@ -81,7 +90,7 @@ describe('convertAdmonitions', () => {
     const input = '??? tip "Click to expand"\n    Hidden content.\n';
     const result = convertAdmonitions(input);
     expect(result.content).toBe(
-      '> [!TIP] Click to expand\n> Hidden content.\n',
+      '> [!TIP]\n> **Click to expand**\n>\n> Hidden content.\n',
     );
     expect(result.admonitionsConverted).toBe(1);
   });

--- a/packages/cli/src/commands/docs/migrate/codemod.ts
+++ b/packages/cli/src/commands/docs/migrate/codemod.ts
@@ -40,10 +40,22 @@ export function convertAdmonitions(content: string): CodemodResult {
     const title = match[2] ?? undefined;
     const gfmType = ADMONITION_TYPE_MAP[typeName] ?? 'NOTE';
 
-    const header = title ? `> [!${gfmType}] ${title}` : `> [!${gfmType}]`;
-    output.push(header);
+    // GitHub-style alerts (and the Fumadocs alert plugin) do not support a
+    // custom title on the marker line. Emit a bare `> [!TYPE]` marker and
+    // promote the admonition's title to a bold first body line so it survives
+    // rendering instead of being demoted to the generic type label.
+    output.push(`> [!${gfmType}]`);
     admonitionsConverted++;
     i++;
+
+    if (title) {
+      output.push(`> **${title}**`);
+      // Separate the promoted title from the body with a blockquote blank so it
+      // renders as its own paragraph — but only when body content follows.
+      if (i < lines.length && lines[i]!.startsWith('    ')) {
+        output.push('>');
+      }
+    }
 
     while (i < lines.length) {
       const line = lines[i]!;

--- a/packages/cli/src/commands/docs/migrate/fixtures/admonitions-expected.md
+++ b/packages/cli/src/commands/docs/migrate/fixtures/admonitions-expected.md
@@ -2,7 +2,9 @@
 
 This guide covers deploying your application.
 
-> [!NOTE] Prerequisites
+> [!NOTE]
+> **Prerequisites**
+>
 > You need the following installed:
 >
 > - Node.js 20+
@@ -11,19 +13,25 @@ This guide covers deploying your application.
 > [!WARNING]
 > Make sure to back up your database before proceeding.
 
-> [!TIP] Quick Start
+> [!TIP]
+> **Quick Start**
+>
 > Run `docker compose up` to get started quickly.
 >
 > This will start all required services.
 
-> [!NOTE] Advanced Configuration
+> [!NOTE]
+> **Advanced Configuration**
+>
 > You can configure the following environment variables:
 >
 > - `DB_HOST` — database host
 > - `DB_PORT` — database port
 > - `DB_NAME` — database name
 
-> [!CAUTION] Data Loss Warning
+> [!CAUTION]
+> **Data Loss Warning**
+>
 > Running this command will **permanently delete** all data.
 >
 > ```bash

--- a/packages/cli/src/commands/docs/migrate/fixtures/combined-expected.md
+++ b/packages/cli/src/commands/docs/migrate/fixtures/combined-expected.md
@@ -7,7 +7,9 @@ description: ""
 
 The OAT CLI provides a comprehensive API for tool management.
 
-> [!IMPORTANT] Breaking Change
+> [!IMPORTANT]
+> **Breaking Change**
+>
 > The `v2` API removes support for legacy tool formats.
 > Please migrate your tools before upgrading.
 
@@ -22,7 +24,9 @@ const client = new OATClient({
 });
 ```
 
-> [!TIP] Usage Example
+> [!TIP]
+> **Usage Example**
+>
 > Here's how to list your tools:
 >
 > ```typescript

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Problem

`oat docs migrate` emitted MkDocs admonition titles on the marker line — `> [!NOTE] Prerequisites`. Neither GitHub's alert spec nor the Fumadocs `remark-github-blockquote-alert` plugin (configured with the default `legacyTitle: false` in `packages/docs-config/src/source-config.ts`) reads a title there:

- The plugin's `alertRegex` matches only `[!NOTE]`, so the alert renders the **generic** "Note" label.
- The custom title text (`Prerequisites`) leaks into the body as a leading run, with a stray leading space.

Surfaced as a follow-up while running a docs migration in another repo.

## Fix

`packages/cli/src/commands/docs/migrate/codemod.ts` — emit a bare `> [!TYPE]` marker and promote the title to a **bold first body line**, separated by a blockquote blank so it renders as its own paragraph:

```md
> [!NOTE]
> **Prerequisites**
>
> You need the following installed:
```

This renders correctly under **both** the Fumadocs plugin and GitHub, and needs no plugin-config coupling. Untitled admonitions are unchanged.

### Alternatives considered
- Enable `legacyTitle: true` + emit `> [!NOTE/Title]` — preserves a real title slot but is non-GitHub-standard and couples migrate output to this repo's plugin config.
- Drop titles entirely — loses information.

Option above (bold lead-in) was chosen as the most portable with no config coupling. Tradeoff: the alert's title bar shows the generic type label (standard GitHub alerts don't support custom titles); the title text is preserved and visible as a bold lead-in.

## Verification (TDD)
- Updated `codemod.test.ts` unit specs first, watched them fail for the right reason, then implemented.
- Regenerated golden fixtures (`admonitions-expected.md`, `combined-expected.md`); diff shows only titled callouts changed.
- Updated two assertions in `e2e-pipeline.test.ts`.
- Full CLI suite: **1756 passed** (194 files). Lint: 0 errors. Type-check + format: clean.

## Release
Touches shipped `packages/cli/src`, so per the lockstep policy all five public packages bump **0.1.16 → 0.1.17** (`cli`, `control-plane`, `docs-config`, `docs-theme`, `docs-transforms`). `pnpm release:validate` passes.

## Note
Docs already migrated elsewhere with the old format won't self-heal; re-running `oat docs migrate` on them now produces the corrected output.