### PR TITLE
fix: vendor skills-guide.md into create-agnostic-skill bundle

### DIFF
--- a/.agents/skills/create-agnostic-skill/SKILL.md
+++ b/.agents/skills/create-agnostic-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-agnostic-skill
-version: 1.3.0
+version: 1.4.0
 description: Use when adding a reusable workflow skill for AI coding agents. Scaffolds a new .agents/skills skill using the Agent Skills open standard.
 argument-hint: '[skill-name]'
 disable-model-invocation: true
@@ -12,7 +12,7 @@ user-invocable: true
 
 Create a new skill for AI coding agents using the [Agent Skills open standard](https://agentskills.io). Skills live in `.agents/skills/` (canonical source) and work across Claude Code, Cursor, Codex CLI, Gemini CLI, GitHub Copilot, and 20+ other compatible agents.
 
-For deep-dive research on cross-provider compatibility, frontmatter behavior, and distribution patterns, see `.agents/docs/skills-guide.md`.
+For deep-dive research on cross-provider compatibility, frontmatter behavior, and distribution patterns, see `references/docs/skills-guide.md` (bundled with this skill).
 
 ## When to Use
 
@@ -362,9 +362,12 @@ For multi-step skills, print brief progress updates so the user knows what's hap
 
 ### Shared References
 
-- If multiple skills need the same reference document, place it in `.agents/docs/` (not duplicated per skill)
 - Skill-specific references go in the skill's own `references/` directory
-- Reference from SKILL.md via relative path: `[guide](../../docs/my-guide.md)`
+- Keep a shared doc's canonical copy in `.agents/docs/` — edit it in one place, don't fork copies per skill
+- If a **distributed** skill needs that shared doc at invocation time, vendor it into the skill's `references/docs/` as a symlink to the canonical file:
+  `ln -s ../../../../docs/my-guide.md references/docs/my-guide.md`
+  The build (`bundle-assets.sh`, which copies with `cp -RL`) materializes the symlink into a real file, so the doc travels with the skill and the reference resolves wherever the skill is installed.
+- Reference the **bundled** path from SKILL.md (`references/docs/my-guide.md`), not repo-root `.agents/docs/`. A bare `.agents/docs/...` reference only resolves inside this monorepo and dangles once the skill is installed in another repo.
 
 ### Frontmatter Reference
 
@@ -384,7 +387,7 @@ Legend: ✅ supported | ⚠️ provider-specific | 💤 ignored | ❓ unknown
 | `context` / `agent`        | ❌              | ✅          | ❌     | 💤          | ❓         |
 | `hooks`                    | ❌              | ✅          | ❌     | 💤          | ❓         |
 
-**Key takeaway:** `name` + `description` are the only truly portable interface. Codex ignores unknown keys (safe to include Claude fields), so layer tool-specific fields on top of a portable baseline. For the full matrix, see `.agents/docs/skills-guide.md`.
+**Key takeaway:** `name` + `description` are the only truly portable interface. Codex ignores unknown keys (safe to include Claude fields), so layer tool-specific fields on top of a portable baseline. For the full matrix, see `references/docs/skills-guide.md` (bundled with this skill).
 
 ### Detail Level
 
@@ -426,8 +429,8 @@ I need a skill for running database migrations
 - [Gemini CLI Skills](https://geminicli.com/docs/cli/skills/) — Gemini-specific features
 - [npx skills CLI](https://github.com/vercel-labs/skills) — installing remote/community skills
 - [Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) — authoring guidance
-- `.agents/docs/skills-guide.md` — local deep-dive: compatibility matrix, resolved questions, patterns
-- `.agents/docs/reference-architecture.md` — local: where skills/agents/docs live and why
+- `references/docs/skills-guide.md` — bundled deep-dive: compatibility matrix, resolved questions, patterns
+- `.agents/docs/reference-architecture.md` — where skills/agents/docs live and why (OAT monorepo only; not bundled)
 
 ## Troubleshooting
 

--- a/.agents/skills/create-agnostic-skill/references/docs/skills-guide.md
+++ b/.agents/skills/create-agnostic-skill/references/docs/skills-guide.md
@@ -1,0 +1,1 @@
+../../../../docs/skills-guide.md

--- a/.agents/skills/create-agnostic-skill/references/skill-template.md
+++ b/.agents/skills/create-agnostic-skill/references/skill-template.md
@@ -208,7 +208,7 @@ Successful completion means:
 - At 60+ skills, descriptions may be silently truncated
 - Keep descriptions concise; the body handles detail
 
-**Shared references:** If multiple skills need the same document, place it in `.agents/docs/` and reference via relative path (`../../docs/my-guide.md`). Don't duplicate into each skill's `references/` directory.
+**Shared references:** Keep a shared doc's canonical copy in `.agents/docs/` (edit it in one place). If a distributed skill needs it at invocation time, vendor it into `references/docs/` as a symlink to the canonical file (`ln -s ../../../../docs/my-guide.md references/docs/my-guide.md`); the build materializes the symlink so the doc travels with the skill. Reference the bundled `references/docs/...` path — a bare `.agents/docs/...` reference dangles once the skill is installed in another repo.
 
-For the full compatibility matrix and resolved research questions, see `.agents/docs/skills-guide.md`.
+For the full compatibility matrix and resolved research questions, see `references/docs/skills-guide.md`.
 ```

--- a/.agents/skills/oat-wrap-up/SKILL.md
+++ b/.agents/skills/oat-wrap-up/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-wrap-up
-version: 1.0.1
+version: 1.0.2
 description: Use when preparing a shipping digest or weekly/biweekly wrap-up summarizing OAT projects and merged PRs over a time window. Reads local summary files and GitHub PR metadata; writes a version-controlled markdown report.
 argument-hint: '[--since YYYY-MM-DD] [--until YYYY-MM-DD] [--past-week|--past-2-weeks|--past-month] [--output <path>] [--dry-run]'
 disable-model-invocation: false

--- a/.agents/skills/oat-wrap-up/references/automation-recipes.md
+++ b/.agents/skills/oat-wrap-up/references/automation-recipes.md
@@ -1,6 +1,6 @@
 # Automation Recipes
 
-The `oat-wrap-up` skill is manual and model-invocable by design. OAT itself does not ship a scheduler (see `.agents/docs/agent-instruction.md:18` — scheduling is out of scope for OAT). To run the skill on a recurring cadence, configure your host agent or an external cron to invoke it. Three patterns are documented below.
+The `oat-wrap-up` skill is manual and model-invocable by design. OAT itself does not ship a scheduler (scheduling is intentionally out of scope for OAT). To run the skill on a recurring cadence, configure your host agent or an external cron to invoke it. Three patterns are documented below.
 
 ## Pattern 1 — Claude Code `CronCreate` trigger
 

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.1.23",
-  "docs-config": "0.1.23",
-  "docs-theme": "0.1.23",
-  "docs-transforms": "0.1.23"
+  "cli": "0.1.24",
+  "docs-config": "0.1.24",
+  "docs-theme": "0.1.24",
+  "docs-transforms": "0.1.24"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/init/tools/shared/create-agnostic-skill-bundle-contract.test.ts
+++ b/packages/cli/src/commands/init/tools/shared/create-agnostic-skill-bundle-contract.test.ts
@@ -1,0 +1,46 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  cwd: import.meta.dirname,
+  encoding: 'utf8',
+}).trim();
+
+function repoFilePath(relativePath: string): string {
+  return join(REPO_ROOT, relativePath);
+}
+
+const SKILL_DIR = '.agents/skills/create-agnostic-skill';
+
+describe('create-agnostic-skill bundle contract', () => {
+  it('vendors skills-guide.md into the skill so it travels when distributed', () => {
+    // readFileSync follows the symlink; a broken/missing link throws and fails here.
+    const vendored = readFileSync(
+      repoFilePath(`${SKILL_DIR}/references/docs/skills-guide.md`),
+      'utf8',
+    );
+
+    expect(vendored).toContain('# Skills Research Reference');
+  });
+
+  it('references the bundled doc path, not the repo-root .agents/docs/ path', () => {
+    const skill = readFileSync(repoFilePath(`${SKILL_DIR}/SKILL.md`), 'utf8');
+    const template = readFileSync(
+      repoFilePath(`${SKILL_DIR}/references/skill-template.md`),
+      'utf8',
+    );
+
+    // Bundled pointer must be present in both surfaces.
+    expect(skill).toContain('references/docs/skills-guide.md');
+    expect(template).toContain('references/docs/skills-guide.md');
+
+    // The dangling repo-root pointer must not return: it does not resolve once
+    // the skill is installed into a consumer repo (.agents/docs/ does not ship
+    // with the skill bundle).
+    expect(skill).not.toContain('.agents/docs/skills-guide.md');
+    expect(template).not.toContain('.agents/docs/skills-guide.md');
+  });
+});

--- a/packages/cli/src/commands/init/tools/shared/skills-bundled-docs-contract.test.ts
+++ b/packages/cli/src/commands/init/tools/shared/skills-bundled-docs-contract.test.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  cwd: import.meta.dirname,
+  encoding: 'utf8',
+}).trim();
+
+const SKILLS_DIR = join(REPO_ROOT, '.agents', 'skills');
+const SHARED_DOCS_DIR = join(REPO_ROOT, '.agents', 'docs');
+
+// Matches a Markdown reference to a real shared doc, e.g. `.agents/docs/skills-guide.md`.
+const SHARED_DOC_REF = /\.agents\/docs\/([a-zA-Z0-9_-]+)\.md/g;
+
+// A line carrying this marker is opting out: the reference is intentionally
+// monorepo-internal and not expected to resolve in consumer repos.
+const MONOREPO_ONLY_MARKER = /monorepo only/i;
+
+interface Violation {
+  file: string;
+  doc: string;
+  line: string;
+}
+
+function listSkillDirs(): string[] {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}
+
+function listAuthoredMarkdown(skillDir: string): string[] {
+  // Recurse the skill, but skip references/docs/ — those are vendored copies of
+  // shared docs (symlinks materialized at build time), not authored pointers.
+  return readdirSync(skillDir, { recursive: true, encoding: 'utf8' })
+    .filter((rel) => rel.endsWith('.md') && !rel.includes('references/docs'))
+    .map((rel) => join(skillDir, rel));
+}
+
+function collectViolations(): Violation[] {
+  const violations: Violation[] = [];
+
+  for (const skill of listSkillDirs()) {
+    const skillDir = join(SKILLS_DIR, skill);
+
+    for (const file of listAuthoredMarkdown(skillDir)) {
+      const relFile = file.slice(REPO_ROOT.length + 1);
+
+      for (const line of readFileSync(file, 'utf8').split('\n')) {
+        for (const match of line.matchAll(SHARED_DOC_REF)) {
+          const doc = match[1];
+
+          // Illustrative example paths (e.g. my-guide.md) don't exist — skip.
+          if (!existsSync(join(SHARED_DOCS_DIR, `${doc}.md`))) continue;
+          // The skill vendors the doc into its own bundle — it travels. OK.
+          if (existsSync(join(skillDir, 'references', 'docs', `${doc}.md`))) {
+            continue;
+          }
+          // Explicit opt-out: intentionally monorepo-internal.
+          if (MONOREPO_ONLY_MARKER.test(line)) continue;
+
+          violations.push({
+            file: relFile,
+            doc: `${doc}.md`,
+            line: line.trim(),
+          });
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+describe('skills bundled docs contract', () => {
+  it('no shipped skill references a shared .agents/docs/ doc that does not travel with it', () => {
+    const violations = collectViolations();
+
+    // A reference to `.agents/docs/<doc>.md` resolves inside this monorepo but
+    // dangles once the skill is installed standalone, since `.agents/docs/` is
+    // not part of the skill bundle. Fix by vendoring the doc via symlink into
+    // the skill's `references/docs/` and pointing at that bundled path, or — if
+    // the reference is intentionally monorepo-internal — annotate the line with
+    // a "monorepo only" marker.
+    const detail = violations
+      .map((v) => `  ${v.file} -> .agents/docs/${v.doc}\n    ${v.line}`)
+      .join('\n');
+
+    expect(
+      violations,
+      `Skill(s) reference a shared doc that won't ship with the bundle:\n${detail}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Problem

`create-agnostic-skill` referenced `.agents/docs/skills-guide.md` directly. That path resolves inside this monorepo, but the skill bundle's distribution boundary is the skill directory (`SKILL.md` + `references/`) — `.agents/docs/` does **not** travel with an installed skill. So once the skill is installed into a consumer repo, every `skills-guide.md` pointer becomes a dangling reference (observed by an agent in another repo).

## Fix

Apply the repo's existing **vendor-at-build** convention (already used by `oat-agent-instructions-{analyze,apply}`): a single canonical doc in `.agents/docs/`, surfaced into the skill via a symlink that `bundle-assets.sh` (`cp -RL`) materializes into a real file at build time.

- **Vendor** `skills-guide.md` via symlink → `references/docs/skills-guide.md`; rewrite the 3 SKILL.md/template pointers to the bundled path. The canonical source stays single (symlink), self-containment happens only in the built artifact.
- **Doctrine fix (root cause):** the skill *taught* "place shared docs in `.agents/docs/`, don't duplicate per skill" — the exact advice that produces dangling pointers in distributed skills. Rewrote the "Shared References" guidance in both `SKILL.md` and the scaffold template so newly-created skills vendor distributed docs instead.
- **Mark** the `reference-architecture.md` pointer as monorepo-only (OAT-internal layout, not useful to consumers; intentionally not bundled).
- **oat-wrap-up:** softened a dead `.agents/docs/agent-instruction.md:18` provenance cite that didn't resolve in consumer repos.

## Guard

- `skills-bundled-docs-contract.test.ts` — repo-wide guard: fails if any skill references a real `.agents/docs/<doc>.md` that won't ship with its bundle, unless the line carries a `monorepo only` opt-out marker. Verified non-vacuous (fails on an injected dangling ref, green when clean).
- `create-agnostic-skill-bundle-contract.test.ts` — asserts the vendored doc resolves and no dangling pointer remains.

## Versioning

- Skills: `create-agnostic-skill` 1.3.0 → 1.4.0, `oat-wrap-up` 1.0.1 → 1.0.2
- Lockstep public packages: all five → 0.1.24 (`.agents/skills` counts as shipped CLI functionality)

## Verification

- lint ✓ · format ✓ · type-check ✓ · full CLI suite (1812) ✓
- `pnpm release:validate` ✓ (5 public packages at 0.1.24)
- Confirmed `bundle-assets.sh` materializes the symlink into a real file in the bundle (0 dangling refs in the built `assets/`)