### PR TITLE
fix(local): make localPaths glob expansion safe for worktrees

### DIFF
--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.1.24",
-  "docs-config": "0.1.24",
-  "docs-theme": "0.1.24",
-  "docs-transforms": "0.1.24"
+  "cli": "0.1.25",
+  "docs-config": "0.1.25",
+  "docs-theme": "0.1.25",
+  "docs-transforms": "0.1.25"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/local/expand.test.ts
+++ b/packages/cli/src/commands/local/expand.test.ts
@@ -1,0 +1,145 @@
+import type { Dirent } from 'node:fs';
+import * as fsp from 'node:fs/promises';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { expandLocalPaths } from './expand';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof fsp>();
+  return { ...actual, readdir: vi.fn() };
+});
+
+type DirectoryTree = Record<string, Dirent[]>;
+
+function fakeDirent(name: string, directory = false): Dirent {
+  return {
+    name,
+    isDirectory: () => directory,
+  } as Dirent;
+}
+
+function normalizeFsPath(path: unknown): string {
+  return String(path).replaceAll('\\', '/');
+}
+
+function mockDirectoryTree(tree: DirectoryTree): string[] {
+  const calls: string[] = [];
+
+  vi.mocked(fsp.readdir).mockImplementation(async (path) => {
+    const normalizedPath = normalizeFsPath(path);
+    calls.push(normalizedPath);
+    return (tree[normalizedPath] ?? []) as any;
+  });
+
+  return calls;
+}
+
+describe('expandLocalPaths', () => {
+  afterEach(() => {
+    vi.mocked(fsp.readdir).mockReset();
+  });
+
+  it('prunes generated and cache directories from glob candidates', async () => {
+    const root = '/repo';
+    const prunedDirectories = [
+      '.git',
+      '.worktrees',
+      'node_modules',
+      'dist',
+      '.turbo',
+    ];
+    const tree: DirectoryTree = {
+      [root]: [
+        fakeDirent('.oat', true),
+        ...prunedDirectories.map((name) => fakeDirent(name, true)),
+      ],
+      [`${root}/.oat`]: [fakeDirent('projects', true)],
+      [`${root}/.oat/projects`]: [fakeDirent('shared', true)],
+      [`${root}/.oat/projects/shared`]: [fakeDirent('alpha', true)],
+      [`${root}/.oat/projects/shared/alpha`]: [fakeDirent('reviews', true)],
+      [`${root}/.oat/projects/shared/alpha/reviews`]: [],
+    };
+
+    for (const directory of prunedDirectories) {
+      tree[`${root}/${directory}`] = [fakeDirent('nested', true)];
+      tree[`${root}/${directory}/nested`] = [fakeDirent('reviews', true)];
+      tree[`${root}/${directory}/nested/reviews`] = [];
+    }
+
+    const calls = mockDirectoryTree(tree);
+
+    await expect(expandLocalPaths(root, ['**'])).resolves.toEqual({
+      resolved: [
+        '.oat',
+        '.oat/projects',
+        '.oat/projects/shared',
+        '.oat/projects/shared/alpha',
+        '.oat/projects/shared/alpha/reviews',
+      ],
+      missingGlobs: [],
+    });
+
+    for (const directory of prunedDirectories) {
+      expect(calls).not.toContain(`${root}/${directory}`);
+    }
+  });
+
+  it('appends large matched child collections without overflowing', async () => {
+    const root = '/large-repo';
+    const matchCount = 150_000;
+    const tree: DirectoryTree = {
+      [root]: [fakeDirent('.oat', true)],
+      [`${root}/.oat`]: [fakeDirent('projects', true)],
+      [`${root}/.oat/projects`]: Array.from(
+        { length: matchCount },
+        (_, index) => fakeDirent(`review-${String(index).padStart(6, '0')}.md`),
+      ),
+    };
+    mockDirectoryTree(tree);
+
+    const result = await expandLocalPaths(root, ['.oat/projects/review-*']);
+
+    expect(result.missingGlobs).toEqual([]);
+    expect(result.resolved).toHaveLength(matchCount);
+    expect(result.resolved[0]).toBe('.oat/projects/review-000000.md');
+    expect(result.resolved.at(-1)).toBe('.oat/projects/review-149999.md');
+  });
+
+  it('resolves expected project review directories', async () => {
+    const root = '/repo';
+    mockDirectoryTree({
+      [root]: [fakeDirent('.oat', true)],
+      [`${root}/.oat`]: [fakeDirent('projects', true)],
+      [`${root}/.oat/projects`]: [fakeDirent('shared', true)],
+      [`${root}/.oat/projects/shared`]: [
+        fakeDirent('alpha', true),
+        fakeDirent('beta', true),
+        fakeDirent('dist', true),
+      ],
+      [`${root}/.oat/projects/shared/alpha`]: [
+        fakeDirent('reviews', true),
+        fakeDirent('pr', true),
+      ],
+      [`${root}/.oat/projects/shared/alpha/reviews`]: [
+        fakeDirent('artifact.md'),
+      ],
+      [`${root}/.oat/projects/shared/alpha/pr`]: [],
+      [`${root}/.oat/projects/shared/beta`]: [fakeDirent('reviews', true)],
+      [`${root}/.oat/projects/shared/beta/reviews`]: [],
+      [`${root}/.oat/projects/shared/dist`]: [fakeDirent('reviews', true)],
+      [`${root}/.oat/projects/shared/dist/reviews`]: [],
+    });
+
+    await expect(
+      expandLocalPaths(root, ['.oat/projects/**/reviews']),
+    ).resolves.toEqual({
+      resolved: [
+        '.oat/projects/shared/alpha/reviews',
+        '.oat/projects/shared/beta/reviews',
+        '.oat/projects/shared/dist/reviews',
+      ],
+      missingGlobs: [],
+    });
+  });
+});

--- a/packages/cli/src/commands/local/expand.ts
+++ b/packages/cli/src/commands/local/expand.ts
@@ -2,6 +2,31 @@ import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 const GLOB_CHARS = /[*?[]/;
+const PRUNED_CANDIDATE_DIRECTORIES = new Set([
+  '.cache',
+  '.git',
+  '.gradle',
+  '.next',
+  '.nuxt',
+  '.output',
+  '.parcel-cache',
+  '.pnpm-store',
+  '.pytest_cache',
+  '.ruff_cache',
+  '.turbo',
+  '.venv',
+  '.vite',
+  '.worktrees',
+  '.yarn',
+  '__pycache__',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'target',
+  'tmp',
+]);
 
 function normalizePattern(path: string): string {
   return path.replaceAll('\\', '/').replace(/^\.\//, '').replace(/\/+$/, '');
@@ -48,21 +73,42 @@ function globToRegExp(pattern: string): RegExp {
   return new RegExp(regex);
 }
 
+function isOatStatePath(path: string): boolean {
+  return path === '.oat' || path.startsWith('.oat/');
+}
+
+function shouldPruneCandidateDirectory(path: string, name: string): boolean {
+  return !isOatStatePath(path) && PRUNED_CANDIDATE_DIRECTORIES.has(name);
+}
+
 async function collectRelativePaths(
   root: string,
   current = '',
 ): Promise<string[]> {
-  const dirPath = current === '' ? root : join(root, current);
-  const entries = await readdir(dirPath, { withFileTypes: true });
   const paths: string[] = [];
+  const pendingDirectories = [current];
 
-  for (const entry of entries) {
-    const relativePath =
-      current === '' ? entry.name : `${current}/${entry.name}`;
-    paths.push(relativePath);
+  while (pendingDirectories.length > 0) {
+    const directory = pendingDirectories.pop()!;
+    const dirPath = directory === '' ? root : join(root, directory);
+    const entries = await readdir(dirPath, { withFileTypes: true });
 
-    if (entry.isDirectory()) {
-      paths.push(...(await collectRelativePaths(root, relativePath)));
+    for (const entry of entries) {
+      const relativePath =
+        directory === '' ? entry.name : `${directory}/${entry.name}`;
+      const shouldPrune =
+        entry.isDirectory() &&
+        shouldPruneCandidateDirectory(relativePath, entry.name);
+
+      if (shouldPrune) {
+        continue;
+      }
+
+      paths.push(relativePath);
+
+      if (entry.isDirectory()) {
+        pendingDirectories.push(relativePath);
+      }
     }
   }
 
@@ -106,7 +152,9 @@ export async function expandLocalPaths(
     if (matches.length === 0) {
       missingGlobs.push(localPath);
     } else {
-      resolved.push(...matches.sort());
+      for (const match of matches.sort()) {
+        resolved.push(match);
+      }
     }
   }
 

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- prune generated/cache directories during localPaths glob candidate collection, including repo-local `.worktrees`
- replace recursive collection and large array spreads with iterative traversal and append loops
- add focused coverage for pruned subtrees, large match sets, and `.oat/projects/**/reviews` expansion
- bump lockstep public packages to `0.1.25` for shipped CLI behavior

## Root Cause
`expandLocalPaths` recursively scanned the full repo for glob localPaths and used `push(...largeArray)` while collecting candidates and resolved matches. Large repos with repo-local worktrees could feed hundreds of thousands of paths into that flow and trip V8 call stack/argument limits.

## Validation
- `pnpm --filter @open-agent-toolkit/cli exec vitest run src/commands/local`
- `pnpm --filter @open-agent-toolkit/cli build`
- `pnpm --filter @open-agent-toolkit/cli lint`
- `pnpm release:check-versions`
- `pnpm release:validate`
- push hooks: release check, skill version validation, workspace type-check, lint, format