### PR TITLE
fix(docs): remove useless-spread from fumadocs scaffold next.config.js

### DIFF
--- a/.oat/templates/docs-app-fuma/next.config.js
+++ b/.oat/templates/docs-app-fuma/next.config.js
@@ -2,6 +2,4 @@ import { createDocsConfig } from '@open-agent-toolkit/docs-config';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || undefined;
 
-export default createDocsConfig({
-  ...(basePath ? { basePath } : {}),
-});
+export default createDocsConfig(basePath ? { basePath } : {});

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.1.28",
-  "docs-config": "0.1.28",
-  "docs-theme": "0.1.28",
-  "docs-transforms": "0.1.28"
+  "cli": "0.1.29",
+  "docs-config": "0.1.29",
+  "docs-theme": "0.1.29",
+  "docs-transforms": "0.1.29"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/docs/init/integration.test.ts
+++ b/packages/cli/src/commands/docs/init/integration.test.ts
@@ -119,8 +119,9 @@ describe('scaffold integration', () => {
         join(result.appRoot, 'next.config.js'),
         'utf8',
       );
-      expect(nextConfig).toContain('createDocsConfig({');
-      expect(nextConfig).toContain('...(basePath ? { basePath } : {})');
+      expect(nextConfig).toContain(
+        'createDocsConfig(basePath ? { basePath } : {})',
+      );
       expect(nextConfig).not.toContain('title:');
       expect(nextConfig).not.toContain('description:');
       expect(nextConfig).toContain('NEXT_PUBLIC_BASE_PATH');

--- a/packages/cli/src/commands/docs/init/scaffold.test.ts
+++ b/packages/cli/src/commands/docs/init/scaffold.test.ts
@@ -39,7 +39,7 @@ const FUMA_TEMPLATE_FILES: Record<string, string> = {
   '.gitignore':
     '# Dependencies\nnode_modules/\n\n# Next.js build output\n.next/\nout/\n\n# fumadocs-mdx generated source\n.source/\n\n# Next.js generated types\nnext-env.d.ts\n',
   'next.config.js':
-    "import { createDocsConfig } from '@open-agent-toolkit/docs-config';\nconst basePath = process.env.NEXT_PUBLIC_BASE_PATH || undefined;\nexport default createDocsConfig({ ...(basePath ? { basePath } : {}) });\n",
+    "import { createDocsConfig } from '@open-agent-toolkit/docs-config';\nconst basePath = process.env.NEXT_PUBLIC_BASE_PATH || undefined;\nexport default createDocsConfig(basePath ? { basePath } : {});\n",
   'postcss.config.mjs':
     "const config = {\n  plugins: {\n    '@tailwindcss/postcss': {},\n  },\n};\n\nexport default config;\n",
   'source.config.ts':
@@ -424,8 +424,9 @@ describe('scaffoldDocsApp', () => {
       join(result.appRoot, 'next.config.js'),
       'utf8',
     );
-    expect(nextConfig).toContain('createDocsConfig({');
-    expect(nextConfig).toContain('...(basePath ? { basePath } : {})');
+    expect(nextConfig).toContain(
+      'createDocsConfig(basePath ? { basePath } : {})',
+    );
     expect(nextConfig).not.toContain('title:');
     expect(nextConfig).not.toContain('description:');
     expect(nextConfig).toContain('NEXT_PUBLIC_BASE_PATH');

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Problem

The `oat-fumadocs` scaffold shipped `next.config.js` with a redundant conditional spread:

```js
export default createDocsConfig({ ...(basePath ? { basePath } : {}) });
```

`(basePath ? { basePath } : {})` already returns a fresh object, so spreading it into a wrapper literal trips `unicorn(no-useless-spread)`. **Every** scaffold therefore landed a file that fails a tree-wide oxlint run out of the box. The scaffold's own `docs:lint` only checks Markdown, so it slipped through CI on the scaffolded side — the failure surfaces wherever the generated file lands in a repo that lints the whole tree.

This is the second scaffold-bug data point alongside the `allowBuilds` placeholder.

## Fix

Pass the object directly instead of spreading it — behavior is identical:

```js
export default createDocsConfig(basePath ? { basePath } : {});
```

## Changes

- `.oat/templates/docs-app-fuma/next.config.js` — the fix (canonical source; the gitignored bundled copy regenerates from this via `bundle-assets.sh`).
- `packages/cli/src/commands/docs/init/{scaffold,integration}.test.ts` — updated the assertions and mock-template fixture that pinned the old spread.
- Lockstep version bump `0.1.27 → 0.1.28` for the five public packages (cli, control-plane, docs-config, docs-theme, docs-transforms), per the `.oat/templates` shipped-functionality policy in `AGENTS.md`. The tracked `assets/public-package-versions.json` manifest picked up the bump automatically.

## Verification

- `oxlint` on the changed template: 0 warnings, 0 errors
- `pnpm lint`, `pnpm type-check`: pass
- affected tests (`scaffold.test.ts` + `integration.test.ts`): 15/15 pass
- `pnpm release:validate`: pass (5 public packages)
- `pnpm release:check-versions`: pass