### PR TITLE
[codex] fix worktree hook install path

### DIFF
--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.1.30",
-  "docs-config": "0.1.30",
-  "docs-theme": "0.1.30",
-  "docs-transforms": "0.1.30"
+  "cli": "0.1.31",
+  "docs-config": "0.1.31",
+  "docs-theme": "0.1.31",
+  "docs-transforms": "0.1.31"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/engine/hook.test.ts
+++ b/packages/cli/src/engine/hook.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import {
   lstat,
   mkdir,
@@ -210,6 +211,54 @@ describe('git hook', () => {
     expect(content).toContain('--scope project');
   });
 
+  it('installHook writes to Git active hooks directory from a linked worktree', async () => {
+    const mainRoot = await mkdtemp(join(tmpdir(), 'oat-hook-main-'));
+    tempDirs.push(mainRoot);
+    execFileSync('git', ['init'], { cwd: mainRoot, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.name', 'OAT Test'], {
+      cwd: mainRoot,
+    });
+    execFileSync('git', ['config', 'user.email', 'oat@example.test'], {
+      cwd: mainRoot,
+    });
+    await writeFile(join(mainRoot, 'README.md'), 'test\n', 'utf8');
+    execFileSync('git', ['add', 'README.md'], {
+      cwd: mainRoot,
+      stdio: 'ignore',
+    });
+    execFileSync('git', ['commit', '-m', 'initial'], {
+      cwd: mainRoot,
+      stdio: 'ignore',
+    });
+
+    const worktreeParent = await mkdtemp(join(tmpdir(), 'oat-hook-worktree-'));
+    tempDirs.push(worktreeParent);
+    const worktreeRoot = join(worktreeParent, 'feature');
+    execFileSync('git', ['worktree', 'add', '-b', 'feature', worktreeRoot], {
+      cwd: mainRoot,
+      stdio: 'ignore',
+    });
+
+    const hookPath = await installHook(worktreeRoot);
+    const activeHooksDir = execFileSync(
+      'git',
+      ['rev-parse', '--path-format=absolute', '--git-path', 'hooks'],
+      { cwd: worktreeRoot, encoding: 'utf8' },
+    ).trim();
+    const privateGitDir = execFileSync(
+      'git',
+      ['rev-parse', '--path-format=absolute', '--git-dir'],
+      { cwd: worktreeRoot, encoding: 'utf8' },
+    ).trim();
+
+    expect(hookPath).toBe(join(activeHooksDir, 'pre-commit'));
+    const content = await readFile(hookPath, 'utf8');
+    expect(content).toContain(HOOK_MARKER_START);
+    await expect(
+      readFile(join(privateGitDir, 'hooks', 'pre-commit'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   describe('core.hooksPath support', () => {
     async function createGitRepoRoot(prefix: string): Promise<string> {
       const root = await mkdtemp(join(tmpdir(), prefix));
@@ -265,8 +314,13 @@ describe('git hook', () => {
       );
 
       const info = await getHookInstallInfo(root);
+      const activeHooksDir = execFileSync(
+        'git',
+        ['rev-parse', '--path-format=absolute', '--git-path', 'hooks'],
+        { cwd: root, encoding: 'utf8' },
+      ).trim();
 
-      expect(info.hookPath).toBe(join(root, '.git', 'hooks', 'pre-commit'));
+      expect(info.hookPath).toBe(join(activeHooksDir, 'pre-commit'));
       expect(info.suggestedHooksPath).toBe('.githooks');
       expect(info.suggestedHookPath).toBe(
         join(root, '.githooks', 'pre-commit'),

--- a/packages/cli/src/engine/hook.ts
+++ b/packages/cli/src/engine/hook.ts
@@ -121,6 +121,23 @@ async function resolveHooksDirectory(
     return configuredPath;
   }
 
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--path-format=absolute', '--git-path', 'hooks'],
+      { cwd: projectRoot },
+    );
+    const gitHooksDir = stdout.trim();
+    if (gitHooksDir) {
+      if (shouldCreate) {
+        await ensureDir(gitHooksDir);
+      }
+      return gitHooksDir;
+    }
+  } catch {
+    // Fall back to filesystem resolution for tests and nonstandard fixtures.
+  }
+
   const gitDir = await resolveGitDirectory(projectRoot);
   const hooksDir = join(gitDir, 'hooks');
 

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- Resolve the default Git hooks directory with `git rev-parse --path-format=absolute --git-path hooks` so CLI hook installation targets the hooks directory Git actually executes from linked worktrees.
- Keep the existing filesystem fallback for nonstandard fixtures.
- Add a regression test that installs the OAT hook from a linked worktree and verifies it does not write into the private worktree gitdir hooks path.
- Bump the lockstep public package versions to `0.1.31` and refresh bundled public package version metadata.

## Verification
- `pnpm --filter @open-agent-toolkit/cli exec vitest run src/engine/hook.test.ts`
- `pnpm --filter @open-agent-toolkit/cli lint`
- `pnpm --filter @open-agent-toolkit/cli type-check`
- `pnpm release:validate`
- `pnpm release:check-versions`
- `git push -u origin worktree-init-fix` (pre-push hook passed version checks, skill-version checks, full type-check, lint, and format)