### PR TITLE
fix: harden gate review artifact handling

### DIFF
--- a/.agents/skills/oat-review-provide/SKILL.md
+++ b/.agents/skills/oat-review-provide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-review-provide
-version: 1.2.1
+version: 1.2.2
 description: Use when you need an ad-hoc review outside an active OAT project lifecycle. Reviews code or artifacts without project phase state, unlike oat-project-review-provide.
 argument-hint: '[unstaged|staged|base_branch=<branch>|base_sha=<sha>|<sha1>..<sha2>|--files <path1,path2,...>] [--output <path>] [--mode auto|local|tracked|inline]'
 disable-model-invocation: true
@@ -183,7 +183,7 @@ If the file already exists (same scope reviewed twice in one day), suffix with `
 
 Use the same severity model and checklist as project reviews:
 
-- Critical / Important / Minor findings
+- Critical / Important / Medium / Minor findings
 - file:line references
 - actionable fix guidance
 - verification commands

--- a/.agents/skills/oat-review-provide/references/review-artifact-template.md
+++ b/.agents/skills/oat-review-provide/references/review-artifact-template.md
@@ -23,19 +23,25 @@ oat_review_mode: ad_hoc
 
 {2-3 sentence summary}
 
+Findings: {N} critical, {N} important, {N} medium, {N} minor
+
 ## Findings
 
 ### Critical
 
-{None or list}
+{If none: "None"}
 
 ### Important
 
-{None or list}
+{If none: "None"}
+
+### Medium
+
+{If none: "None"}
 
 ### Minor
 
-{None or list}
+{If none: "None"}
 
 ## Verification Commands
 

--- a/.oat/sync/manifest.json
+++ b/.oat/sync/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "oatVersion": "0.1.36",
+  "oatVersion": "0.1.38",
   "entries": [
     {
       "canonicalPath": ".agents/agents/oat-codebase-mapper.md",

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.1.37",
-  "docs-config": "0.1.37",
-  "docs-theme": "0.1.37",
-  "docs-transforms": "0.1.37"
+  "cli": "0.1.38",
+  "docs-config": "0.1.38",
+  "docs-theme": "0.1.38",
+  "docs-transforms": "0.1.38"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/gate/index.test.ts
+++ b/packages/cli/src/commands/gate/index.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -308,7 +315,14 @@ describe('oat gate', () => {
     fileName?: string;
     generatedAt?: string;
     reviewScope?: string;
-    finding?: 'important' | 'clean';
+    finding?: 'important' | 'minor' | 'clean';
+    omitMediumSection?: boolean;
+    counts?: {
+      critical: number;
+      important: number;
+      medium: number;
+      minor: number;
+    };
   }): Promise<string> {
     const relativePath = `${options.projectPath}/reviews/${options.fileName ?? 'p01-review.md'}`;
     await mkdir(join(options.root, dirname(relativePath)), {
@@ -318,6 +332,21 @@ describe('oat gate', () => {
       options.finding === 'important'
         ? ['- Important finding that should block.']
         : ['None.'];
+    const minorContent =
+      options.finding === 'minor'
+        ? ['- Minor finding that still needs disposition.']
+        : ['None.'];
+    const countLines = options.counts
+      ? [
+          `oat_review_critical_count: ${options.counts.critical}`,
+          `oat_review_important_count: ${options.counts.important}`,
+          `oat_review_medium_count: ${options.counts.medium}`,
+          `oat_review_minor_count: ${options.counts.minor}`,
+        ]
+      : [];
+    const mediumSection = options.omitMediumSection
+      ? []
+      : ['### Medium', '', 'None', ''];
     await writeFile(
       join(options.root, relativePath),
       [
@@ -328,6 +357,7 @@ describe('oat gate', () => {
         `oat_review_scope: ${options.reviewScope ?? 'p01'}`,
         'oat_review_invocation: gate',
         `oat_project: ${options.projectPath}`,
+        ...countLines,
         '---',
         '',
         '# Review',
@@ -342,13 +372,10 @@ describe('oat gate', () => {
         '',
         ...importantContent,
         '',
-        '### Medium',
-        '',
-        'None',
-        '',
+        ...mediumSection,
         '### Minor',
         '',
-        'None',
+        ...minorContent,
       ].join('\n'),
       'utf8',
     );
@@ -1503,6 +1530,221 @@ describe('oat gate', () => {
     expect(process.exitCode).toBe(0);
   });
 
+  it('normalizes a gate review artifact missing only a zero-count Medium heading', async () => {
+    const { root, home } = await setup();
+    const projectPath = await writeProject(root);
+    await writeActiveProject(root, projectPath);
+    let artifactPath = '';
+    const runner = createProcessRunner({
+      onExecute: async () => {
+        artifactPath = await writeReviewArtifact({
+          root,
+          projectPath,
+          reviewScope: 'final',
+          finding: 'clean',
+          omitMediumSection: true,
+          counts: {
+            critical: 0,
+            important: 0,
+            medium: 0,
+            minor: 0,
+          },
+        });
+      },
+    });
+
+    const capture = await runReviewGate({
+      root,
+      home,
+      runProcess: runner.runProcess,
+      args: [
+        '--target',
+        'codex-default',
+        '--review-scope',
+        'final',
+        '--review-type',
+        'code',
+        '--exit-nonzero-on',
+        'important',
+        'Use oat-project-review-provide code final.',
+      ],
+    });
+
+    expect(capture.jsonPayloads[0]).toMatchObject({
+      status: 'ok',
+      outcome: 'review_completed_artifact_normalized_gate_passed',
+      artifactPath,
+      blocking: false,
+      counts: {
+        critical: 0,
+        important: 0,
+        medium: 0,
+        minor: 0,
+      },
+      normalization: {
+        insertedSeverities: ['medium'],
+      },
+    });
+    const artifactContent = await readFile(join(root, artifactPath), 'utf8');
+    expect(artifactContent).toMatch(
+      /### Important[\s\S]*None[\s\S]*### Medium\s+None[\s\S]*### Minor/i,
+    );
+    await expect(readdir(join(root, projectPath, 'reviews'))).resolves.toEqual([
+      'p01-review.md',
+    ]);
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('reports artifact validation failure when a missing severity has nonzero findings', async () => {
+    const { root, home } = await setup();
+    const projectPath = await writeProject(root);
+    await writeActiveProject(root, projectPath);
+    let artifactPath = '';
+    const runner = createProcessRunner({
+      onExecute: async () => {
+        artifactPath = await writeReviewArtifact({
+          root,
+          projectPath,
+          reviewScope: 'final',
+          finding: 'clean',
+          omitMediumSection: true,
+          counts: {
+            critical: 0,
+            important: 0,
+            medium: 1,
+            minor: 0,
+          },
+        });
+      },
+    });
+
+    const capture = await runReviewGate({
+      root,
+      home,
+      runProcess: runner.runProcess,
+      args: ['--target', 'codex-default', 'Review'],
+    });
+
+    expect(capture.jsonPayloads[0]).toMatchObject({
+      status: 'artifact_validation_failed',
+      outcome: 'review_completed_artifact_validation_failed',
+      artifactPath,
+      message: expect.stringContaining('cannot be safely normalized'),
+      recovery: expect.stringContaining('oat-project-review-receive'),
+    });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('keeps final-scope Minor-only gate success tied to review-receive disposition', async () => {
+    const { root, home } = await setup();
+    const projectPath = await writeProject(root);
+    await writeActiveProject(root, projectPath);
+    let artifactPath = '';
+    const runner = createProcessRunner({
+      onExecute: async () => {
+        artifactPath = await writeReviewArtifact({
+          root,
+          projectPath,
+          reviewScope: 'final',
+          finding: 'minor',
+        });
+      },
+    });
+
+    const capture = await runReviewGate({
+      root,
+      home,
+      runProcess: runner.runProcess,
+      args: [
+        '--target',
+        'codex-default',
+        '--review-scope',
+        'final',
+        '--review-type',
+        'code',
+        '--exit-nonzero-on',
+        'important',
+        'Review',
+      ],
+    });
+
+    expect(capture.jsonPayloads[0]).toMatchObject({
+      status: 'ok',
+      outcome: 'review_completed_gate_passed',
+      artifactPath,
+      blocking: false,
+      counts: {
+        critical: 0,
+        important: 0,
+        medium: 0,
+        minor: 1,
+      },
+      handoff: expect.stringContaining(
+        'final review still contains non-blocking findings',
+      ),
+    });
+    expect(capture.jsonPayloads[0]).toMatchObject({
+      handoff: expect.stringContaining(
+        'before marking the final review row passed',
+      ),
+    });
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('keeps final-scope Important findings in handoff text when only Critical blocks', async () => {
+    const { root, home } = await setup();
+    const projectPath = await writeProject(root);
+    await writeActiveProject(root, projectPath);
+    let artifactPath = '';
+    const runner = createProcessRunner({
+      onExecute: async () => {
+        artifactPath = await writeReviewArtifact({
+          root,
+          projectPath,
+          reviewScope: 'final',
+          finding: 'important',
+        });
+      },
+    });
+
+    const capture = await runReviewGate({
+      root,
+      home,
+      runProcess: runner.runProcess,
+      args: [
+        '--target',
+        'codex-default',
+        '--review-scope',
+        'final',
+        '--review-type',
+        'code',
+        '--exit-nonzero-on',
+        'critical',
+        'Review',
+      ],
+    });
+
+    expect(capture.jsonPayloads[0]).toMatchObject({
+      status: 'ok',
+      outcome: 'review_completed_gate_passed',
+      artifactPath,
+      blocking: false,
+      counts: {
+        critical: 0,
+        important: 1,
+        medium: 0,
+        minor: 0,
+      },
+      handoff: expect.stringContaining('important=1'),
+    });
+    expect(capture.jsonPayloads[0]).toMatchObject({
+      handoff: expect.stringContaining(
+        'before marking the final review row passed',
+      ),
+    });
+    expect(process.exitCode).toBe(0);
+  });
+
   it('detects a same-day lower-rank review produced when a higher-rank review already exists', async () => {
     const { root, home } = await setup();
     const projectPath = await writeProject(root);
@@ -1658,7 +1900,8 @@ describe('oat gate', () => {
     });
 
     expect(capture.jsonPayloads[0]).toMatchObject({
-      status: 'error',
+      status: 'artifact_validation_failed',
+      outcome: 'review_completed_artifact_validation_failed',
       message: expect.stringContaining('No new review artifact was detected'),
     });
     expect(process.exitCode).toBe(1);
@@ -1686,7 +1929,8 @@ describe('oat gate', () => {
     });
 
     expect(capture.jsonPayloads[0]).toMatchObject({
-      status: 'error',
+      status: 'artifact_validation_failed',
+      outcome: 'review_completed_artifact_validation_failed',
       message: expect.stringContaining('No new review artifact was detected'),
     });
     expect(process.exitCode).toBe(1);

--- a/packages/cli/src/commands/gate/index.ts
+++ b/packages/cli/src/commands/gate/index.ts
@@ -43,6 +43,7 @@ import { Command } from 'commander';
 
 import {
   parseReviewGateVerdict,
+  severityDisplayName,
   type ReviewGateVerdict,
 } from './review-verdict';
 
@@ -170,7 +171,7 @@ const VALID_REVIEW_GATE_THRESHOLDS: readonly ReviewGateThreshold[] = [
   'minor',
 ];
 const REVIEW_GATE_CONTEXT_NOTE =
-  'This review is gate-originated. If you run `oat-project-review-provide`, set `oat_review_invocation: gate` in the review artifact.';
+  'This review is gate-originated. If you run `oat-project-review-provide`, set `oat_review_invocation: gate` in the review artifact. Write a canonical review artifact with `### Critical`, `### Important`, `### Medium`, and `### Minor` headings in that order, using `None` for empty sections.';
 
 function reviewGateProjectContext(projectPath: string): string {
   return `Resolved OAT project path: ${projectPath}. Run the review for this project path.`;
@@ -1048,6 +1049,51 @@ function reviewBlocksAtThreshold(
   return verdict.counts.minor > 0;
 }
 
+function buildReviewGateHandoff(options: {
+  artifactPath: string;
+  verdict: ReviewGateVerdict;
+  threshold: ReviewGateThreshold;
+  blocking: boolean;
+}): string {
+  const receiveInstruction = `Run oat-project-review-receive for ${options.artifactPath} before treating this gate review as consumed.`;
+  const thresholdIndex = VALID_REVIEW_GATE_THRESHOLDS.indexOf(
+    options.threshold,
+  );
+  const nonBlockingSeverities = VALID_REVIEW_GATE_THRESHOLDS.slice(
+    thresholdIndex + 1,
+  ).filter((severity) => options.verdict.counts[severity] > 0);
+  const hasFinalNonBlockingFindings =
+    options.verdict.scope === 'final' &&
+    !options.blocking &&
+    nonBlockingSeverities.length > 0;
+
+  if (!hasFinalNonBlockingFindings) {
+    return receiveInstruction;
+  }
+
+  const counts = nonBlockingSeverities
+    .map((severity) => `${severity}=${options.verdict.counts[severity]}`)
+    .join(', ');
+
+  return `Gate passed at the ${options.threshold} threshold, but the final review still contains non-blocking findings (${counts}). Run oat-project-review-receive for ${options.artifactPath} to disposition them before marking the final review row passed.`;
+}
+
+function reviewGateOutcome(payload: {
+  blocking: boolean;
+  normalization?: ReviewGateVerdict['normalization'];
+}):
+  | 'review_completed_blocking_findings'
+  | 'review_completed_artifact_normalized_gate_passed'
+  | 'review_completed_gate_passed' {
+  if (payload.blocking) {
+    return 'review_completed_blocking_findings';
+  }
+  if (payload.normalization) {
+    return 'review_completed_artifact_normalized_gate_passed';
+  }
+  return 'review_completed_gate_passed';
+}
+
 function writeReviewGateResult(
   context: CommandContext,
   payload: {
@@ -1061,19 +1107,88 @@ function writeReviewGateResult(
     reviewType: ReviewGateVerdict['reviewType'];
     scope: string | null;
     invocation: string | null;
+    normalization?: ReviewGateVerdict['normalization'];
     handoff: string;
   },
 ): void {
+  const outcome = reviewGateOutcome(payload);
   if (context.json) {
-    context.logger.json(payload);
+    context.logger.json({ outcome, ...payload });
     return;
   }
 
+  if (outcome === 'review_completed_blocking_findings') {
+    context.logger.info('Review completed and found blocking issues.');
+  } else if (outcome === 'review_completed_artifact_normalized_gate_passed') {
+    context.logger.info(
+      'Review completed, artifact was normalized, and gate passed.',
+    );
+  } else {
+    context.logger.info('Review completed and gate passed.');
+  }
   context.logger.info(`Review artifact: ${payload.artifactPath}`);
+  if (payload.normalization) {
+    context.logger.info(
+      `Artifact normalized: inserted ${payload.normalization.insertedSeverities.map((severity) => severityDisplayName(severity)).join(', ')} empty Findings section(s).`,
+    );
+  }
   context.logger.info(
     `Verdict: ${payload.status} (critical=${payload.counts.critical}, important=${payload.counts.important}, medium=${payload.counts.medium}, minor=${payload.counts.minor})`,
   );
   context.logger.info(payload.handoff);
+}
+
+function writeReviewGateExecutionFailure(
+  context: CommandContext,
+  payload: {
+    target: string;
+    project: string;
+    exitCode: number;
+  },
+): void {
+  const message = `Review did not complete: target ${payload.target} exited with code ${payload.exitCode}.`;
+  if (context.json) {
+    context.logger.json({
+      status: 'review_failed',
+      outcome: 'review_did_not_complete',
+      target: payload.target,
+      project: payload.project,
+      exitCode: payload.exitCode,
+      message,
+    });
+    return;
+  }
+
+  context.logger.error(message);
+}
+
+function writeReviewGateArtifactValidationFailure(
+  context: CommandContext,
+  payload: {
+    target: string;
+    project: string;
+    artifactPath: string | null;
+    message: string;
+    recovery: string;
+  },
+): void {
+  if (context.json) {
+    context.logger.json({
+      status: 'artifact_validation_failed',
+      outcome: 'review_completed_artifact_validation_failed',
+      target: payload.target,
+      project: payload.project,
+      artifactPath: payload.artifactPath,
+      message: payload.message,
+      recovery: payload.recovery,
+    });
+    return;
+  }
+
+  context.logger.error(
+    `Review completed but artifact validation failed: ${payload.message}`,
+  );
+  context.logger.error(payload.recovery);
 }
 
 async function updateConfigLayer(
@@ -1289,6 +1404,11 @@ async function runReviewGate(
     );
 
     if (childExitCode !== 0) {
+      writeReviewGateExecutionFailure(context, {
+        target: selected.id,
+        project: projectPath,
+        exitCode: childExitCode,
+      });
       process.exitCode = childExitCode;
       return;
     }
@@ -1299,16 +1419,45 @@ async function runReviewGate(
     });
     const producedArtifact = findProducedReviewArtifact(before, after);
     if (!producedArtifact) {
-      throw new Error(
-        `No new review artifact was detected for project ${projectPath}. Ensure the review provider wrote a project review artifact before the gate exits.`,
-      );
+      writeReviewGateArtifactValidationFailure(context, {
+        target: selected.id,
+        project: projectPath,
+        artifactPath: null,
+        message: `No new review artifact was detected for project ${projectPath}.`,
+        recovery:
+          'Ensure the review provider wrote a project review artifact. If it did, fix or attach that artifact and run oat-project-review-receive before treating the review as consumed.',
+      });
+      process.exitCode = 1;
+      return;
     }
 
-    const verdict = await parseReviewGateVerdict(
-      join(repoRoot, producedArtifact.path),
-    );
+    let verdict: ReviewGateVerdict;
+    try {
+      verdict = await parseReviewGateVerdict(
+        join(repoRoot, producedArtifact.path),
+        {
+          normalizeMissingEmptySeveritySections: true,
+        },
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      writeReviewGateArtifactValidationFailure(context, {
+        target: selected.id,
+        project: projectPath,
+        artifactPath: producedArtifact.path,
+        message: detail,
+        recovery: `The review artifact was created at ${producedArtifact.path} but could not be consumed. Fix the artifact format, then run oat-project-review-receive for ${producedArtifact.path}; if the only issue is a missing zero-count severity heading, rerun the gate to normalize the same artifact instead of creating a new review version.`,
+      });
+      process.exitCode = 1;
+      return;
+    }
     const blocking = reviewBlocksAtThreshold(verdict, threshold);
-    const handoff = `Run oat-project-review-receive for ${producedArtifact.path} before treating this gate review as consumed.`;
+    const handoff = buildReviewGateHandoff({
+      artifactPath: producedArtifact.path,
+      verdict,
+      threshold,
+      blocking,
+    });
 
     writeReviewGateResult(context, {
       status: blocking ? 'blocked' : 'ok',
@@ -1321,6 +1470,7 @@ async function runReviewGate(
       reviewType: verdict.reviewType,
       scope: verdict.scope,
       invocation: verdict.invocation,
+      normalization: verdict.normalization,
       handoff,
     });
     process.exitCode = blocking ? 1 : 0;

--- a/packages/cli/src/commands/gate/review-verdict.test.ts
+++ b/packages/cli/src/commands/gate/review-verdict.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -186,6 +186,55 @@ None
     });
   });
 
+  it('ignores markdown headings inside fenced code blocks while finding severity sections', async () => {
+    const artifactPath = await writeArtifact(`---
+oat_review_type: code
+oat_review_scope: final
+oat_review_invocation: gate
+---
+
+# Review
+
+## Findings
+
+### Critical
+
+- Critical finding with a fenced reproduction.
+  ~~~bash
+  # reproduce the issue
+  ## this is not a markdown section
+  ~~~
+
+### Important
+
+- Important finding
+
+### Medium
+
+None
+
+### Minor
+
+- Minor finding
+
+## Verification Commands
+
+~~~bash
+# still not part of Findings
+~~~
+`);
+
+    await expect(parseReviewGateVerdict(artifactPath)).resolves.toMatchObject({
+      counts: {
+        critical: 1,
+        important: 1,
+        medium: 0,
+        minor: 1,
+      },
+      blocking: true,
+    });
+  });
+
   it('parses a complete Findings count line as a standalone verdict source', async () => {
     const artifactPath = await writeArtifact(`---
 oat_review_type: code
@@ -279,6 +328,163 @@ None
 
     expect(verdict.counts.important).toBe(1);
     expect(verdict.blocking).toBe(true);
+  });
+
+  it('normalizes a missing zero-count severity heading when explicit counts are available', async () => {
+    const artifactPath = await writeArtifact(`---
+oat_review_type: code
+oat_review_scope: final
+oat_review_invocation: gate
+oat_review_critical_count: 0
+oat_review_important_count: 0
+oat_review_medium_count: 0
+oat_review_minor_count: 0
+---
+
+# Review
+
+## Findings
+
+### Critical
+
+None
+
+### Important
+
+None
+
+### Minor
+
+None
+`);
+
+    const verdict = await parseReviewGateVerdict(artifactPath, {
+      normalizeMissingEmptySeveritySections: true,
+    });
+
+    expect(verdict).toMatchObject({
+      counts: {
+        critical: 0,
+        important: 0,
+        medium: 0,
+        minor: 0,
+      },
+      blocking: false,
+      normalization: {
+        insertedSeverities: ['medium'],
+      },
+    });
+    const normalizedContent = await readFile(artifactPath, 'utf8');
+    expect(normalizedContent).toMatch(
+      /### Important[\s\S]*None[\s\S]*### Medium\s+None[\s\S]*### Minor/i,
+    );
+  });
+
+  it('does not insert duplicate severity headings when fenced code contains markdown headings', async () => {
+    const artifactPath = await writeArtifact(`---
+oat_review_type: code
+oat_review_scope: final
+oat_review_invocation: gate
+oat_review_critical_count: 1
+oat_review_important_count: 0
+oat_review_medium_count: 0
+oat_review_minor_count: 0
+---
+
+# Review
+
+## Findings
+
+### Critical
+
+- Critical finding with a fenced reproduction.
+  ~~~bash
+  # reproduce the issue
+  ## this is not a markdown section
+  ~~~
+
+### Important
+
+None
+
+### Medium
+
+None
+
+### Minor
+
+None
+`);
+    const before = await readFile(artifactPath, 'utf8');
+
+    const verdict = await parseReviewGateVerdict(artifactPath, {
+      normalizeMissingEmptySeveritySections: true,
+    });
+
+    expect(verdict.normalization).toBeUndefined();
+    await expect(readFile(artifactPath, 'utf8')).resolves.toBe(before);
+  });
+
+  it('refuses to normalize missing severity headings without a Findings section', async () => {
+    const artifactPath = await writeArtifact(`---
+oat_review_type: code
+oat_review_scope: final
+oat_review_invocation: gate
+oat_review_critical_count: 0
+oat_review_important_count: 0
+oat_review_medium_count: 0
+oat_review_minor_count: 0
+---
+
+# Review
+
+Findings: 0 critical, 0 important, 0 medium, 0 minor
+
+## Summary
+
+The review completed but did not render canonical Findings sections.
+`);
+
+    await expect(
+      parseReviewGateVerdict(artifactPath, {
+        normalizeMissingEmptySeveritySections: true,
+      }),
+    ).rejects.toThrow(/does not contain a ## Findings section/i);
+  });
+
+  it('does not normalize a missing severity heading when explicit counts report findings', async () => {
+    const artifactPath = await writeArtifact(`---
+oat_review_type: code
+oat_review_scope: final
+oat_review_invocation: gate
+oat_review_critical_count: 0
+oat_review_important_count: 0
+oat_review_medium_count: 1
+oat_review_minor_count: 0
+---
+
+# Review
+
+## Findings
+
+### Critical
+
+None
+
+### Important
+
+None
+
+### Minor
+
+None
+`);
+
+    await expect(
+      parseReviewGateVerdict(artifactPath, {
+        normalizeMissingEmptySeveritySections: true,
+      }),
+    ).rejects.toThrow(/cannot be safely normalized/i);
   });
 
   it('returns an actionable parse error for partial Findings sections', async () => {

--- a/packages/cli/src/commands/gate/review-verdict.ts
+++ b/packages/cli/src/commands/gate/review-verdict.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 
 import { getFrontmatterBlock } from '@commands/shared/frontmatter';
 import YAML from 'yaml';
@@ -15,9 +15,33 @@ export interface ReviewGateVerdict {
     minor: number;
   };
   blocking: boolean;
+  normalization?: {
+    insertedSeverities: Severity[];
+  };
 }
 
-type Severity = keyof ReviewGateVerdict['counts'];
+export type Severity = keyof ReviewGateVerdict['counts'];
+
+export interface ParseReviewGateVerdictOptions {
+  normalizeMissingEmptySeveritySections?: boolean;
+}
+
+interface SeverityHeading {
+  severity: Severity;
+  index: number;
+  headingLength: number;
+}
+
+interface FindingsSection {
+  start: number;
+  end: number;
+  content: string;
+}
+
+interface MarkdownLine {
+  text: string;
+  start: number;
+}
 
 const SEVERITIES: readonly Severity[] = [
   'critical',
@@ -133,6 +157,117 @@ function normalizeHeading(value: string): Severity | null {
   return null;
 }
 
+export function severityDisplayName(severity: Severity): string {
+  return severity.charAt(0).toUpperCase() + severity.slice(1);
+}
+
+function markdownLines(content: string): MarkdownLine[] {
+  const lines: MarkdownLine[] = [];
+  let start = 0;
+
+  while (start < content.length) {
+    const newlineIndex = content.indexOf('\n', start);
+    const end = newlineIndex === -1 ? content.length : newlineIndex;
+    lines.push({
+      text: content.slice(start, end),
+      start,
+    });
+    start = newlineIndex === -1 ? content.length : newlineIndex + 1;
+  }
+
+  return lines;
+}
+
+function fenceMarker(
+  line: string,
+): { marker: '`' | '~'; length: number } | null {
+  const match = line.match(/^\s*(`{3,}|~{3,})/);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  return {
+    marker: match[1].startsWith('`') ? '`' : '~',
+    length: match[1].length,
+  };
+}
+
+function linesOutsideFences(content: string): MarkdownLine[] {
+  const outsideFenceLines: MarkdownLine[] = [];
+  let activeFence: { marker: '`' | '~'; length: number } | null = null;
+
+  for (const line of markdownLines(content)) {
+    const marker = fenceMarker(line.text);
+    if (marker) {
+      if (!activeFence) {
+        activeFence = marker;
+      } else if (
+        marker.marker === activeFence.marker &&
+        marker.length >= activeFence.length
+      ) {
+        activeFence = null;
+      }
+      continue;
+    }
+
+    if (!activeFence) {
+      outsideFenceLines.push(line);
+    }
+  }
+
+  return outsideFenceLines;
+}
+
+function findFindingsSection(content: string): FindingsSection | null {
+  const lines = linesOutsideFences(content);
+  const findingsHeading = lines.find((line) =>
+    /^##\s+Findings\s*#*\s*$/i.test(line.text),
+  );
+  if (!findingsHeading) {
+    return null;
+  }
+
+  const start = findingsHeading.start + findingsHeading.text.length;
+  const nextPeerHeading = lines.find(
+    (line) =>
+      line.start > findingsHeading.start &&
+      /^#{1,2}\s+.+?\s*#*\s*$/.test(line.text),
+  );
+  const end = nextPeerHeading?.start ?? content.length;
+
+  return {
+    start,
+    end,
+    content: content.slice(start, end),
+  };
+}
+
+function findSeverityHeadings(content: string): SeverityHeading[] {
+  const findingsSection = findFindingsSection(content);
+  const scanContent = findingsSection?.content ?? content;
+  const offset = findingsSection?.start ?? 0;
+
+  return linesOutsideFences(scanContent)
+    .map((line) => {
+      const match = line.text.match(/^#{3,6}\s+(.+?)\s*#*\s*$/);
+      return {
+        severity: normalizeHeading(match?.[1] ?? ''),
+        index: offset + line.start,
+        headingLength: line.text.length,
+      };
+    })
+    .filter((heading): heading is SeverityHeading => heading.severity !== null);
+}
+
+function missingSeverityHeadings(
+  severityHeadings: readonly SeverityHeading[],
+): Severity[] {
+  const seenSeverities = new Set(
+    severityHeadings.map((heading) => heading.severity),
+  );
+  return SEVERITIES.filter((severity) => !seenSeverities.has(severity));
+}
+
 function parseFindingsSummaryCounts(
   content: string,
 ): ReviewGateVerdict['counts'] | null {
@@ -155,33 +290,14 @@ function parseFindingsSectionCounts(
   content: string,
   artifactPath: string,
 ): ReviewGateVerdict['counts'] | null {
-  const headingMatches = [...content.matchAll(/^#{3,6}\s+(.+?)\s*#*\s*$/gm)];
-  const severityHeadings = headingMatches
-    .map((match) => ({
-      severity: normalizeHeading(match[1] ?? ''),
-      index: match.index ?? 0,
-      headingLength: match[0].length,
-    }))
-    .filter(
-      (
-        heading,
-      ): heading is {
-        severity: Severity;
-        index: number;
-        headingLength: number;
-      } => heading.severity !== null,
-    );
+  const findingsSection = findFindingsSection(content);
+  const severityHeadings = findSeverityHeadings(content);
 
   if (severityHeadings.length === 0) {
     return null;
   }
 
-  const seenSeverities = new Set(
-    severityHeadings.map((heading) => heading.severity),
-  );
-  const missingSeverities = SEVERITIES.filter(
-    (severity) => !seenSeverities.has(severity),
-  );
+  const missingSeverities = missingSeverityHeadings(severityHeadings);
   if (missingSeverities.length > 0) {
     throw new Error(
       `Review artifact at ${artifactPath} has an incomplete Findings section; expected headings for Critical, Important, Medium, and Minor. Missing: ${missingSeverities.join(', ')}.`,
@@ -198,7 +314,8 @@ function parseFindingsSectionCounts(
   for (const [offset, heading] of severityHeadings.entries()) {
     const nextHeading = severityHeadings[offset + 1];
     const sectionStart = heading.index + heading.headingLength;
-    const sectionEnd = nextHeading?.index ?? content.length;
+    const sectionEnd =
+      nextHeading?.index ?? findingsSection?.end ?? content.length;
     counts[heading.severity] = countFindingsInSection(
       content.slice(sectionStart, sectionEnd),
     );
@@ -234,8 +351,94 @@ function hasBlockingFindings(counts: ReviewGateVerdict['counts']): boolean {
   return counts.critical > 0 || counts.important > 0;
 }
 
+function insertionTextForSeverity(severity: Severity): string {
+  return `\n### ${severityDisplayName(severity)}\n\nNone\n`;
+}
+
+function insertionPointForMissingSeverity(
+  content: string,
+  missingSeverity: Severity,
+): number {
+  const findingsSection = findFindingsSection(content);
+  const sectionEnd = findingsSection?.end ?? content.length;
+  const severityHeadings = findSeverityHeadings(content);
+  const missingSeverityRank = SEVERITIES.indexOf(missingSeverity);
+  const nextHeading = severityHeadings.find(
+    (heading) => SEVERITIES.indexOf(heading.severity) > missingSeverityRank,
+  );
+
+  return nextHeading?.index ?? sectionEnd;
+}
+
+function insertMissingSeveritySection(
+  content: string,
+  severity: Severity,
+): string {
+  const insertionPoint = insertionPointForMissingSeverity(content, severity);
+  const insertion = insertionTextForSeverity(severity);
+  const suffix = content.slice(insertionPoint);
+  const needsTrailingBlank = suffix.length > 0 ? '\n' : '';
+
+  return `${content.slice(0, insertionPoint)}${insertion}${needsTrailingBlank}${suffix}`;
+}
+
+async function normalizeMissingEmptySeveritySections(
+  artifactPath: string,
+  content: string,
+  counts: ReviewGateVerdict['counts'],
+): Promise<{ content: string; insertedSeverities: Severity[] }> {
+  if (!findFindingsSection(content)) {
+    throw new Error(
+      `Review artifact at ${artifactPath} does not contain a ## Findings section, so missing severity headings cannot be safely normalized.`,
+    );
+  }
+
+  let normalizedContent = content;
+  const insertedSeverities: Severity[] = [];
+
+  for (const severity of missingSeverityHeadings(
+    findSeverityHeadings(content),
+  )) {
+    if (counts[severity] !== 0) {
+      throw new Error(
+        `Review artifact at ${artifactPath} is missing the ${severityDisplayName(severity)} Findings section, but structured counts report ${counts[severity]} ${severity} finding(s). This cannot be safely normalized.`,
+      );
+    }
+
+    normalizedContent = insertMissingSeveritySection(
+      normalizedContent,
+      severity,
+    );
+    insertedSeverities.push(severity);
+  }
+
+  if (insertedSeverities.length > 0) {
+    await writeFile(artifactPath, normalizedContent, 'utf8');
+  }
+
+  return { content: normalizedContent, insertedSeverities };
+}
+
+function resolveCounts(
+  content: string,
+  frontmatter: Record<string, unknown>,
+): ReviewGateVerdict['counts'] | null {
+  const frontmatterCounts = readFrontmatterCounts(frontmatter);
+  if (frontmatterCounts) {
+    return frontmatterCounts;
+  }
+
+  const summaryCounts = parseFindingsSummaryCounts(content);
+  if (summaryCounts) {
+    return summaryCounts;
+  }
+
+  return null;
+}
+
 export async function parseReviewGateVerdict(
   artifactPath: string,
+  options: ParseReviewGateVerdictOptions = {},
 ): Promise<ReviewGateVerdict> {
   let content: string;
   try {
@@ -252,10 +455,22 @@ export async function parseReviewGateVerdict(
   const frontmatter = frontmatterBlock
     ? parseFrontmatterObject(frontmatterBlock, artifactPath)
     : {};
-  const counts =
-    readFrontmatterCounts(frontmatter) ??
-    parseFindingsSummaryCounts(content) ??
-    parseFindingsSectionCounts(content, artifactPath);
+  let counts = resolveCounts(content, frontmatter);
+  let insertedSeverities: Severity[] = [];
+
+  if (counts && options.normalizeMissingEmptySeveritySections) {
+    const normalized = await normalizeMissingEmptySeveritySections(
+      artifactPath,
+      content,
+      counts,
+    );
+    content = normalized.content;
+    insertedSeverities = normalized.insertedSeverities;
+  }
+
+  if (!counts) {
+    counts = parseFindingsSectionCounts(content, artifactPath);
+  }
 
   if (!counts) {
     throw new Error(
@@ -270,5 +485,12 @@ export async function parseReviewGateVerdict(
     invocation: stringOrNull(frontmatter['oat_review_invocation']),
     counts,
     blocking: hasBlockingFindings(counts),
+    ...(insertedSeverities.length > 0
+      ? {
+          normalization: {
+            insertedSeverities,
+          },
+        }
+      : {}),
   };
 }

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

Harden `oat gate review` so a completed review does not look like an implementation failure when the produced review artifact has a harmless formatting omission.

## What Changed

- Normalize missing zero-count severity headings in-place for gate-produced review artifacts.
- Keep review parsing fence-aware so Markdown headings inside code blocks do not truncate the `## Findings` section or corrupt normalization.
- Refuse unsafe normalization when structured counts are nonzero or when the artifact lacks a canonical `## Findings` section.
- Add explicit gate outcomes for review execution failure, blocking review findings, artifact validation failure, normalized pass, and normal pass.
- Make final-scope handoff text call out all non-blocking findings below the configured threshold.
- Align the ad-hoc review artifact template with the four canonical severity buckets and bump `oat-review-provide` to `1.2.2`.
- Bump public packages and generated version metadata to `0.1.38` for shipped CLI/skill changes.

## Root Cause

The gate path treated Markdown artifact shape as a hard validation source after the reviewer had already completed successfully. A missing empty `### Medium` section could therefore fail the gate even when structured counts showed zero Medium findings. The first normalization pass also needed stricter Markdown scanning and section-boundary handling to avoid unsafe rewrites.

## User Impact

A gate-originated review with a pass verdict and zero Medium findings can now be normalized and consumed without creating extra review artifact versions. True ambiguity still fails with an explicit artifact-validation outcome and recovery guidance.

## Validation

- `pnpm --dir packages/cli exec vitest run src/commands/gate/review-verdict.test.ts src/commands/gate/index.test.ts`
- `pnpm --filter @open-agent-toolkit/cli test`
- `pnpm --filter @open-agent-toolkit/cli check`
- `pnpm --filter @open-agent-toolkit/cli build`
- `pnpm release:check-versions`
- `pnpm release:validate`
- `git diff --check`

Pre-push hooks also passed on the final push.
