### PR TITLE
fix(cli): select capped dispatch effort

### DIFF
--- a/.agents/skills/oat-project-implement/SKILL.md
+++ b/.agents/skills/oat-project-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-implement
-version: 2.0.23
+version: 2.0.24
 description: Use when plan.md is ready for execution. Dispatches phase-level subagents with bounded fix loops; supports plan-declared parallel phase groups with worktree-isolated execution and ordered fan-in.
 oat_gateable: true
 argument-hint: '[--retry-limit <N>] [--dry-run]'
@@ -204,7 +204,13 @@ Resolution order:
       "mode": "enforced",
       "mechanism": "pinned-variant",
       "dispatchArgs": { "variant": "oat-phase-implementer-high" },
-      "verifyOnDispatch": false
+      "verifyOnDispatch": false,
+      "selection": {
+        "role": "implementer",
+        "preferredValue": null,
+        "selectedValue": "high",
+        "capped": false
+      }
     }
   }
 }
@@ -212,8 +218,10 @@ Resolution order:
 
 Read `providers.<active-provider>` for the concrete dispatch controls. The
 `dispatchArgs` field carries the provider-specific argument to pass through
-(Codex: `variant` name; Claude: `model` string). Never re-derive these from the
-preset label — the resolver is the single compilation/join point.
+(Codex: `variant` name; Claude: `model` string). For implementer/fix dispatch,
+pass `--preferred <preferred-effort>` and use `selection.selectedValue` as the
+selected axis value. Never re-derive these from the preset label or a ceiling-only
+variant — the resolver is the single compilation/join point.
 
 Print before phase work:
 
@@ -311,7 +319,7 @@ Codex rules:
    - `high`: broad architecture, security/auth/redaction boundaries, subtle state behavior, or repeated substantive review failures
    - `xhigh`: highest-risk work that requires the configured ceiling to allow xhigh
 3. Selected effort is `min(preferred, resolved_ceiling)` for implementer/fix work.
-4. For implementer/fix dispatch: call `oat project dispatch-ceiling resolve --provider codex --role implementer`; read `providers.codex.dispatchArgs.variant` for the role name (e.g., `oat-phase-implementer-high`). Pass that variant name directly — do not re-derive it from the ceiling value.
+4. For implementer/fix dispatch: call `oat project dispatch-ceiling resolve --provider codex --role implementer --preferred <preferred-effort>`; read `providers.codex.selection.selectedValue` and `providers.codex.dispatchArgs.variant` for the selected role name (e.g., `oat-phase-implementer-medium`). The resolver caps the preferred effort against the ceiling; never pass a ceiling-only implementer variant when `selection.selectedValue` is lower.
 5. For review dispatch: call `oat project dispatch-ceiling resolve --provider codex --role reviewer`; read `providers.codex.dispatchArgs.variant` for the reviewer role name (e.g., `oat-reviewer-high`). Reviewer always targets the ceiling for deterministic quality gate behavior.
 6. Use base/unpinned Codex roles only as a fallback or explicit provider-default choice. Log `Selected effort: provider-default`, display provider default effort when known, and do not describe this as parent-ceiling inheritance.
 7. Do not use top-level per-call `reasoning_effort` as the standard OAT selected-effort path; dogfooding showed that path can be inconsistent.
@@ -319,9 +327,9 @@ Codex rules:
 Claude rules:
 
 - Claude ceiling is model-based: `haiku < sonnet < opus`.
-- Implementer dispatch: select the lowest sufficient model capped by the resolved Claude ceiling (`min(preferred, ceiling)`).
+- Implementer/fix dispatch: classify the preferred model (`haiku`, `sonnet`, or `opus`) and pass it to the resolver as `--preferred <preferred-model>`. The resolver selects the lowest sufficient model capped by the resolved Claude ceiling (`min(preferred, ceiling)`).
 - Review dispatch: target the resolved Claude ceiling directly.
-- Call `oat project dispatch-ceiling resolve --provider claude --role implementer --orchestrator-tier <current-orchestrator-tier>` (or `--role reviewer`); read `providers.claude.dispatchArgs.model` for the model string to pass. Pass `--orchestrator-tier` so the resolver can flag above-orchestrator upgrade requests and set `verifyOnDispatch` correctly.
+- For implementer/fix dispatch, call `oat project dispatch-ceiling resolve --provider claude --role implementer --preferred <preferred-model> --orchestrator-tier <current-orchestrator-tier>`; for review dispatch, call the same resolver with `--role reviewer` and no `--preferred`. Read `providers.claude.selection.selectedValue` and `providers.claude.dispatchArgs.model` for the selected model string to pass. Pass `--orchestrator-tier` so the resolver can flag above-orchestrator upgrade requests and set `verifyOnDispatch` correctly.
 - Pass `model: "<value>"` when `model_axis=selected:<value>` on the Task tool call.
 - Keep `effort_axis=not-applicable`; Claude Code has no separate per-dispatch effort axis.
 
@@ -336,7 +344,7 @@ Structured dispatch log:
 ```text
 OAT Dispatch: Phase {phase_id} {implementation | fix | review}
 Host: {Claude Code | Codex | Cursor | other host}
-Preferred effort: {low | medium | high | xhigh | not-applicable}
+Preferred effort: {low | medium | high | xhigh | provider-default | not-applicable}
 Dispatch ceiling: {resolved ceiling value}
 Selected effort: {low | medium | high | xhigh | provider-default | not-applicable}
 Ceiling source: {repo config | project state | preflight prompt}
@@ -393,6 +401,29 @@ Model axis: inherited
 Effort axis: provider-default
 Dispatch target: oat-reviewer
 Rationale: base unpinned role fallback; effective effort follows Codex provider default.
+```
+
+Generic sidecar/explorer dispatch:
+
+- Built-in or generic sidecars such as `explorer` are not OAT-managed implementer, reviewer, or fix roles.
+- If a sidecar spawn payload does not explicitly pin a reliable effort/model control, log `Preferred effort: provider-default`, `Selected effort: provider-default`, and `Effort axis: provider-default`.
+- Do not classify a generic sidecar as `Preferred effort: low|medium|high|xhigh` unless the actual host invocation contains the corresponding reliable selection. If the host has no reliable effort control for that sidecar, use provider-default wording instead.
+- Sidecar outputs are advisory context only. Implementation work and review/fix gates still follow the OAT-managed dispatch rules above.
+
+Codex generic explorer example:
+
+```text
+OAT Dispatch: p02-t10 sidecar exploration
+Host: Codex
+Preferred effort: provider-default
+Dispatch ceiling: xhigh
+Selected effort: provider-default
+Ceiling source: project state
+Provider default effort: xhigh
+Model axis: inherited
+Effort axis: provider-default
+Dispatch target: explorer
+Rationale: read-only sidecar exploration; generic explorer payload does not pin an OAT-managed effort variant.
 ```
 
 Include resolved dispatch context in scope packets when known:
@@ -740,8 +771,8 @@ For each phase `pNN` in the plan (or each phase in the current parallel group), 
 
 2. Perform a pre-dispatch assertion against the host invocation parameters. The Phase Scope fields are audit/context fields; selected axes must also be represented in the actual host dispatch call.
    - Codex implementer/fix dispatch:
-     - Before building the `spawn_agent` argument map, classify the phase complexity and choose preferred effort (`low`, `medium`, `high`, or `xhigh`), then cap it to the resolved Codex dispatch ceiling.
-     - Build the `spawn_agent` argument map before logging the dispatch. If `effort_axis=selected:low|medium|high|xhigh`, the argument map MUST use the matching `agent_type`: `"oat-phase-implementer-low"`, `"oat-phase-implementer-medium"`, `"oat-phase-implementer-high"`, or `"oat-phase-implementer-xhigh"`. Then derive the `OAT Dispatch:` block `Effort axis:` field from that same argument map.
+     - Before building the `spawn_agent` argument map, classify the phase complexity and choose preferred effort (`low`, `medium`, `high`, or `xhigh`), then call `oat project dispatch-ceiling resolve --provider codex --role implementer --preferred <preferred-effort>`.
+     - Build the `spawn_agent` argument map from `providers.codex.selection.selectedValue` and `providers.codex.dispatchArgs.variant` before logging the dispatch. If `effort_axis=selected:low|medium|high|xhigh`, the argument map MUST use the matching `agent_type`: `"oat-phase-implementer-low"`, `"oat-phase-implementer-medium"`, `"oat-phase-implementer-high"`, or `"oat-phase-implementer-xhigh"`. Then derive the `OAT Dispatch:` block `Effort axis:` field from that same argument map.
      - Example selected low payload shape: `agent_type: "oat-phase-implementer-low"` and a Phase Scope message containing `effort_axis: selected:low`.
      - Immediately after spawning, compare the returned Codex status line with the selected effort before waiting on the agent. If the spawned status reports a different effort than the selected value (for example, the log says `effort_axis=selected:medium` but the spawn result reports `gpt-5.5 high`), treat this as an orchestration deviation. Stop, record the deviation in `implementation.md`, and redispatch with corrected parameters before continuing. Do not use work from the mismatched dispatch.
      - If `effort_axis=provider-default`, use base `agent_type: "oat-phase-implementer"` and omit `reasoning_effort`. The dispatch rationale MUST say this is a base/unpinned fallback and include provider default effort when known.

--- a/apps/oat-docs/docs/cli-utilities/configuration.md
+++ b/apps/oat-docs/docs/cli-utilities/configuration.md
@@ -232,6 +232,8 @@ reading config keys directly:
 
 ```bash
 oat project dispatch-ceiling resolve --provider codex --json
+oat project dispatch-ceiling resolve --provider codex --role implementer --preferred medium --json
+oat project dispatch-ceiling resolve --provider claude --role implementer --preferred sonnet --orchestrator-tier sonnet --json
 oat project dispatch-ceiling resolve --provider claude --orchestrator-tier sonnet --json
 ```
 

--- a/apps/oat-docs/docs/workflows/projects/dispatch-ceiling.md
+++ b/apps/oat-docs/docs/workflows/projects/dispatch-ceiling.md
@@ -61,11 +61,20 @@ Before dispatching a subagent, the orchestrator calls:
 oat project dispatch-ceiling resolve --provider <provider> --role <implementer|reviewer> --preflight --json
 ```
 
+For implementer or fix dispatch, pass the runtime classification too. In Codex
+this is the preferred effort; in Claude it is the preferred model tier:
+
+```bash
+oat project dispatch-ceiling resolve --provider codex --role implementer --preferred medium --json
+oat project dispatch-ceiling resolve --provider claude --role implementer --preferred sonnet --json
+```
+
 The resolver:
 
 1. reads the concrete `providers.<provider>` value (config precedence, then project state) — **never the preset label**;
 2. looks up that provider's **adapter** in the provider ceiling registry;
-3. returns a per-provider result: `{ value, mode, mechanism, dispatchArgs }`.
+3. applies `--preferred` for implementer/fix dispatch, capping it against the ceiling;
+4. returns a per-provider result: `{ value, mode, mechanism, dispatchArgs, selection }`.
 
 `mode` is the honest enforcement status, computed right there and never persisted:
 
@@ -89,8 +98,8 @@ The same ceiling intent produces different — but honest — behavior per provi
 
 ### Why the mechanisms differ
 
-- **Codex** dispatches through **pinned, sync-time role variants**. Per-call reasoning-effort proved unreliable in practice, so OAT generates committed `oat-phase-implementer-{low..xhigh}` / `oat-reviewer-{low..xhigh}` role files and dispatches the variant matching the resolved effort.
-- **Claude** uses the **per-call Task `model` parameter**, which is reliable and bidirectional (a Sonnet orchestrator can dispatch an Opus subagent and vice-versa) and overrides agent frontmatter — so OAT simply passes `model` at dispatch and needs no variant files.
+- **Codex** dispatches through **pinned, sync-time role variants**. Per-call reasoning-effort proved unreliable in practice, so OAT generates committed `oat-phase-implementer-{low..xhigh}` / `oat-reviewer-{low..xhigh}` role files. Implementer/fix dispatch passes `--preferred` so `dispatchArgs.variant` matches the selected capped effort; reviewer dispatch uses the variant matching the resolved ceiling.
+- **Claude** uses the **per-call Task `model` parameter**, which is reliable and bidirectional (a Sonnet orchestrator can dispatch an Opus subagent and vice-versa) and overrides agent frontmatter. Implementer/fix dispatch passes `--preferred` as the preferred model tier and receives the capped selected `model`; reviewer dispatch uses the ceiling model. OAT needs no variant files.
 - **Unsupported providers** (any without a registered adapter) resolve to `unsupported` with `dispatchArgs: null`. The resolve command **returns cleanly and never blocks** — the ceiling is recorded as intent and applied if/when an adapter ships, while the provider runs at its own capabilities.
 
 A **provider adapter registry** is what lets these genuinely different mechanisms sit behind one resolver, so the lifecycle skills consume `dispatchArgs` without ever branching on provider.
@@ -103,6 +112,8 @@ The ceiling means slightly different things for the two dispatch roles:
 - **Reviewer** runs **at** the ceiling — a **target** — so quality gates are deterministic.
 
 Both providers honor this distinction (Codex selects the matching variant; Claude passes the matching model).
+
+Generic sidecars such as built-in `explorer` are outside this implementer/reviewer/fix contract. They may run at provider default when they are read-only advisory helpers. In that case, dispatch logs should say `Preferred effort: provider-default`, `Selected effort: provider-default`, and `Effort axis: provider-default`; only log a concrete selected effort when the actual sidecar payload pins a reliable provider control.
 
 ## Verify-on-upgrade
 

--- a/apps/oat-docs/docs/workflows/projects/implementation-execution.md
+++ b/apps/oat-docs/docs/workflows/projects/implementation-execution.md
@@ -108,9 +108,9 @@ Model and effort are separate axes. Each axis logs one of these states:
 - `not-applicable` — this host/API has no meaningful per-dispatch concept for that axis.
 - `host-auto` — exceptional; the host uses that axis internally but the orchestrator cannot read or pin it.
 
-In Codex, implementation and fix dispatch classify a preferred effort (`low`, `medium`, `high`, or `xhigh`) and select `min(preferred, resolved_ceiling)`. The selected effort maps to the matching pinned role: `oat-phase-implementer-low`, `oat-phase-implementer-medium`, `oat-phase-implementer-high`, or `oat-phase-implementer-xhigh`. Reviewer dispatch uses the reviewer variant matching the resolved ceiling (`oat-reviewer-low|medium|high|xhigh`) for deterministic quality gates. Base/unpinned Codex roles are provider-default fallbacks; they should be logged as `provider-default`, not as inherited parent-session ceiling.
+In Codex, implementation and fix dispatch classify a preferred effort (`low`, `medium`, `high`, or `xhigh`) and pass it to `oat project dispatch-ceiling resolve --provider codex --role implementer --preferred <effort>`. The resolver selects `min(preferred, resolved_ceiling)` and returns the matching pinned role: `oat-phase-implementer-low`, `oat-phase-implementer-medium`, `oat-phase-implementer-high`, or `oat-phase-implementer-xhigh`. Reviewer dispatch uses the reviewer variant matching the resolved ceiling (`oat-reviewer-low|medium|high|xhigh`) for deterministic quality gates. Base/unpinned Codex roles are provider-default fallbacks; they should be logged as `provider-default`, not as inherited parent-session ceiling.
 
-In Claude Code, subagent model selection is a model axis when available and is capped by `workflow.dispatchCeiling.providers.claude` (or the compiled concrete value from a preset) or project `oat_dispatch_ceiling`. The separate effort axis is `not-applicable`.
+In Claude Code, implementation and fix dispatch classify a preferred model tier (`haiku`, `sonnet`, or `opus`) and pass it to `oat project dispatch-ceiling resolve --provider claude --role implementer --preferred <model> --orchestrator-tier <current-orchestrator-tier>`. The resolver selects `min(preferred, resolved_ceiling)` and returns the `model` argument to pass at dispatch. Reviewer dispatch targets the resolved Claude ceiling directly. The separate effort axis is `not-applicable`.
 
 Dispatch logs use a consistent structured block so provider behavior is comparable without flattening the model and effort axes:
 
@@ -151,9 +151,23 @@ Model axis: host-auto
 Effort axis: host-auto
 Dispatch target: host default
 Rationale: host does not expose readable or pinnable dispatch controls; rationale maps to standard effort.
+
+OAT Dispatch: p02-t10 sidecar exploration
+Host: Codex
+Preferred effort: provider-default
+Dispatch ceiling: xhigh
+Selected effort: provider-default
+Ceiling source: project state
+Provider default effort: xhigh
+Model axis: inherited
+Effort axis: provider-default
+Dispatch target: explorer
+Rationale: read-only sidecar exploration; generic explorer payload does not pin an OAT-managed effort variant.
 ```
 
 Phase and review scope packets include dispatch context when the orchestrator has resolved it: `model_axis`, `effort_axis`, `dispatch_ceiling`, `ceiling_source`, `provider_default_effort`, and `dispatch_rationale`.
+
+Generic sidecars such as built-in `explorer` are not OAT-managed implementer, reviewer, or fix roles. If a sidecar payload does not pin a reliable effort/model control, log it as provider-default rather than classifying the task complexity as a selected effort. Sidecar results are advisory context; implementation and review/fix gates still follow the OAT-managed dispatch rules above.
 
 ### Dispatch Profile overrides
 

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.1.39",
-  "docs-config": "0.1.39",
-  "docs-theme": "0.1.39",
-  "docs-transforms": "0.1.39"
+  "cli": "0.1.40",
+  "docs-config": "0.1.40",
+  "docs-theme": "0.1.40",
+  "docs-transforms": "0.1.40"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/project/dispatch-ceiling/index.test.ts
+++ b/packages/cli/src/commands/project/dispatch-ceiling/index.test.ts
@@ -531,5 +531,235 @@ describe('oat project dispatch-ceiling resolve', () => {
         },
       });
     });
+
+    it('selects the lower preferred Codex effort under a higher ceiling', async () => {
+      const { root, home } = await setup();
+      await writeJson(join(root, '.oat', 'config.json'), {
+        version: 1,
+        workflow: { dispatchCeiling: { providers: { codex: 'xhigh' } } },
+      });
+
+      const { command, capture } = createHarness({ cwd: root, home });
+      await runCommand(command, [
+        '--provider',
+        'codex',
+        '--role',
+        'implementer',
+        '--preferred',
+        'medium',
+        '--json',
+      ]);
+
+      expect(capture.jsonPayloads[0]).toMatchObject({
+        value: 'xhigh',
+        providers: {
+          codex: {
+            value: 'xhigh',
+            dispatchArgs: { variant: 'oat-phase-implementer-medium' },
+            selection: {
+              role: 'implementer',
+              preferredValue: 'medium',
+              selectedValue: 'medium',
+              capped: false,
+            },
+          },
+        },
+      });
+    });
+
+    it('caps implementer dispatch args down when preferred exceeds the Codex ceiling', async () => {
+      const { root, home } = await setup();
+      await writeJson(join(root, '.oat', 'config.json'), {
+        version: 1,
+        workflow: { dispatchCeiling: { providers: { codex: 'medium' } } },
+      });
+
+      const { command, capture } = createHarness({ cwd: root, home });
+      await runCommand(command, [
+        '--provider',
+        'codex',
+        '--role',
+        'implementer',
+        '--preferred',
+        'xhigh',
+        '--json',
+      ]);
+
+      expect(capture.jsonPayloads[0]).toMatchObject({
+        value: 'medium',
+        providers: {
+          codex: {
+            dispatchArgs: { variant: 'oat-phase-implementer-medium' },
+            selection: {
+              role: 'implementer',
+              preferredValue: 'xhigh',
+              selectedValue: 'medium',
+              capped: true,
+            },
+          },
+        },
+      });
+    });
+
+    it('reports an error for invalid preferred Codex effort', async () => {
+      const { root, home } = await setup();
+      await writeJson(join(root, '.oat', 'config.json'), {
+        version: 1,
+        workflow: { dispatchCeiling: { providers: { codex: 'xhigh' } } },
+      });
+
+      const { command, capture } = createHarness({ cwd: root, home });
+      await runCommand(command, [
+        '--provider',
+        'codex',
+        '--role',
+        'implementer',
+        '--preferred',
+        'bogus',
+        '--json',
+      ]);
+
+      expect(capture.jsonPayloads[0]).toMatchObject({
+        status: 'error',
+      });
+      expect(
+        (capture.jsonPayloads[0] as { message?: string }).message,
+      ).toContain('Invalid preferred dispatch value "bogus" for codex');
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('keeps preferred effort informational when the Codex ceiling is unresolved', async () => {
+      const { root, home } = await setup();
+
+      const { command, capture } = createHarness({ cwd: root, home });
+      await runCommand(command, [
+        '--provider',
+        'codex',
+        '--role',
+        'implementer',
+        '--preferred',
+        'medium',
+        '--json',
+      ]);
+
+      expect(capture.jsonPayloads[0]).toMatchObject({
+        status: 'unresolved',
+        value: null,
+        providers: {
+          codex: {
+            value: null,
+            dispatchArgs: null,
+            selection: {
+              role: 'implementer',
+              preferredValue: 'medium',
+              selectedValue: null,
+              capped: false,
+            },
+          },
+        },
+      });
+      expect(process.exitCode).toBe(0);
+    });
+
+    it('ignores preferred values for unsupported providers', async () => {
+      const { root, home } = await setup();
+
+      const { command, capture } = createHarness({ cwd: root, home });
+      await runCommand(command, [
+        '--provider',
+        'cursor',
+        '--role',
+        'implementer',
+        '--preferred',
+        'medium',
+        '--json',
+      ]);
+
+      expect(capture.jsonPayloads[0]).toMatchObject({
+        status: 'unresolved',
+        provider: 'cursor',
+        providers: {
+          cursor: {
+            value: null,
+            mode: 'unsupported',
+            dispatchArgs: null,
+            selection: {
+              role: 'implementer',
+              preferredValue: null,
+              selectedValue: null,
+              capped: false,
+            },
+          },
+        },
+      });
+      expect(process.exitCode).toBe(0);
+    });
+
+    it('caps Claude implementer dispatch args down when preferred exceeds the ceiling', async () => {
+      const { root, home } = await setup();
+      await writeJson(join(root, '.oat', 'config.json'), {
+        version: 1,
+        workflow: { dispatchCeiling: { providers: { claude: 'sonnet' } } },
+      });
+
+      const { command, capture } = createHarness({ cwd: root, home });
+      await runCommand(command, [
+        '--provider',
+        'claude',
+        '--role',
+        'implementer',
+        '--preferred',
+        'opus',
+        '--json',
+      ]);
+
+      expect(capture.jsonPayloads[0]).toMatchObject({
+        value: 'sonnet',
+        providers: {
+          claude: {
+            dispatchArgs: { model: 'sonnet' },
+            selection: {
+              role: 'implementer',
+              preferredValue: 'opus',
+              selectedValue: 'sonnet',
+              capped: true,
+            },
+          },
+        },
+      });
+    });
+
+    it('keeps reviewer dispatch args at the Codex ceiling even with a preferred value', async () => {
+      const { root, home } = await setup();
+      await writeJson(join(root, '.oat', 'config.json'), {
+        version: 1,
+        workflow: { dispatchCeiling: { providers: { codex: 'xhigh' } } },
+      });
+
+      const { command, capture } = createHarness({ cwd: root, home });
+      await runCommand(command, [
+        '--provider',
+        'codex',
+        '--role',
+        'reviewer',
+        '--preferred',
+        'medium',
+        '--json',
+      ]);
+
+      expect(capture.jsonPayloads[0]).toMatchObject({
+        providers: {
+          codex: {
+            dispatchArgs: { variant: 'oat-reviewer-xhigh' },
+            selection: {
+              role: 'reviewer',
+              preferredValue: 'medium',
+              selectedValue: 'xhigh',
+              capped: false,
+            },
+          },
+        },
+      });
+    });
   });
 });

--- a/packages/cli/src/commands/project/dispatch-ceiling/index.ts
+++ b/packages/cli/src/commands/project/dispatch-ceiling/index.ts
@@ -53,6 +53,7 @@ interface ProviderResolution {
   mechanism: EnforcementMechanism;
   dispatchArgs: CeilingDispatchArgs;
   verifyOnDispatch: boolean;
+  selection: DispatchSelection;
 }
 
 interface DispatchCeilingDependencies {
@@ -73,6 +74,7 @@ interface DispatchCeilingResolveOptions {
   provider?: string;
   role?: string;
   orchestratorTier?: string;
+  preferred?: string;
   projectPath?: string;
   preflight?: boolean;
   nonInteractive?: boolean;
@@ -104,6 +106,13 @@ const CLAUDE_VALUES: readonly WorkflowClaudeDispatchCeiling[] = [
   'sonnet',
   'opus',
 ];
+
+interface DispatchSelection {
+  role: CeilingRole;
+  preferredValue: DispatchCeilingValue | null;
+  selectedValue: DispatchCeilingValue | null;
+  capped: boolean;
+}
 
 const DEFAULT_DEPENDENCIES: DispatchCeilingDependencies = {
   buildCommandContext,
@@ -307,6 +316,82 @@ function normalizeRole(value: string | undefined): CeilingRole {
   return value === 'reviewer' ? 'reviewer' : 'implementer';
 }
 
+function providerValueOrder(
+  provider: DispatchCeilingProvider,
+): readonly DispatchCeilingValue[] | null {
+  if (provider === 'codex') {
+    return CODEX_VALUES;
+  }
+  if (provider === 'claude') {
+    return CLAUDE_VALUES;
+  }
+  return null;
+}
+
+function normalizePreferredValue(
+  provider: DispatchCeilingProvider,
+  value: string | undefined,
+): DispatchCeilingValue | null {
+  if (!value) {
+    return null;
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const order = providerValueOrder(provider);
+  if (!order) {
+    return null;
+  }
+
+  if (!isValidProviderValue(provider, normalized)) {
+    const validValues = order.join(', ');
+    throw new Error(
+      `Invalid preferred dispatch value "${normalized}" for ${provider}. Valid values: ${validValues}.`,
+    );
+  }
+
+  return normalized;
+}
+
+function selectDispatchValue(
+  provider: DispatchCeilingProvider,
+  role: CeilingRole,
+  ceilingValue: DispatchCeilingValue,
+  preferredValue: DispatchCeilingValue | null,
+): DispatchSelection {
+  if (role === 'reviewer' || preferredValue === null) {
+    return {
+      role,
+      preferredValue,
+      selectedValue: ceilingValue,
+      capped: false,
+    };
+  }
+
+  const order = providerValueOrder(provider);
+  const preferredIndex = order?.indexOf(preferredValue) ?? -1;
+  const ceilingIndex = order?.indexOf(ceilingValue) ?? -1;
+  if (!order || preferredIndex < 0 || ceilingIndex < 0) {
+    return {
+      role,
+      preferredValue,
+      selectedValue: ceilingValue,
+      capped: false,
+    };
+  }
+
+  const selectedIndex = Math.min(preferredIndex, ceilingIndex);
+  return {
+    role,
+    preferredValue,
+    selectedValue: order[selectedIndex]!,
+    capped: preferredIndex > ceilingIndex,
+  };
+}
+
 /**
  * Join a resolved ceiling value with the active provider's adapter to compute
  * the enforcement mode, mechanism, dispatch args, and verify-on-upgrade flag.
@@ -317,6 +402,7 @@ function buildProviderResolution(
   value: DispatchCeilingValue | null,
   role: CeilingRole,
   orchestratorTier: string | undefined,
+  preferredValue: DispatchCeilingValue | null,
 ): ProviderResolution {
   const adapter = getCeilingAdapter(provider);
 
@@ -327,10 +413,18 @@ function buildProviderResolution(
       mechanism: adapter.mechanism,
       dispatchArgs: null,
       verifyOnDispatch: false,
+      selection: {
+        role,
+        preferredValue,
+        selectedValue: null,
+        capped: false,
+      },
     };
   }
 
-  const dispatchArgs = adapter.compileToDispatchArgs(value, role, {
+  const selection = selectDispatchValue(provider, role, value, preferredValue);
+  const dispatchValue = selection.selectedValue ?? value;
+  const dispatchArgs = adapter.compileToDispatchArgs(dispatchValue, role, {
     orchestratorTier,
   });
 
@@ -348,7 +442,10 @@ function buildProviderResolution(
     mode,
     mechanism: adapter.mechanism,
     dispatchArgs,
-    verifyOnDispatch: adapter.verifyOnDispatch(value, { orchestratorTier }),
+    verifyOnDispatch: adapter.verifyOnDispatch(dispatchValue, {
+      orchestratorTier,
+    }),
+    selection,
   };
 }
 
@@ -421,6 +518,7 @@ async function resolveDispatchCeiling(
     provider === 'codex'
       ? await resolveCodexProviderDefaultEffort(repoRoot, context, dependencies)
       : 'not-applicable';
+  const preferredValue = normalizePreferredValue(provider, options.preferred);
 
   const resolvedValue = await resolveCeilingValue(
     provider,
@@ -434,6 +532,7 @@ async function resolveDispatchCeiling(
     resolvedValue?.value ?? null,
     role,
     orchestratorTier,
+    preferredValue,
   );
   const providers: Record<string, ProviderResolution> = {
     [provider]: providerResolution,
@@ -544,8 +643,24 @@ function writeHumanResolution(
     context.logger.info(
       `Note: OAT will use pinned subagent variants up to ${resolution.value ?? 'the resolved ceiling'}. Base/unpinned roles resolve through the provider default.`,
     );
+    if (
+      providerResolution?.selection.selectedValue &&
+      providerResolution.selection.preferredValue
+    ) {
+      context.logger.info(
+        `Selected Codex effort: ${providerResolution.selection.selectedValue}`,
+      );
+    }
   } else {
     context.logger.info('Effort axis: not-applicable');
+    if (
+      providerResolution?.selection.selectedValue &&
+      providerResolution.selection.preferredValue
+    ) {
+      context.logger.info(
+        `Selected dispatch value: ${providerResolution.selection.selectedValue}`,
+      );
+    }
   }
 }
 
@@ -605,6 +720,10 @@ export function createProjectDispatchCeilingCommand(
       .option(
         '--orchestrator-tier <tier>',
         'Orchestrator tier, used to flag verify-on-upgrade for above-orchestrator requests',
+      )
+      .option(
+        '--preferred <value>',
+        'Preferred implementer/fix dispatch value before capping by the resolved ceiling',
       )
       .option(
         '--project-path <path>',

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- Add `--preferred` selection support to `oat project dispatch-ceiling resolve` so implementer/fix dispatches resolve `min(preferred, ceiling)` through the resolver instead of re-deriving variants in workflow instructions.
- Return a `selection` block in resolver output and preserve reviewer ceiling-target behavior for deterministic review gates.
- Clarify Codex, Claude, and generic explorer/provider-default dispatch semantics in `oat-project-implement` and OAT docs.
- Bump the lockstep public packages to `0.1.40` after rebasing onto latest `origin/main`.

## Validation

- `pnpm --filter @open-agent-toolkit/cli test -- src/commands/project/dispatch-ceiling/index.test.ts`
- `pnpm --filter @open-agent-toolkit/cli type-check`
- `pnpm --filter @open-agent-toolkit/cli lint`
- `pnpm run oat:validate-skills`
- `pnpm release:validate`
- `pnpm format`
- `pnpm exec commitlint --from origin/main --to HEAD --verbose`
- `git diff --check origin/main HEAD`

## Notes

- The branch was rebased onto current `origin/main` before opening this PR.
- Pre-push hooks also passed `release:check-versions`, skill version bump validation, workspace type-check, lint, and format.
