### PR TITLE
chore(backlog): add live workflow smoke fixture

### DIFF
--- a/.oat/repo/pjm/backlog/index.md
+++ b/.oat/repo/pjm/backlog/index.md
@@ -10,11 +10,13 @@
 - High-priority review throughput work now tracks `oat-reviewer` orchestration of cheaper/faster reconnaissance subagents while preserving primary-reviewer judgment for synthesis, severity, and final findings.
 - The `codex-family-subagents` dispatch UX supplement is split: human-facing display guidance is folded into project p03-t05, while reusable machine schema/formatter work is tracked as `BL-260709-add-dispatch-machine-schema`.
 - High-priority workflow follow-up now tracks structured post-implementation sequencing so final-review-passed projects can run summary/docs/PR preparation before final HiLL approval when configured, while stricter repos can defer selected actions until after approval.
+- High-priority workflow follow-up `BL-260711-add-live-workflow-smoke` tracks a disposable real-provider fixture for end-to-end dispatch, phase-review, and lifecycle-gate smoke validation.
 
 <!-- OAT BACKLOG-INDEX -->
 
 | ID                                       | Title                                                                | Status | Priority | Scope   | Estimate |
 | ---------------------------------------- | -------------------------------------------------------------------- | ------ | -------- | ------- | -------- |
+| BL-260711-add-live-workflow-smoke        | Add live workflow smoke fixture                                      | open   | high     | feature | L        |
 | BL-260708-enable-oat-reviewer-subagent   | Enable oat-reviewer subagent orchestration for faster broad reviews  | open   | high     | feature | M        |
 | BL-260709-split-post-implementation      | Split post-implementation sequence into pre- and post-approval steps | open   | high     | feature | M        |
 | BL-260709-add-dispatch-machine-schema    | Add dispatch machine schema and formatter                            | open   | medium   | feature | M        |

--- a/.oat/repo/pjm/backlog/items/BL-260711-add-live-workflow-smoke.md
+++ b/.oat/repo/pjm/backlog/items/BL-260711-add-live-workflow-smoke.md
@@ -1,0 +1,50 @@
+---
+id: BL-260711-add-live-workflow-smoke
+title: 'Add live workflow smoke fixture'
+status: open # open | in_progress | closed | wont_do
+priority: high # urgent | high | medium | low | none
+scope: feature # idea | task | feature | initiative
+scope_estimate: L # XS | S | M | L | XL | XXL
+labels: [workflow, smoke-test, e2e, gates, dispatch]
+assignee: null
+created: '2026-07-11T00:00:45Z'
+updated: '2026-07-11T00:00:45Z'
+associated_issues: []
+---
+
+## Description
+
+Add an opt-in, disposable live-provider smoke workflow that exercises real OAT
+project execution end to end. The fixture should contain two short phases with
+three explicit tasks each; every task makes a deterministic append to a fixture
+log so the implementation is intentionally trivial while the orchestration is
+real.
+
+The smoke runner must use real authenticated provider runtimes and the normal
+project lifecycle, including exact task-worker dispatch, configured phase
+reviews, and the final lifecycle gate. It should leave the user's OAT config
+and the source repository unchanged, then summarize the recorded dispatch and
+gate evidence. This is the practical acceptance surface for cross-cutting
+workflow, gate, and dispatch changes that are hard to prove with unit tests
+alone. It is deliberately opt-in rather than a required CI check because it
+consumes provider time and depends on local provider readiness.
+
+## Acceptance Criteria
+
+- A version-controlled fixture can be copied into a disposable worktree and
+  contains two phases with three stable task IDs each; every task has a bounded,
+  deterministic log-append outcome.
+- An opt-in smoke command or documented runner executes the normal project
+  lifecycle against real authenticated providers without modifying the source
+  repository or the user's persisted OAT configuration.
+- The fixture config and report prove phase/task dispatch, the exact selected
+  provider model or Codex role, phase review execution, final gate execution,
+  declared review project, and recorded invocation/producer provenance.
+- The standard fixture exercises a lower exact candidate beneath a higher named
+  project ceiling, including a Cursor opaque model argument when Cursor is
+  available.
+- Provider/readiness preflight reports unavailable runtimes or targets clearly
+  and exits without starting a partial workflow; cleanup handles interrupted
+  runs without deleting unrelated worktrees or project artifacts.
+- The runner is documented as a manual or release-validation smoke test and is
+  not added to the default CI test suite.


### PR DESCRIPTION
## Summary
- add `BL-260711-add-live-workflow-smoke` for a disposable real-provider workflow smoke fixture
- define two-phase, six-task fixture coverage for exact task dispatch, phase reviews, and final lifecycle gates
- require readiness preflight, evidence reporting, isolation, and explicit opt-in execution outside default CI

## Validation
- `oat backlog init`
- `oat backlog regenerate-index`
- `oxfmt --check .oat/repo/pjm/backlog/index.md .oat/repo/pjm/backlog/items/BL-260711-add-live-workflow-smoke.md`
