### PR TITLE
chore(oat): seed cursor-subagent-materialization project

### DIFF
--- a/.oat/projects/shared/cursor-subagent-materialization/discovery.md
+++ b/.oat/projects/shared/cursor-subagent-materialization/discovery.md
@@ -1,0 +1,116 @@
+---
+oat_status: complete
+oat_ready_for: oat-project-quick-start
+oat_blockers: []
+oat_last_updated: 2026-07-15
+oat_generated: false
+oat_template: false
+oat_template_name: discovery
+---
+
+# Discovery: cursor-subagent-materialization
+
+## Phase Guardrails (Discovery)
+
+Discovery is for requirements and decisions, not implementation details.
+
+## Initial Request
+
+Operator (2026-07-15): the Cursor team confirmed that while the _native_ subagent model list is narrower than the full Cursor CLI model list, model-pinned subagent definitions are respected — a `model:` pin in an agent definition file uses "the exact model you specify" (now verified as documented behavior, not just verbal confirmation). This unlocks Codex-style materialized, model/effort-pinned subagent variants for Cursor, giving OAT dispatch access to Cursor's full **multi-family** catalogue (GPT/sol-family, Anthropic, Grok, Composer) — a capability no other provider offers. Materialize subagents for Cursor the way OAT already does for Codex.
+
+## Current State (verified 2026-07-15 against main)
+
+- **Codex is fully materialized:** `.codex/agents/oat-{reviewer,phase-implementer}-gpt-5-6-{luna,terra,sol}-{low,medium,high,xhigh}[,max].toml` — generated files (`oat-owner: supported-catalogue` markers) pinning `model` + `model_reasoning_effort` and embedding full role instructions. Generator: `packages/cli/src/commands/providers/codex/materialize.ts`; catalogue: hardcoded `SUPPORTED_CODEX_ROLE_TARGETS` in `packages/cli/src/providers/codex/codec/shared.ts`; owner system distinguishes `supported-catalogue | user-config | project-config` (user/project ladder cells outside the catalogue also get variants materialized).
+- **Cursor has none:** `.cursor/agents/` holds only symlinks to canonical unpinned `.agents/agents/*.md`. Dispatch passes an opaque `dispatchArgs.model` string; the skills say "use the exact resolver-returned model value"; `runtimeIdentity` reports `not-reported` for Cursor.
+- **The bundled dispatch-matrix recommendation's Cursor cells are gpt-only** (`2026-07-10.2`), while the operator's cloud environment already runs a **proven multi-family Cursor ladder** (`cloud-agent-env-node` `.cursor/oat-user-config.json`, marker version `2026-07-11.1`): Economy = `composer-2.5`, `claude-sonnet-5-high`, `gpt-5.6-luna-high/xhigh`; Balanced = `cursor-grok-4.5-high`, `gpt-5.6-terra-high`; High = `gpt-5.6-sol-medium/high`; Frontier = `claude-fable-5-thinking-high/xhigh`, `gpt-5.6-sol-xhigh/max`. That config also shows the existing availability-probe pattern (`cursor-agent --list-models | grep -Fq -- '<id>'`).
+
+## Cursor Subagent Contract (docs-verified 2026-07-15, cursor.com/docs/subagents)
+
+- **Frontmatter schema is exactly five fields:** `name` (lowercase+hyphens, defaults from filename), `description`, `model` (default `inherit`), `readonly` (default false), `is_background` (default false). **No `tools:` field** (Claude-only syntax). Body = system prompt.
+- **Model pinning syntax (documented form):** base model ID + optional bracket params — `gpt-5.6-sol`, `claude-opus-4-8[effort=high]`, `composer-2.5[fast=false]`, combined `[effort=high,context=300k]`. Documented options: `effort`, `context`, `fast` ("available options depend on the model"). **Flat effort-suffixed IDs (`gpt-5.6-sol-high`) are never documented as frontmatter values** — they are the CLI `--list-models`/ladder surface; the two catalogues are not documented as interchangeable.
+- **Fallback (not failure) when a pin can't be honored:** team admin restrictions, Max Mode required, plan limitations → "Cursor falls back to a compatible model"; plus legacy request-based plans run subagents on Composer regardless of config. No rejection signal is emitted.
+- **Discovery locations:** `.cursor/agents/` plus `.claude/agents/` and `.codex/agents/` compat dirs (project and user level); project beats user; `.cursor/` wins name conflicts over compat dirs.
+- **Runtime environment facts (verified live in this repo):** `CURSOR_AGENT=1` provider marker set; `CURSOR_CONVERSATION_ID` gives an agent its own session ID (transcript addressable at `agent-transcripts/<id>/<id>.jsonl`); **no model env var and no model field in transcripts** — a Cursor agent cannot verify its own model.
+
+## Solution Space
+
+### Approach A: Extend the existing materializer (chosen)
+
+**Description:** Generalize the Codex materialization path to a provider-parameterized one. Same canonical `.agents/agents/` sources, same owner-marker system, emitting `.cursor/agents/oat-<role>-<catalogue-id>.md` — a near-pure copy of the canonical file with `model:` frontmatter added (plus managed/owner markers). New `SUPPORTED_CURSOR_ROLE_TARGETS` catalogue constant; sync/doctor/strays machinery generalized.
+**Tradeoffs:** touches providers/sync core; but the codec is trivial (frontmatter-only — no instruction re-embedding like Codex TOML) and the mechanism is proven.
+
+### Approach B: Hand-authored variant files
+
+**Tradeoffs:** fast to ship; ~30 files × every future role-instruction change = the drift factory the Codex generator exists to prevent. Rejected.
+
+### Approach C: Dynamic pinning at dispatch time
+
+**Tradeoffs:** no file proliferation, but diverges from the proven Codex launch contract (exact native agent type first) and fights Cursor's agent-discovery model. Rejected.
+
+### Chosen Direction
+
+**Approach:** A — extend the materializer.
+**Rationale:** the provider asymmetry is the bug; A removes it with machinery that already works, and the Cursor codec is the cheapest possible codec.
+**User validated:** Yes (2026-07-15).
+
+## Key Decisions
+
+1. **Frontmatter-only codec, documented syntax only:** emitted `model:` values use the documented base-ID + bracket form. Flat suffixed IDs never go into generated frontmatter.
+2. **Catalogue is an explicit mapping table:** each entry pairs the ladder-surface flat string with its frontmatter form. Known-clean mappings: `gpt-5.6-{luna,terra,sol}-<effort>` → `gpt-5.6-{family}[effort=<effort>]` (incl. `sol-max` → `[effort=max]`); `claude-sonnet-5-high` → `claude-sonnet-5[effort=high]` (docs-example shape); Composer explicitly `composer-2.5[]` (standard) / `composer-2.5[fast=true]` (fast) — bare `composer-2.5` may default fast, so always bracket-explicit. **Awkward entries flagged for the verification lane, not guessed:** `claude-fable-5-thinking-high` (likely base `claude-fable-5-thinking` + `[effort=high]`, since `thinking` is not a documented bracket option and must be part of the family name) and `cursor-grok-4.5-high-fast` (plausibly `cursor-grok-4.5[effort=high,fast=true]`).
+3. **Verification lane is a requirement:** implementation launches one pinned test subagent per syntax family and confirms the pin took before a mapping entry is trusted; ambiguous entries are corrected or excluded (mapping is data — one-line fixes). Bonus check: whether flat IDs happen to work (undocumented; never relied upon).
+4. **Catalogue scope is multi-family, seeded from the proven cloud ladder** (the operator-authored `2026-07-11.1` set above), not a Codex mirror: gpt-5.6 ladder + Claude family + Grok (Balanced tier per operator) + Composer. Two roles (`oat-reviewer`, `oat-phase-implementer`) × catalogue ≈ 30 files. Cursor-exclusive models ARE the point — that's the differentiating capability.
+5. **Bundled `dispatch-matrix-recommendation.json` Cursor cells are enriched in the same project** (multi-family tier placement promoted from the cloud ladder; Grok in Balanced). Variants no ladder cell can select are dead files. The catalogue (capability) stays broader than any one operator's ladder (selection policy) — the operator keeps their own ladder narrow; the layer separation is exactly the existing Codex owner-marker architecture.
+6. **Resolver/skill adoption is in scope:** the resolver's Cursor cells emit the materialized variant name Codex-style (launch as native subagent type first), and the dispatch skills' Cursor rules update from "pass the opaque model value" accordingly.
+7. **Provenance is launcher-owned, `configured` confidence:** Cursor cannot self-report model identity (no env var, no transcript field, model self-belief unreliable) and pin fallback is silent — so the dispatch audit claims "configured to run X via variant file," never "verified running X." Variant instructions have the agent report `CURSOR_CONVERSATION_ID` (session identity — verifiable) into its output for transcript-precise correlation.
+
+## Constraints
+
+- Canonical skills/agents edits require frontmatter version bumps; generated assets count as shipped functionality → lockstep five-package version bump + `pnpm release:validate`.
+- Generated variant names must not shadow or be shadowed across Cursor's compat dirs (`.claude/agents/`, `.codex/agents/`) — name-collision check in the generator.
+- The materializer must preserve the Codex owner-marker system (`supported-catalogue | user-config | project-config`) so user/project ladder cells outside the catalogue also materialize.
+- Availability probing reuses the existing `cursor-agent --list-models` grep pattern (doctor check: variant pins a model no longer listed).
+- Sequencing: independent of `gate-execution-hardening` implementation (no shared files beyond possible dispatch-skill prose adjacency — check at planning; both may touch `oat-dispatch-subagents` references, where gate-hardening p02-t06 adds dispatch-mode guidance).
+
+## Success Criteria
+
+- `.cursor/agents/` contains generated pinned variants for both roles across the catalogue, byte-identical to canonical instructions apart from frontmatter additions and managed markers.
+- Managed Cursor dispatch resolves a ladder cell to a named materialized variant and launches it as the native subagent type; the dispatch audit records launcher-owned `configured` provenance.
+- The bundled recommendation's Cursor cells are multi-family; `oat sync`/doctor/strays handle Cursor variants as they do Codex ones.
+- Verification lane results recorded: every shipped mapping entry's pin confirmed live (or the entry excluded with a note).
+
+## Out of Scope
+
+- `context=300k`-style large-context variants (deferred idea — e.g. big final reviews).
+- `is_background`-pinned variant flavors (deferred — intersects gate-hardening's dispatch-mode guidance; revisit after both land).
+- Other roles beyond reviewer/phase-implementer (oat-codebase-mapper etc. — follow-up if the pattern proves out).
+- Changing Claude-provider dispatch (unaffected).
+
+## Deferred Ideas
+
+- Large-context reviewer variants via `[context=…]` for oversized final reviews.
+- Definition-level `is_background: true` reviewer variants (ties into the dispatch-mode guidance shipping in gate-execution-hardening p02-t06).
+- Extending materialization to additional roles.
+
+## Open Questions
+
+- **Awkward mapping decompositions** (Key Decision 2): settle `claude-fable-5-thinking-*` and `cursor-grok-4.5-high-fast` via the verification lane; consult the models reference during implementation.
+- **Variant file naming:** keep the ladder-surface flat string as the filename/agent name (`oat-reviewer-claude-fable-5-thinking-high`) for 1:1 resolver mapping, even though the frontmatter uses bracket syntax? (Lean yes — the resolver speaks flat strings.)
+- **Does `name:` frontmatter need to be set explicitly** or is filename-derivation sufficient for the launch-by-agent-type contract? (Check at implementation; lowercase+hyphen rule is satisfied either way.)
+
+## Assumptions
+
+- Cursor honors definition-level pins in the operator's environments (docs-confirmed; fallback conditions absent per operator).
+- The Codex materializer's structure generalizes without a rewrite (codec interface extraction is enough).
+
+## Risks
+
+- **Silent pin fallback in restricted environments** corrupts provenance claims.
+  - **Likelihood:** Low (operator envs unrestricted) / **Impact:** Medium
+  - **Mitigation Ideas:** `configured`-not-`verified` audit language (Key Decision 7); doctor availability check.
+- **Cursor model-catalogue churn** (model IDs renamed/retired) rots the mapping table.
+  - **Likelihood:** Medium / **Impact:** Low
+  - **Mitigation Ideas:** availability probe in doctor; mapping is data with one-line fixes.
+
+## Next Steps
+
+Quick mode → **hand off to another agent** for `oat-project-quick-start` (straight to plan is plausible; lightweight design optional if the materializer generalization surfaces structure questions). Discovery is complete and operator-validated — do not re-run discovery.

--- a/.oat/projects/shared/cursor-subagent-materialization/implementation.md
+++ b/.oat/projects/shared/cursor-subagent-materialization/implementation.md
@@ -1,0 +1,210 @@
+---
+oat_status: in_progress
+oat_ready_for: null
+oat_blockers: []
+oat_last_updated: 2026-07-16
+oat_current_task_id: p01-t01
+oat_generated: false
+---
+
+# Implementation: cursor-subagent-materialization
+
+**Started:** 2026-07-16
+**Last Updated:** 2026-07-16
+
+> This document is used to resume interrupted implementation sessions.
+>
+> Conventions:
+>
+> - `oat_current_task_id` always points at the **next plan task to do** (not the last completed task).
+> - When all plan tasks are complete, set `oat_current_task_id: null`.
+> - Reviews are **not** plan tasks. Track review status in `plan.md` under `## Reviews` (e.g., `| final | code | passed | ... |`).
+> - Keep phase/task statuses consistent with the Progress Overview table so restarts resume correctly.
+> - Before running the `oat-project-pr-final` skill, ensure `## Final Summary (for PR/docs)` is filled with what was actually implemented.
+
+## Progress Overview
+
+| Phase   | Status      | Tasks | Completed |
+| ------- | ----------- | ----- | --------- |
+| Phase 1 | in_progress | N     | 0/N       |
+| Phase 2 | pending     | N     | 0/N       |
+
+**Total:** 0/{N} tasks completed
+
+---
+
+## Phase 1: {Phase Name}
+
+**Status:** in_progress
+**Started:** 2026-07-16
+
+### Phase Summary (fill when phase is complete)
+
+**Outcome (what changed):**
+
+- {2-5 bullets describing user-visible / behavior-level changes delivered in this phase}
+
+**Key files touched:**
+
+- `{path}` - {why}
+
+**Verification:**
+
+- Run: `{command(s)}`
+- Result: {pass/fail + notes}
+
+**Notes / Decisions:**
+
+- {trade-offs or deviations discovered during implementation}
+
+### Task p01-t01: {Task Name}
+
+**Status:** completed / in_progress / pending / blocked
+**Commit:** {sha} (if completed)
+
+**Outcome (required when completed):**
+
+- {what materially changed (not “did task”, but “system now does X”)}
+
+**Files changed:**
+
+- `{path}` - {why}
+
+**Verification:**
+
+- Run: `{command(s)}`
+- Result: {pass/fail + notes}
+
+**Notes / Decisions:**
+
+- {gotchas, trade-offs, design deltas, important context for future sessions}
+
+**Issues Encountered:**
+
+- {Issue and resolution}
+
+---
+
+### Task p01-t02: {Task Name}
+
+**Status:** pending
+**Commit:** -
+
+**Notes:**
+
+- {Notes will be added during implementation}
+
+---
+
+## Phase 2: {Phase Name}
+
+**Status:** pending
+**Started:** -
+
+### Task p02-t01: {Task Name}
+
+**Status:** pending
+**Commit:** -
+
+---
+
+## Orchestration Runs
+
+_Each run from `oat-project-implement` appends an entry below with:_
+_- Run header (number, timestamp, branch, tier, policy, phase counts)_
+_- Phase Outcomes table_
+_- Parallel Groups list_
+_- Outstanding Items_
+
+<!-- orchestration-runs-start -->
+
+_Orchestration runs from `oat-project-implement` are appended here, most-recent-first within the file but append-only at the bottom of the log._
+
+<!-- orchestration-runs-end -->
+
+---
+
+## Implementation Log
+
+Chronological log of implementation progress.
+
+### 2026-07-16
+
+**Session Start:** {time}
+
+- [x] p01-t01: {Task name} - {commit sha}
+- [ ] p01-t02: {Task name} - in progress
+
+**What changed (high level):**
+
+- {short bullets suitable for PR/docs}
+
+**Decisions:**
+
+- {Decision made and rationale}
+
+**Follow-ups / TODO:**
+
+- {anything discovered during implementation that should be captured for later}
+
+**Blockers:**
+
+- {Blocker description} - {status: resolved/pending}
+
+**Session End:** {time}
+
+---
+
+### 2026-07-16
+
+**Session Start:** {time}
+
+{Continue log...}
+
+---
+
+## Deviations from Plan / Design
+
+Document any intentional deviations from the original plan, spec, or design. Include accepted review findings where the shipped implementation is source of truth and a lifecycle artifact needs alignment.
+
+| Task / Review | Source Artifact | Planned / Documented | Actual / Accepted | Reason | Source of Truth | Follow-up |
+| ------------- | --------------- | -------------------- | ----------------- | ------ | --------------- | --------- |
+| -             | -               | -                    | -                 | -      | -               | -         |
+
+## Test Results
+
+Track test execution during implementation.
+
+| Phase | Tests Run | Passed | Failed | Coverage |
+| ----- | --------- | ------ | ------ | -------- |
+| 1     | -         | -      | -      | -        |
+| 2     | -         | -      | -      | -        |
+
+## Final Summary (for PR/docs)
+
+**What shipped:**
+
+- {capability 1}
+- {capability 2}
+
+**Behavioral changes (user-facing):**
+
+- {bullet}
+
+**Key files / modules:**
+
+- `{path}` - {purpose}
+
+**Verification performed:**
+
+- {tests/lint/typecheck/build/manual steps}
+
+**Design deltas (if any):**
+
+- {what changed vs design.md and why}
+
+## References
+
+- Plan: `plan.md`
+- Design: `design.md`
+- Spec: `spec.md`

--- a/.oat/projects/shared/cursor-subagent-materialization/plan.md
+++ b/.oat/projects/shared/cursor-subagent-materialization/plan.md
@@ -1,0 +1,206 @@
+---
+oat_status: in_progress
+oat_ready_for: null
+oat_blockers: []
+oat_last_updated: 2026-07-16
+oat_phase: plan
+oat_phase_status: in_progress
+oat_plan_hill_phases: [] # phases to pause AFTER completing (empty = every phase)
+oat_plan_parallel_groups: [] # groups of phases that run concurrently in worktrees; [] = fully sequential
+oat_plan_source: spec-driven # spec-driven | quick | imported
+oat_import_reference: null # e.g., references/imported-plan.md
+oat_import_source_path: null # original source path provided by user
+oat_import_provider: null # codex | cursor | claude | null
+oat_generated: false
+---
+
+# Implementation Plan: cursor-subagent-materialization
+
+> Execute this plan using `oat-project-implement` — sequential by default, parallel when `oat_plan_parallel_groups` is declared.
+
+**Goal:** {Brief goal statement from spec}
+
+**Architecture:** {1-2 sentence architecture summary from design}
+
+**Tech Stack:** {Key technologies from design}
+
+**Commit Convention:** `{type}({scope}): {description}` - e.g., `feat(p01-t01): add user auth endpoint`
+
+## Planning Checklist
+
+- [ ] Confirmed HiLL checkpoints with user
+- [ ] Set `oat_plan_hill_phases` in frontmatter
+- [ ] Evaluated phases for parallelism opportunities
+- [ ] Set `oat_plan_parallel_groups` in frontmatter
+
+---
+
+## Parallelism
+
+Phases that have no overlapping file modifications may run concurrently. To declare parallelism:
+
+```yaml
+oat_plan_parallel_groups: [['p02', 'p03']]
+```
+
+Each inner array is a group of phases that execute in parallel (each in its own worktree) and merge back in plan order after all pass. Groups themselves run sequentially.
+
+Default is `[]` (fully sequential, no worktrees). Only declare parallelism when phases are genuinely file-disjoint — overlap will produce merge conflicts that stop the run.
+
+---
+
+## Dispatch Profile
+
+_Optional override surface. Use only for explicit user-authored constraints or preferences. Omit this section when runtime selection should choose the lowest confident tier._
+
+Blank or `auto` means there is no explicit constraint for that provider. Do not generate rows by default; a missing phase row uses runtime selection.
+
+| Phase | Claude model                     | Codex effort                   | Rationale                     |
+| ----- | -------------------------------- | ------------------------------ | ----------------------------- |
+| pNN   | haiku\|sonnet\|opus\|fable\|auto | low\|medium\|high\|xhigh\|auto | why this constraint is needed |
+
+Codex effort values are preferred controls. `oat-project-implement` caps them when a capped managed dispatch policy exists, selects them directly under managed `Uncapped`, and maps selected efforts to pinned implementer variants when available. Codex provider default effort is informational only for explicit inherit/default behavior or base/unpinned fallback paths.
+
+---
+
+RED/GREEN/Refactor is the recommended default where work is testable, not a validator requirement. Other task-body shapes, including non-TDD shapes, are allowed when appropriate, provided the plan preserves stable `pNN-tNN` IDs, per-task verification, and atomic commits.
+
+## Phase 1: {Phase Name}
+
+### Task p01-t01: {Task Name}
+
+**Files:**
+
+- Create: `{path/to/file.ts}`
+- Modify: `{path/to/existing.ts}`
+
+**Step 1: Write test (RED)**
+
+```typescript
+// {path/to/file.test.ts}
+describe('{feature}', () => {
+  it('{test case}', () => {
+    // Test implementation
+  });
+});
+```
+
+Run: `pnpm --filter {package-name} exec vitest run {path/to/file.test.ts}`
+Expected: Test fails (RED)
+
+**Step 2: Implement (GREEN)**
+
+```typescript
+// {path/to/file.ts}
+// Implementation code or interface signatures
+```
+
+Run: `pnpm --filter {package-name} exec vitest run {path/to/file.test.ts}`
+Expected: Test passes (GREEN)
+
+Use the actual runner command that scopes to the intended file or test target. Do not write a package-level shortcut unless it truly executes only the scope the task claims.
+
+**Step 3: Refactor**
+
+{Any cleanup or improvements while tests stay green}
+
+**Step 4: Verify**
+
+Run: `pnpm lint && pnpm type-check`
+Expected: No errors
+
+**Step 5: Commit**
+
+```bash
+git add {files}
+git commit -m "feat(p01-t01): {description}"
+```
+
+---
+
+### Task p01-t02: {Task Name}
+
+**Files:**
+
+- {File list}
+
+**Step 1: Write test (RED)**
+
+{Test code}
+
+**Step 2: Implement (GREEN)**
+
+{Implementation code or signatures}
+
+**Step 3: Refactor**
+
+{Optional cleanup}
+
+**Step 4: Verify**
+
+Run: `{verification command}`
+Expected: {output}
+
+Verification commands should be behaviorally accurate. If the task claims a file-scoped or test-scoped check, use the concrete runner invocation that really scopes to that target.
+
+**Step 5: Commit**
+
+```bash
+git add {files}
+git commit -m "feat(p01-t02): {description}"
+```
+
+---
+
+## Phase 2: {Phase Name}
+
+### Task p02-t01: {Task Name}
+
+{Continue TDD pattern...}
+
+---
+
+## Reviews
+
+{Track reviews here after running the oat-project-review-provide and oat-project-review-receive skills.}
+
+{Keep both code + artifact rows below. Add additional code rows (p03, p04, etc.) as needed, but do not delete `spec`/`design`.}
+
+| Scope  | Type     | Status  | Date | Artifact |
+| ------ | -------- | ------- | ---- | -------- |
+| p01    | code     | pending | -    | -        |
+| p02    | code     | pending | -    | -        |
+| final  | code     | pending | -    | -        |
+| spec   | artifact | pending | -    | -        |
+| design | artifact | pending | -    | -        |
+
+**Status values:** `pending` → `received` → `fixes_added` → `fixes_completed` → `passed`
+
+**Meaning:**
+
+- `received`: review artifact exists (not yet converted into fix tasks)
+- `fixes_added`: fix tasks were added to the plan (work queued)
+- `fixes_completed`: fix tasks implemented, awaiting re-review
+- `passed`: re-review run and recorded as passing (no Critical/Important)
+
+---
+
+## Implementation Complete
+
+**Summary:**
+
+- Phase 1: {N} tasks - {Description}
+- Phase 2: {N} tasks - {Description}
+
+**Total: {N} tasks**
+
+Ready for code review and merge.
+
+---
+
+## References
+
+- Design: `design.md` (required in spec-driven mode; optional in quick/import mode)
+- Spec: `spec.md` (required in spec-driven mode; optional in quick/import mode)
+- Discovery: `discovery.md`
+- Imported Source: `references/imported-plan.md` (when `oat_plan_source: imported`)

--- a/.oat/projects/shared/cursor-subagent-materialization/state.md
+++ b/.oat/projects/shared/cursor-subagent-materialization/state.md
@@ -1,0 +1,71 @@
+---
+oat_current_task: null
+oat_last_commit: null
+oat_blockers: []
+associated_issues: [] # [{type: backlog|project|jira|linear, ref: "identifier"}]
+oat_kind: implementation # implementation | coordination; coordination parents may use oat_phase: decomposition
+oat_parent: null # optional child-only coordination parent slug
+oat_siblings: [] # optional child-only sibling slugs
+oat_depends_on: [] # optional child-only sibling dependencies
+oat_children: [] # optional coordination-parent child slugs
+oat_hill_checkpoints: [] # Configured: which phases require human-in-the-loop lifecycle approval
+oat_hill_completed: [] # Progress: which HiLL checkpoints have been completed
+oat_parallel_execution: false
+oat_phase: discovery # Current phase: discovery | spec | design | plan | implement | decomposition
+oat_phase_status: in_progress # Status: in_progress | complete | pr_open
+# oat_orchestration_retry_limit: 2  # optional; override fix-loop retry limit (range 0-5)
+# oat_dispatch_policy: # optional project dispatch policy; managed keeps OAT selection active, inherit leaves controls to the host
+#   mode: managed # managed | inherit
+#   policy: balanced # economy | balanced | high | frontier | uncapped; omit when mode: inherit
+#   providers: # present for capped managed policies; omitted for uncapped/inherit
+#     codex: high # low|medium|high|xhigh
+#     claude: sonnet # haiku|sonnet|opus|fable
+#   matrix: # optional sparse project override; full dispatch matrix lives in layered config
+#     cursor:
+#       high:
+#         - composer-2.5
+#         - { harness: cursor, model: gpt-5.5-xhigh }
+#   source: project-state
+# oat_dispatch_ceiling: # legacy compatibility alias for capped managed provider targets
+oat_workflow_mode: quick # spec-driven | quick | import
+oat_workflow_origin: native # native | imported
+oat_docs_updated: null # null | skipped | complete — documentation sync status
+oat_pr_status: null # null | ready | open | closed | merged — actual PR state for the current project
+oat_pr_url: null # null | string — tracked PR URL when a PR exists
+oat_project_created: '2026-07-16T01:32:14.171Z' # ISO 8601 UTC timestamp — set once at project creation
+oat_project_completed: null # ISO 8601 UTC timestamp — set when project is completed/archived
+oat_project_state_updated: '2026-07-16T01:32:14.171Z' # ISO 8601 UTC timestamp — updated on every state.md mutation
+oat_generated: false
+---
+
+# Project State: cursor-subagent-materialization
+
+**Status:** Discovery
+**Started:** 2026-07-16
+**Last Updated:** 2026-07-16
+
+## Current Phase
+
+Discovery - Gathering requirements for a quick workflow before planning
+
+## Artifacts
+
+- **Discovery:** `discovery.md` (in_progress)
+- **Spec:** N/A (quick mode)
+- **Design:** N/A (quick mode unless lightweight design is needed)
+- **Plan:** `plan.md` (scaffolded template — not started)
+- **Implementation:** `implementation.md` (scaffolded template — not started)
+
+## Progress
+
+- ✓ Discovery started
+- ✓ Execution artifacts scaffolded
+- ⧗ Awaiting user input
+
+## Blockers
+
+None
+
+## Next Milestone
+
+Complete discovery and generate a quick implementation plan

--- a/.oat/projects/shared/cursor-subagent-materialization/state.md
+++ b/.oat/projects/shared/cursor-subagent-materialization/state.md
@@ -12,7 +12,7 @@ oat_hill_checkpoints: [] # Configured: which phases require human-in-the-loop li
 oat_hill_completed: [] # Progress: which HiLL checkpoints have been completed
 oat_parallel_execution: false
 oat_phase: discovery # Current phase: discovery | spec | design | plan | implement | decomposition
-oat_phase_status: in_progress # Status: in_progress | complete | pr_open
+oat_phase_status: complete # Status: in_progress | complete | pr_open
 # oat_orchestration_retry_limit: 2  # optional; override fix-loop retry limit (range 0-5)
 # oat_dispatch_policy: # optional project dispatch policy; managed keeps OAT selection active, inherit leaves controls to the host
 #   mode: managed # managed | inherit


### PR DESCRIPTION
## Summary

- Scaffolds and seeds the `cursor-subagent-materialization` project from a structured brainstorm (2026-07-15): materialize model/effort-pinned Cursor subagent variants the way OAT already does for Codex, unlocking Cursor's full multi-family catalogue (GPT/sol, Anthropic, Grok, Composer) for managed dispatch.
- Discovery is complete and operator-validated: chosen approach (extend the Codex materializer with a frontmatter-only codec), seven key decisions including documented bracket-syntax-only emission via an explicit mapping table, a live verification lane gating every mapping entry, catalogue seeded from the proven cloud-environment ladder, bundled recommendation enrichment, resolver/skill adoption in scope, and launcher-owned `configured` provenance.
- Docs-verified Cursor subagent contract facts (five-field frontmatter schema, bracket params, silent-fallback conditions, compat-dir precedence) and live-verified runtime facts (`CURSOR_AGENT`, `CURSOR_CONVERSATION_ID`, no model self-identity) are recorded in discovery.
- Implementation is already underway by a resident agent in its own worktree (design reviewed 2026-07-16; through plan-phase gating) — this PR lands the canonical seed those artifacts build on.

Bookkeeping only (`.oat/projects/`), no version bump required.

## Test plan

- [ ] Discovery frontmatter parses; format check passes (committed through lint-staged/oxfmt)