### PR TITLE
Preserve final gate across base-only updates

### DIFF
--- a/.agents/skills/oat-project-implement/SKILL.md
+++ b/.agents/skills/oat-project-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-implement
-version: 2.1.5
+version: 2.1.6
 description: Use when plan.md is ready for execution. Dispatches one phase implementer per phase, owns independent phase review and bounded fix routing, and supports plan-declared worktree-isolated parallel phases.
 oat_gateable: true
 argument-hint: '[--retry-limit <N>] [--dry-run]'

--- a/.agents/skills/oat-project-implement/references/completion-and-closeout.md
+++ b/.agents/skills/oat-project-implement/references/completion-and-closeout.md
@@ -310,7 +310,10 @@ oat_implement_exit_gate:
   max_attempts: 2
   attempts_completed: 0
   reviewed_head: null
+  implementation_base_ref: null
   implementation_fingerprint: null
+  freshness_head: null
+  freshness_fingerprint: null
   launch_state: not_started # not_started | intent_persisted | accepted | result_persisted | not_accepted
   launch_attempt_id: null
   launch_started_at: null
@@ -342,6 +345,29 @@ resolved command, description, `onFailure`, and `maxAttempts` to derive
 pending` before any gate launch. Missing state means unresolved, never no gate.
 A `null` resolution persists `allowed/no_gate` with `disposition: no_gate`,
 null run/artifact/receive provenance, and the current implementation basis.
+
+New generations persist `implementation_fingerprint` as
+`sha256:effective-delta-v1:<digest>`. Resolve the logical integration base from
+the tracked PR's exact base ref, then the repository's configured remote default
+branch; missing or ambiguous resolution fails closed. Persist the logical base
+ref as `implementation_base_ref`; require exactly one merge base between that
+ref and each compared HEAD.
+
+Prefix the fingerprint input with the bytes `effective-delta-v1\0`. Hash the
+exact NUL-delimited byte stream from Git
+`--raw -z --no-renames --no-abbrev` output, which includes both base and final
+modes and full object IDs for blobs, symlinks, deletions, and gitlinks. Run with
+`LC_ALL=C` from the unique merge base to the compared HEAD. Git's raw `-z`
+format owns path framing and byte ordering; do not parse and reserialize it,
+abbreviate object IDs, enable rename detection, or hash human patch output.
+
+Exclude only the exact `$PROJECT_PATH/state.md` checkpoint carrier to avoid a
+self-referential digest. Use Git's literal exclusion pathspec, not a glob.
+Validate that file independently as the structured transition above. Every
+other path remains fingerprinted. Set `freshness_head` to `reviewed_head` and
+`freshness_fingerprint` to `implementation_fingerprint` when the generation
+starts. These rolling fields preserve the accepted tree outcome after later
+authorized closeout transitions without changing the immutable reviewed basis.
 
 An in-flight `pending` or `blocked` generation reuses its persisted resolved
 configuration and never re-resolves it. Recompute the fingerprint from those
@@ -476,19 +502,43 @@ disposition.
   policy, or persistence boundary.
 - A fresh `allowed` result resumes after the gate without executing the gate or
   receive a second time. Reuse requires a valid disposition, complete
-  configured-gate provenance when configured, an unchanged implementation
-  fingerprint, and any eligible receive marked complete.
+  configured-gate provenance when configured, an unchanged immutable
+  implementation fingerprint, a valid rolling freshness checkpoint, and any
+  eligible receive marked complete.
 - Closeout-only descendants include configured gate artifacts and receipts,
   project tracking, `project-log.md` appends, summary/documentation/PR sequence
   outputs, final HiLL bookkeeping, and completion bookkeeping. Classify
   gate-owned `oat project log append` mutations introduced with PR #156 as
-  closeout-only; they do not invalidate the reviewed implementation basis.
-- Determine freshness from every path changed after `reviewed_head`, and require
-  each descendant commit to contain only recognized closeout work. An unknown
-  changed path fails closed as substantive implementation change.
-  Implementation, test, skill, template, or workflow configuration changes
-  make the prior result `stale`. Preserve its provenance for audit, require a
-  current final lifecycle review for the new basis, and start a new generation.
+  closeout-only. A path category alone is insufficient: the corresponding
+  persisted gate or sequence transition must own that descendant boundary;
+  unknown or mixed work is substantive.
+- For a qualified `sha256:effective-delta-v1:<digest>` value, require the
+  persisted `implementation_base_ref`, `freshness_head`, one current merge base,
+  and 64-character lowercase hexadecimal implementation and freshness digests.
+  Missing or malformed inputs fail closed. Walk descendants after
+  `freshness_head` in commit order. Ignore a checkpoint-persistence commit only
+  after verifying its diff changes the exact state carrier and nothing else.
+  After a corroborated closeout-only transition, hash the complete current
+  effective delta and persist the rolling freshness checkpoint. Record the
+  transition's last non-checkpoint commit as `freshness_head`; the following
+  state-only persistence commit is the verified carrier exception above. For a
+  merge, rebase, or base-update boundary, recompute the complete effective delta
+  against the current merge base. A merge, rebase, or base update is not
+  substantive by itself. When it matches the rolling fingerprint, preserve the
+  allowed generation and persist an advanced rolling checkpoint without
+  rerunning gate or receive. A mismatch, unknown commit, or mixed
+  closeout/substantive boundary marks the generation `stale`.
+  Conflict resolution or branch-owned implementation, test, skill, template, or
+  workflow changes that alter the effective delta are substantive.
+- Legacy unqualified `sha256:<digest>` values keep the descendant-path policy
+  and are never reinterpreted or migrated in place. Determine freshness from
+  every path changed after `reviewed_head`, and require each descendant commit
+  to contain only recognized closeout work. An unknown changed path fails closed
+  as substantive implementation change. Implementation, test, skill, template,
+  or workflow configuration changes make the prior result `stale`.
+- Every stale transition preserves prior provenance for audit, requires a
+  current final lifecycle review for the changed basis, and starts a new
+  generation using the qualified fingerprint format.
 
 Before approval-aware sequencing, final HiLL approval, implementation
 completion, or success output, run the configured gate:
@@ -682,6 +732,14 @@ Commit each completed step before dispatching the next step. On failure, persist
 A pre-approval failure leaves `approval: pending`; a post-approval failure
 retains `approval: approved`. Fail fast with the boundary, failed step, and
 exact resume command: `oat-project-implement`.
+
+For qualified gate state, treat each committed sequence step as a corroborated
+closeout boundary. Recompute the complete effective delta, record that step
+commit as `freshness_head`, and persist `freshness_fingerprint` in a separate
+state-only checkpoint commit before dispatching the next step. Apply the same
+checkpoint protocol to gate bookkeeping, final HiLL bookkeeping, and completion
+bookkeeping. A mixed commit, missing child transition, or non-state path in the
+checkpoint-persistence commit fails closed as stale.
 
 1. Dispatch incomplete `pre_approval` steps in stored order.
 2. When they succeed and a final checkpoint exists, commit `status:

--- a/.agents/skills/oat-project-next/SKILL.md
+++ b/.agents/skills/oat-project-next/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oat-project-next
-version: 1.0.10
+version: 1.0.11
 description: Use when continuing work on the active OAT project. Reads project state, determines the next lifecycle action, and invokes the appropriate skill automatically.
 disable-model-invocation: true
 user-invocable: true
@@ -270,9 +270,13 @@ Before every other post-implementation route, inspect
 or not fresh, route to `oat-project-implement`.
 
 This override applies even when `oat_phase_status` is `complete` or `pr_open`,
-and before the summary, document, PR, or `oat-project-complete` routes. Announce
-exactly: "Implementation exit gate unresolved or stale — resume with
-`oat-project-implement` before post-implementation routing."
+and before the summary, document, PR, or `oat-project-complete` routes. When a
+qualified allowed result matches but its rolling checkpoint trails HEAD,
+announce exactly: "Implementation exit gate freshness checkpoint pending —
+resume with `oat-project-implement` before post-implementation routing." For all
+other unresolved or stale cases, announce exactly: "Implementation exit gate
+unresolved or stale — resume with `oat-project-implement` before
+post-implementation routing."
 
 Only an `allowed` and fresh exit-gate disposition falls through to the normal
 post-implementation checks.
@@ -282,11 +286,13 @@ alone:
 
 - `allowed/no_gate` is valid only with `disposition: no_gate`, null gate-run and
   artifact provenance, and current `reviewed_head` and implementation
-  fingerprint fields.
+  fingerprint fields. Qualified state also requires `implementation_base_ref`,
+  `freshness_head`, and `freshness_fingerprint`.
 - `allowed/configured` is valid only with `disposition: passed`, `warned`, or
   `prompt_approved`; matching `config_fingerprint`, `reviewed_head`,
-  `implementation_fingerprint`, and configured gate-run provenance; and any
-  eligible receive durably completed.
+  `implementation_fingerprint`, configured gate-run provenance, and any eligible
+  receive durably completed. Qualified state also requires the complete rolling
+  freshness fields.
 - `pending`, `blocked`, malformed, contradictory, or legacy-absent state never
   falls through. Pending and blocked generations resume their persisted
   configuration; configuration-fingerprint mismatch fails closed.
@@ -294,10 +300,24 @@ alone:
   paths and substantive changes route as stale. The recognized set is limited
   to configured gate artifacts and receipts, project tracking and
   `project-log.md` appends, summary/documentation/PR sequence outputs, final
-  HiLL bookkeeping, and completion bookkeeping.
-- Any implementation, test, skill, template, workflow configuration, or other
-  unrecognized change after `reviewed_head` invalidates the implementation
-  fingerprint and routes to `oat-project-implement`.
+  HiLL bookkeeping, and completion bookkeeping. A category match without its
+  persisted transition boundary is unknown, not closeout-only.
+- For qualified state, require `implementation_base_ref`, `freshness_head`, and
+  a valid `freshness_fingerprint`. Exactly one merge base and 64-character
+  lowercase hexadecimal implementation/freshness digests are mandatory.
+  Missing or malformed inputs route as stale. When HEAD differs from
+  `freshness_head`, use the full raw Git byte algorithm from
+  `oat-project-implement` with only its literal state-carrier exclusion. Verify
+  and ignore state-only checkpoint commits before classification. An unchanged
+  qualified fingerprint preserves freshness across a merge, rebase, or base
+  update but routes to `oat-project-implement` to persist the advanced rolling
+  checkpoint; a mismatch routes as stale. This read-only router never advances
+  state or invents another fingerprint algorithm.
+- Legacy unqualified fingerprints retain the closeout-only descendant-path
+  check. Any implementation, test, skill, template, workflow configuration, or
+  other unrecognized change after `reviewed_head` invalidates the implementation
+  fingerprint and routes to `oat-project-implement`. Do not reinterpret or
+  migrate legacy state while routing.
 
 Routing is read-only: announce stale or malformed state, but leave transition
 repair, gate execution, receive, and persistence to `oat-project-implement`.

--- a/.oat/repo/pjm/backlog/archived/BL-260719-avoid-final-gate-reruns.md
+++ b/.oat/repo/pjm/backlog/archived/BL-260719-avoid-final-gate-reruns.md
@@ -1,7 +1,7 @@
 ---
 id: BL-260719-avoid-final-gate-reruns
 title: Avoid final-gate reruns for merge-only updates
-status: open
+status: closed
 priority: high
 scope: task
 scope_estimate: S
@@ -12,7 +12,7 @@ labels:
   - performance
 assignee: null
 created: 2026-07-19T13:42:05.069Z
-updated: 2026-07-19T13:42:05.069Z
+updated: '2026-07-19T16:34:24Z'
 associated_issues: []
 external_plans: []
 ---

--- a/.oat/repo/pjm/backlog/completed.md
+++ b/.oat/repo/pjm/backlog/completed.md
@@ -8,6 +8,7 @@
 
 ## Completed Items
 
+- 2026-07-19 — BL-260719-avoid-final-gate-reruns — Avoid final-gate reruns for merge-only updates — Added versioned rolling effective-delta fingerprints so unchanged base integration preserves a passed implementation gate while changed deltas fail closed.
 - 2026-07-18 — BL-260708-enable-oat-reviewer-subagent — Enable oat-reviewer subagent orchestration for faster broad reviews — Enabled bounded reviewer-local reconnaissance for faster broad reviews while preserving primary-reviewer judgment and evidence validation.
 - 2026-07-18 — BL-260718-add-tracked-config-guard — Add tracked-config guard against managed-file reverts — root-caused to stale locally-resolved CLI in consuming repo; dependency hygiene there is the cure; CLI-level guard unnecessary
 - 2026-07-13 — BL-260712-trim-dispatch-and-dry-run — Trim dispatch-and-dry-run implementation reference — Trimmed dispatch-and-dry-run.md from 715 to 562 lines: deduplicated engine/adapter-owned semantics into pointers, compressed the Dispatch Report V1 tutorial content and worked examples to their normative core, and consolidated the Codex target-first invariant. All 41 test-asserted strings and every contract regex preserved; 103 contract tests, 123 smoke tests, and release validation pass. Landed at 562 lines rather than the ~450 target because the remaining content is test-asserted normative contract; further cuts would require relaxing contract tests.

--- a/.oat/repo/pjm/backlog/index.md
+++ b/.oat/repo/pjm/backlog/index.md
@@ -71,7 +71,6 @@
 | BL-260711-add-activity-aware-gate        | Add activity-aware gate timeouts                                       | open   | high     | feature | M        |
 | BL-260718-add-oat-wave-lifecycle-cli     | Add oat wave lifecycle CLI command family                              | open   | high     | feature | L        |
 | BL-260711-add-root-owned-dispatch-broker | Add root-owned dispatch broker for exact OAT subagent launches         | open   | high     | feature | M        |
-| BL-260719-avoid-final-gate-reruns        | Avoid final-gate reruns for merge-only updates                         | open   | high     | task    | S        |
 | BL-260718-harden-full-surface-gate       | Harden full-surface gate reviews against budget and recursive dispatch | open   | high     | feature | M        |
 | BL-260718-mandatory-skill-load-clause    | Mandatory skill-load clause for lifecycle steps that name skills       | open   | high     | task    | S        |
 | BL-260712-serialize-cli-asset-bundling   | Serialize CLI asset bundling with atomic staging                       | open   | high     | task    | S        |

--- a/.oat/sync/manifest.json
+++ b/.oat/sync/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "oatVersion": "0.2.4",
+  "oatVersion": "0.2.5",
   "entries": [
     {
       "canonicalPath": ".agents/agents/oat-codebase-mapper.md",

--- a/.oat/templates/state.md
+++ b/.oat/templates/state.md
@@ -40,7 +40,10 @@ oat_workflow_origin: native # native | imported
 #   max_attempts: 2
 #   attempts_completed: 0
 #   reviewed_head: null
-#   implementation_fingerprint: null
+#   implementation_base_ref: null # exact logical base ref for effective-delta-v1
+#   implementation_fingerprint: null # new generations use sha256:effective-delta-v1:<digest>
+#   freshness_head: null # rolling accepted tree checkpoint
+#   freshness_fingerprint: null # full effective delta at freshness_head
 #   launch_state: not_started # not_started | intent_persisted | accepted | result_persisted | not_accepted
 #   launch_attempt_id: null
 #   launch_started_at: null

--- a/apps/oat-docs/docs/workflows/projects/implementation-execution.md
+++ b/apps/oat-docs/docs/workflows/projects/implementation-execution.md
@@ -117,14 +117,39 @@ event, and bookkeeping commit before marking receive complete. Missing,
 contradictory, or ambiguous correlation fails closed. A valid accepted run or
 completed receive is never duplicated.
 
-Freshness is bound to the reviewed HEAD and an implementation fingerprint.
+Freshness is bound to the reviewed HEAD and a versioned implementation
+fingerprint. New generations use an `effective-delta-v1` fingerprint over
+Git's canonical NUL-delimited raw tree delta. The generation persists the
+logical PR/default-branch base ref, requires one merge base, and hashes full
+base and final modes and object IDs with rename detection disabled. This makes
+same-file base changes visible while excluding commit history and human diff
+context. Every effective-delta path is included except the exact project
+`state.md` file that carries the digest and would otherwise be self-referential;
+that structured state is validated independently.
+
 Recognized closeout-only descendants preserve a valid result: gate artifacts
 and receipts, project tracking and project-log appends,
 summary/documentation/PR sequence outputs, final HiLL bookkeeping, and
-completion bookkeeping. An implementation, test, skill, template, workflow
-configuration, or unknown path change is substantive. It makes the gate result
-stale, requires a current final lifecycle review for the new basis, and starts
-a new gate generation.
+completion bookkeeping. Recognition also requires the corresponding persisted
+gate or sequence transition; a matching path category alone is insufficient.
+After each authorized closeout boundary, the workflow advances a rolling
+checkpoint to the complete effective delta at that HEAD. The checkpoint records
+the last non-checkpoint commit; a following persistence commit is ignored only
+when its diff changes that exact state carrier and nothing else.
+
+A merge, rebase, or base update preserves the result only when its full
+effective delta matches that rolling checkpoint. Conflict resolution or
+branch-owned implementation, test, skill, template, or workflow changes that
+alter the delta make the result stale, require a current final lifecycle review,
+and start a new gate generation. No implementation or closeout output path is
+excluded from the comparison. Legacy unqualified fingerprints retain the older
+fail-closed descendant-path behavior and are not migrated in place.
+
+This narrow merge-only exemption relies on fresh repository CI, automated
+review such as Bugbot, and lifecycle self-review to cover integration risk.
+Those checks do not substitute for the semantic gate on the full
+implementation; they avoid repeating that expensive review when the
+implementation outcome itself did not change.
 
 Only an allowed and fresh gate disposition can enter the pre-approval sequence,
 cross final HiLL, run the post-approval sequence, mark implementation complete,

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.2.4",
-  "docs-config": "0.2.4",
-  "docs-theme": "0.2.4",
-  "docs-transforms": "0.2.4"
+  "cli": "0.2.5",
+  "docs-config": "0.2.5",
+  "docs-theme": "0.2.5",
+  "docs-transforms": "0.2.5"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/init/tools/shared/post-implement-sequence-contracts.test.ts
+++ b/packages/cli/src/commands/init/tools/shared/post-implement-sequence-contracts.test.ts
@@ -1,4 +1,13 @@
-import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -42,6 +51,54 @@ function readStateTemplate(): string {
 
 function normalizeWhitespace(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, LC_ALL: 'C' },
+  }).trim();
+}
+
+function effectiveDeltaFingerprint(
+  cwd: string,
+  baseRef: string,
+  head: string,
+  stateCarrier = '.oat/project/state.md',
+): string {
+  const mergeBases = git(cwd, 'merge-base', '--all', baseRef, head)
+    .split('\n')
+    .filter(Boolean);
+  if (mergeBases.length !== 1) {
+    throw new Error(`expected one merge base, got ${mergeBases.length}`);
+  }
+
+  const raw = execFileSync(
+    'git',
+    [
+      'diff',
+      '--raw',
+      '-z',
+      '--no-renames',
+      '--no-abbrev',
+      mergeBases[0],
+      head,
+      '--',
+      '.',
+      `:(exclude,literal)${stateCarrier}`,
+    ],
+    {
+      cwd,
+      encoding: 'buffer',
+      env: { ...process.env, LC_ALL: 'C' },
+    },
+  );
+
+  return createHash('sha256')
+    .update(Buffer.from('effective-delta-v1\0'))
+    .update(raw)
+    .digest('hex');
 }
 
 function expectMarkersInOrder(
@@ -176,7 +233,10 @@ describe('post-implementation sequence contracts', () => {
       'max_attempts',
       'attempts_completed',
       'reviewed_head',
+      'implementation_base_ref',
       'implementation_fingerprint',
+      'freshness_head',
+      'freshness_fingerprint',
       'launch_state',
       'launch_attempt_id',
       'launch_started_at',
@@ -242,7 +302,10 @@ describe('post-implementation sequence contracts', () => {
       'max_attempts',
       'attempts_completed',
       'reviewed_head',
+      'implementation_base_ref',
       'implementation_fingerprint',
+      'freshness_head',
+      'freshness_fingerprint',
       'launch_state',
       'launch_attempt_id',
       'launch_started_at',
@@ -433,6 +496,135 @@ describe('post-implementation sequence contracts', () => {
     expect(normalizedNext).toContain(
       'Pending and blocked generations resume their persisted configuration; configuration-fingerprint mismatch fails closed.',
     );
+  });
+
+  it('preserves a fresh gate across unchanged effective-delta base updates', () => {
+    const skill = normalizeWhitespace(readImplementSkill());
+    const next = normalizeWhitespace(readNextSkill());
+
+    expect(skill).toContain(
+      'New generations persist `implementation_fingerprint` as `sha256:effective-delta-v1:<digest>`.',
+    );
+    expect(skill).toContain(
+      'Persist the logical base ref as `implementation_base_ref`; require exactly one merge base between that ref and each compared HEAD.',
+    );
+    expect(skill).toContain(
+      'Hash the exact NUL-delimited byte stream from Git `--raw -z --no-renames --no-abbrev` output, which includes both base and final modes and full object IDs for blobs, symlinks, deletions, and gitlinks.',
+    );
+    expect(skill).toContain(
+      'Set `freshness_head` to `reviewed_head` and `freshness_fingerprint` to `implementation_fingerprint` when the generation starts.',
+    );
+    expect(skill).toContain(
+      'Exclude only the exact `$PROJECT_PATH/state.md` checkpoint carrier to avoid a self-referential digest.',
+    );
+    expect(skill).toContain(
+      'After a corroborated closeout-only transition, hash the complete current effective delta and persist the rolling freshness checkpoint.',
+    );
+    expect(skill).toContain(
+      'A merge, rebase, or base update is not substantive by itself.',
+    );
+    expect(skill).toContain(
+      'When it matches the rolling fingerprint, preserve the allowed generation and persist an advanced rolling checkpoint without rerunning gate or receive.',
+    );
+    expect(skill).toContain(
+      'Conflict resolution or branch-owned implementation, test, skill, template, or workflow changes that alter the effective delta are substantive.',
+    );
+    expect(skill).toContain(
+      'Legacy unqualified `sha256:<digest>` values keep the descendant-path policy and are never reinterpreted or migrated in place.',
+    );
+    expect(next).toContain(
+      'For qualified state, require `implementation_base_ref`, `freshness_head`, and a valid `freshness_fingerprint`.',
+    );
+    expect(next).toContain(
+      'An unchanged qualified fingerprint preserves freshness across a merge, rebase, or base update but routes to `oat-project-implement` to persist the advanced rolling checkpoint; a mismatch routes as stale.',
+    );
+    expect(next).toContain(
+      'Legacy unqualified fingerprints retain the closeout-only descendant-path check.',
+    );
+  });
+
+  it('fingerprints effective tree deltas instead of merge history', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'oat-effective-delta-'));
+
+    try {
+      git(cwd, 'init', '-b', 'main');
+      git(cwd, 'config', 'user.name', 'OAT Test');
+      git(cwd, 'config', 'user.email', 'oat-test@example.com');
+      writeFileSync(join(cwd, 'app.txt'), 'base\n');
+      writeFileSync(join(cwd, 'unrelated.txt'), 'one\n');
+      git(cwd, 'add', '.');
+      git(cwd, 'commit', '-m', 'base');
+
+      git(cwd, 'checkout', '-b', 'feature');
+      writeFileSync(join(cwd, 'app.txt'), 'feature\n');
+      git(cwd, 'add', 'app.txt');
+      git(cwd, 'commit', '-m', 'feature');
+      const reviewedHead = git(cwd, 'rev-parse', 'HEAD');
+      const reviewedFingerprint = effectiveDeltaFingerprint(
+        cwd,
+        'main',
+        reviewedHead,
+      );
+
+      mkdirSync(join(cwd, '.oat/project'), { recursive: true });
+      writeFileSync(join(cwd, '.oat/project/state.md'), 'closeout\n');
+      writeFileSync(join(cwd, '.oat/project/summary.md'), 'summary\n');
+      git(cwd, 'add', '.oat/project');
+      git(cwd, 'commit', '-m', 'closeout bookkeeping');
+      const closeoutFingerprint = effectiveDeltaFingerprint(
+        cwd,
+        'main',
+        'HEAD',
+      );
+      expect(closeoutFingerprint).not.toBe(reviewedFingerprint);
+
+      writeFileSync(join(cwd, '.oat/project/state.md'), 'checkpoint\n');
+      git(cwd, 'add', '.oat/project/state.md');
+      git(cwd, 'commit', '-m', 'persist freshness checkpoint');
+      expect(effectiveDeltaFingerprint(cwd, 'main', 'HEAD')).toBe(
+        closeoutFingerprint,
+      );
+
+      git(cwd, 'checkout', 'main');
+      writeFileSync(join(cwd, 'unrelated.txt'), 'two\n');
+      git(cwd, 'add', 'unrelated.txt');
+      git(cwd, 'commit', '-m', 'base-only update');
+      git(cwd, 'checkout', 'feature');
+      git(cwd, 'merge', 'main', '--no-edit');
+      expect(effectiveDeltaFingerprint(cwd, 'main', 'HEAD')).toBe(
+        closeoutFingerprint,
+      );
+
+      writeFileSync(join(cwd, 'app.txt'), 'feature-v2\n');
+      git(cwd, 'add', 'app.txt');
+      git(cwd, 'commit', '-m', 'change implementation');
+      expect(effectiveDeltaFingerprint(cwd, 'main', 'HEAD')).not.toBe(
+        closeoutFingerprint,
+      );
+
+      writeFileSync(join(cwd, 'app.txt'), 'feature\n');
+      git(cwd, 'add', 'app.txt');
+      git(cwd, 'commit', '-m', 'restore reviewed implementation');
+      expect(effectiveDeltaFingerprint(cwd, 'main', 'HEAD')).toBe(
+        closeoutFingerprint,
+      );
+
+      git(cwd, 'checkout', 'main');
+      writeFileSync(join(cwd, 'app.txt'), 'changed-base\n');
+      git(cwd, 'add', 'app.txt');
+      git(cwd, 'commit', '-m', 'change implementation base');
+      git(cwd, 'checkout', 'feature');
+      expect(() => git(cwd, 'merge', 'main', '--no-edit')).toThrow();
+      writeFileSync(join(cwd, 'app.txt'), 'feature\n');
+      git(cwd, 'add', 'app.txt');
+      git(cwd, 'commit', '-m', 'resolve with reviewed implementation');
+      expect(readFileSync(join(cwd, 'app.txt'), 'utf8')).toBe('feature\n');
+      expect(effectiveDeltaFingerprint(cwd, 'main', 'HEAD')).not.toBe(
+        closeoutFingerprint,
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it('uses one immutable snapshot and its stored order across every closeout boundary', () => {

--- a/packages/cli/src/validation/skills.test.ts
+++ b/packages/cli/src/validation/skills.test.ts
@@ -1281,7 +1281,7 @@ describe('validateOatSkills', () => {
       },
       {
         skillName: 'oat-project-implement',
-        version: '2.1.5',
+        version: '2.1.6',
         finalizedHeading: '### Step 13: Trigger Final Review',
         gateHeading: '### Step 14: Gate Execution',
         completionHeading: '### Step 16: Mark Implementation Complete',
@@ -1634,7 +1634,7 @@ describe('validateOatSkills', () => {
       '.agents/skills/oat-project-implement/SKILL.md',
     );
 
-    expect(content.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('2.1.5');
+    expect(content.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('2.1.6');
   });
 
   it('routes implementation phases through bounded progressive disclosure', async () => {
@@ -1851,7 +1851,7 @@ describe('validateOatSkills', () => {
       '.agents/skills/oat-project-implement/SKILL.md',
     );
 
-    expect(content.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('2.1.5');
+    expect(content.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('2.1.6');
     expect(content).toMatch(
       /accepted native reviewer[\s\S]{0,260}(?:poll|nudge|continue)[\s\S]{0,180}existing handle/i,
     );
@@ -2280,7 +2280,7 @@ describe('validateOatSkills', () => {
       /implements one plan phase end-to-end/i,
     );
     expect(agent.match(/^tools:\s*(.+)$/m)?.[1]).toContain('Task');
-    expect(implement.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('2.1.5');
+    expect(implement.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('2.1.6');
     expect(agent).toMatch(
       /directly execute(?:s)? every task in dependency order/i,
     );
@@ -2528,11 +2528,11 @@ describe('validateOatSkills', () => {
       ['oat-project-review-provide', '1.3.22'],
       ['oat-project-review-receive', '1.5.9'],
       ['oat-project-review-receive-remote', '1.4.2'],
-      ['oat-project-implement', '2.1.5'],
+      ['oat-project-implement', '2.1.6'],
       ['oat-project-pr-final', '1.5.3'],
       ['oat-project-pr-progress', '1.2.3'],
       ['oat-project-complete', '1.5.3'],
-      ['oat-project-next', '1.0.10'],
+      ['oat-project-next', '1.0.11'],
     ] as const;
 
     for (const [skillName, expectedVersion] of expectedVersions) {
@@ -3420,7 +3420,7 @@ describe('validateOatSkills', () => {
     expect(planTier3Row(quickTable)).toContain('`oat-project-quick-start`');
     expect(planTier3Row(specTable)).toContain('`oat-project-plan`');
     expect(planTier3Row(importTable)).toContain('`oat-project-import-plan`');
-    expect(next.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('1.0.10');
+    expect(next.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('1.0.11');
   });
 
   it('supports project completion before or after PR merge in every mode', async () => {
@@ -3617,7 +3617,7 @@ describe('validateOatSkills', () => {
 
   it('tracks Dispatch Report V1 workflow contract versions and provenance boundaries', async () => {
     const expectedVersions = [
-      ['oat-project-implement', '2.1.5'],
+      ['oat-project-implement', '2.1.6'],
       ['oat-project-review-provide', '1.3.22'],
       ['oat-project-review-provide-remote', '1.0.4'],
     ] as const;

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- add versioned effective-delta fingerprints with deterministic Git raw-byte hashing
- advance rolling freshness checkpoints across corroborated closeout work and preserve passed gates when merge/rebase outcomes are unchanged
- fail closed for changed conflict resolution, malformed state, ambiguous bases, and legacy state; keep the broader freshness-policy evaluation open
- close BL-260719-avoid-final-gate-reruns and bump public packages to 0.2.5

## Verification
- `pnpm oat:validate-skills`
- `pnpm run cli:source -- internal validate-skill-version-bumps --base-ref origin/main`
- `pnpm format`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`
- `pnpm build`
- `pnpm build:docs`
- `pnpm release:validate`
- independent policy review: PASS