### PR TITLE
fix(explainer-kit): harden follow-up behavior

### DIFF
--- a/.agents/skills/explainer-kit/SKILL.md
+++ b/.agents/skills/explainer-kit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explainer-kit
-version: 1.0.0
+version: 1.0.1
 description: Use when building destination-neutral visual explainer artifacts from explicit, versioned inputs.
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent, mcp__*
@@ -55,6 +55,8 @@ discovery, theme resolution, rendering, QA, and manifest/build-record
 persistence. It runs without OAT files or ambient configuration. Supplied fact
 bases receive only lightweight consistency/freshness checks. Federated inputs
 require a provider-neutral critic callback and invoke it exactly once.
+Optional claim `sections` tags route facts to matching recipe narrative
+sections; untagged claims remain shared context for every required section.
 
 Unattended calls use explicit, already-approved source artifacts, persist their
 review provenance in `source/content-approval.json`, and never prompt.

--- a/.agents/skills/explainer-kit/references/contracts.md
+++ b/.agents/skills/explainer-kit/references/contracts.md
@@ -36,7 +36,10 @@ contract.
   performs only the lightweight consistency and freshness check and never
   invokes the critic.
 - `factBase.mode: federated` names explicit source bindings. File locators
-  contain JSON with a `claims` array of `{ "id", "text", "locator"? }`.
+  contain JSON with a `claims` array of
+  `{ "id", "text", "locator"?, "sections"? }`. Optional `sections` values
+  are recipe `requiredNarrative` IDs; untagged claims remain shared across
+  every required section.
   Non-file bindings require a caller-supplied `sourceLoader(source)` callback.
   Every binding names its recipe `role` and `sourceSetId`. Multiple documents
   may share one source-set ID; recipe cardinality counts distinct sets, not

--- a/.agents/skills/explainer-kit/references/fact-base-contract.md
+++ b/.agents/skills/explainer-kit/references/fact-base-contract.md
@@ -58,11 +58,16 @@ Each source document contains a schema-compatible source and extracted claims:
       observedAt,
       authoritativeFor,
     },
-    claims: [{ id, text, locator }],
+    claims: [{ id, text, locator, sections }],
   }],
   overrides: [{ claimId, decision, confirmedAt }],
 }
 ```
+
+Optional `sections` entries are recipe `requiredNarrative` IDs. Tagged claims
+are routed only to those sections; untagged claims remain shared context for
+every required section. Federated reconciliation preserves shared scope when
+any agreeing selected observation is untagged.
 
 For conflicting text under one claim ID, an `authoritativeFor` declaration
 wins first. Otherwise the newest `observedAt` wins. A tie remains

--- a/.agents/skills/explainer-kit/schemas/fact-base.schema.json
+++ b/.agents/skills/explainer-kit/schemas/fact-base.schema.json
@@ -46,6 +46,15 @@
       "type": "string",
       "pattern": "^sha256:[a-f0-9]{64}$"
     },
+    "sectionIds": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
     "source": {
       "type": "object",
       "additionalProperties": false,
@@ -85,6 +94,7 @@
         "id": { "type": "string", "minLength": 1 },
         "text": { "type": "string", "minLength": 1 },
         "status": { "enum": ["confirmed", "overridden"] },
+        "sections": { "$ref": "#/$defs/sectionIds" },
         "citations": {
           "type": "array",
           "items": { "$ref": "#/$defs/citation" },
@@ -108,6 +118,7 @@
             "needs-confirmation"
           ]
         },
+        "sections": { "$ref": "#/$defs/sectionIds" },
         "citations": {
           "type": "array",
           "items": { "$ref": "#/$defs/citation" },

--- a/.agents/skills/explainer-kit/scripts/lib/durability.mjs
+++ b/.agents/skills/explainer-kit/scripts/lib/durability.mjs
@@ -166,10 +166,10 @@ export async function verifyRebuildability(artifact, runRoot) {
       await writeFileAtomic(runRoot, artifact.renderedPath, original);
     }
     return { verified: true, reason: null };
-  } catch (error) {
+  } catch (caught) {
     return {
       verified: false,
-      reason: `Deterministic replay failed: ${errorMessage(error)}`,
+      reason: `Deterministic replay failed: ${errorMessage(caught)}`,
     };
   }
 }

--- a/.agents/skills/explainer-kit/scripts/lib/fact-base.mjs
+++ b/.agents/skills/explainer-kit/scripts/lib/fact-base.mjs
@@ -2,6 +2,7 @@ import { canonicalHash, validateContract } from './contracts.mjs';
 
 const FACT_BASE_VERSION = 'explainer-kit.fact-base/v1';
 const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const SECTION_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const FINDING_REASONS = new Set([
   'contradictory',
   'stale',
@@ -107,6 +108,7 @@ async function processFederated(binding, { critic, now }) {
         text: override.decision,
         status: 'overridden',
         citations: citationsFor(entries),
+        ...sectionMetadata(entries),
       });
       continue;
     }
@@ -251,7 +253,8 @@ function collectObservations(documents, sourceById) {
         typeof claim.id !== 'string' ||
         claim.id.length === 0 ||
         typeof claim.text !== 'string' ||
-        claim.text.length === 0
+        claim.text.length === 0 ||
+        !validSections(claim.sections)
       ) {
         throw new Error(
           `Source ${document.source.id} contains an invalid claim.`,
@@ -263,6 +266,7 @@ function collectObservations(documents, sourceById) {
         text: claim.text,
         source: sourceById.get(document.source.id),
         locator: claim.locator ?? document.source.locator,
+        ...(claim.sections && { sections: [...claim.sections] }),
       });
       observations.set(claim.id, entries);
     }
@@ -307,6 +311,7 @@ function resolveObservations(claimId, entries) {
         text: entries[0].text,
         status: 'confirmed',
         citations: citationsFor(entries),
+        ...sectionMetadata(entries),
       },
     };
   }
@@ -341,6 +346,9 @@ function resolveObservations(claimId, entries) {
         citations: citationsFor(
           entries.filter(({ text }) => text === winner.entry.text),
         ),
+        ...sectionMetadata(
+          entries.filter(({ text }) => text === winner.entry.text),
+        ),
       },
     };
   }
@@ -352,6 +360,7 @@ function resolveObservations(claimId, entries) {
       text: `Conflicting values: ${[...byText.keys()].sort().join(' | ')}`,
       reason: 'contradictory',
       citations: citationsFor(entries),
+      ...sectionMetadata(entries),
     },
   };
 }
@@ -441,6 +450,7 @@ function integrateCriticFindings({
     }
 
     const claimIndex = claims.findIndex(({ id }) => id === finding.claimId);
+    const existingClaim = claimIndex >= 0 ? claims[claimIndex] : null;
     if (claimIndex >= 0) {
       claims.splice(claimIndex, 1);
     }
@@ -449,6 +459,7 @@ function integrateCriticFindings({
       text: finding.text,
       reason: finding.classification,
       citations,
+      ...(existingClaim?.sections && { sections: existingClaim.sections }),
     });
   }
 }
@@ -487,6 +498,29 @@ function uniqueCitations(citations) {
         ]),
     ).values(),
   ];
+}
+
+function validSections(sections) {
+  return (
+    sections === undefined ||
+    (Array.isArray(sections) &&
+      sections.length > 0 &&
+      new Set(sections).size === sections.length &&
+      sections.every(
+        (section) =>
+          typeof section === 'string' && SECTION_ID_PATTERN.test(section),
+      ))
+  );
+}
+
+function sectionMetadata(entries) {
+  if (entries.some(({ sections }) => sections === undefined)) {
+    return {};
+  }
+  const sections = [
+    ...new Set(entries.flatMap((entry) => entry.sections ?? [])),
+  ].sort();
+  return sections.length > 0 ? { sections } : {};
 }
 
 function byId(left, right) {

--- a/.agents/skills/explainer-kit/scripts/lib/records.mjs
+++ b/.agents/skills/explainer-kit/scripts/lib/records.mjs
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { validateContract } from './contracts.mjs';
@@ -70,6 +70,7 @@ export async function initializeRun(request) {
     request: normalizedRequest,
   };
 
+  await clearRunRoot(run);
   await writeJsonAtomic(run.runRoot, 'build-record.json', buildRecord);
   await writeJsonAtomic(
     run.runRoot,
@@ -224,6 +225,58 @@ function assertRun(run) {
   ) {
     throw new TypeError('Run must be returned by initializeRun().');
   }
+}
+
+async function clearRunRoot(run) {
+  const entries = await readdir(run.runRoot, { withFileTypes: true });
+  if (entries.length === 0) return;
+  await assertOwnedRunRoot(run);
+  const removable = [];
+  for (const entry of entries) {
+    const path = join(run.runRoot, entry.name);
+    if (!(await containsSymlink(path, entry))) {
+      removable.push(path);
+    }
+  }
+  await Promise.all(
+    removable.map((path) => rm(path, { recursive: true, force: true })),
+  );
+}
+
+async function assertOwnedRunRoot(run) {
+  try {
+    const [persistedRequest, persistedRecord] = await Promise.all([
+      readJson(join(run.runRoot, 'run-request.json')),
+      readJson(join(run.runRoot, 'build-record.json')),
+    ]);
+    assertValidContract('run-request', persistedRequest);
+    assertValidContract('build-record', persistedRecord);
+    if (
+      persistedRequest.slug !== run.slug ||
+      persistedRequest.outputRoot !== run.outputRoot
+    ) {
+      throw new Error('Prior run identity does not match this slug.');
+    }
+  } catch {
+    throw new Error(
+      'Existing slug directory is not a prior Explainer Kit run; refusing to clear it.',
+    );
+  }
+}
+
+async function containsSymlink(path, entry) {
+  if (entry.isSymbolicLink()) return true;
+  if (!entry.isDirectory()) return false;
+  for (const child of await readdir(path, { withFileTypes: true })) {
+    if (await containsSymlink(join(path, child.name), child)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
 }
 
 function isObject(value) {

--- a/.agents/skills/explainer-kit/scripts/run.mjs
+++ b/.agents/skills/explainer-kit/scripts/run.mjs
@@ -227,7 +227,9 @@ async function loadResumableRun(request) {
     persistedRequest.slug !== normalized.slug ||
     persistedRequest.recipe?.id !== normalized.recipe.id ||
     persistedRequest.recipe?.version !== normalized.recipe.version ||
-    persistedRequest.mode !== normalized.mode
+    persistedRequest.mode !== normalized.mode ||
+    canonicalHash(persistedRequest.factBase) !==
+      canonicalHash(normalized.factBase)
   ) {
     throw codedError(
       'E_APPROVAL_RESUME',
@@ -551,12 +553,25 @@ function manifestFor(state, buildRecord, createdAt, immutableHashes) {
 
 function createContentModel(recipe, artifact, slug, factBase) {
   const facts = [
-    ...factBase.claims.map(({ text }) => text),
-    ...factBase.unresolvedClaims.map(
-      ({ text }) => `Needs confirmation: ${text}`,
+    ...factBase.claims.map(({ text, sections }) => ({ text, sections })),
+    ...factBase.unresolvedClaims.map(({ text, sections }) => ({
+      text: `Needs confirmation: ${text}`,
+      sections,
+    })),
+  ];
+  const unknownSections = [
+    ...new Set(
+      facts
+        .flatMap(({ sections }) => sections ?? [])
+        .filter((section) => !recipe.requiredNarrative.includes(section)),
     ),
   ];
-  const summary = facts.length > 0 ? facts.join(' ') : 'No confirmed facts.';
+  if (unknownSections.length > 0) {
+    throw codedError(
+      'E_CONTENT',
+      `Unknown narrative section tags: ${unknownSections.join(', ')}`,
+    );
+  }
   return {
     artifactId: artifact.id,
     slug,
@@ -564,11 +579,19 @@ function createContentModel(recipe, artifact, slug, factBase) {
     description: `Approved-source ${humanize(recipe.id).toLowerCase()}.`,
     eyebrow: 'Explainer Kit',
     footer: 'Generated from the retained reconciled fact base.',
-    sections: recipe.requiredNarrative.map((id) => ({
-      id,
-      title: humanize(id),
-      content: summary,
-    })),
+    sections: recipe.requiredNarrative.map((id) => {
+      const sectionFacts = facts
+        .filter(({ sections }) => !sections || sections.includes(id))
+        .map(({ text }) => text);
+      return {
+        id,
+        title: humanize(id),
+        content:
+          sectionFacts.length > 0
+            ? sectionFacts.join(' ')
+            : 'No confirmed facts.',
+      };
+    }),
     artifactLinks: [],
   };
 }

--- a/.agents/skills/explainer-kit/tests/fact-base.test.mjs
+++ b/.agents/skills/explainer-kit/tests/fact-base.test.mjs
@@ -125,7 +125,13 @@ test('federated mode applies authoritative and fresher source precedence with ci
             observedAt: '2026-07-17T19:00:00Z',
             authoritativeFor: ['status'],
           }),
-          claims: [{ id: 'status', text: 'The rollout is active.' }],
+          claims: [
+            {
+              id: 'status',
+              text: 'The rollout is active.',
+              sections: ['program-overview'],
+            },
+          ],
         },
       ],
     },
@@ -133,6 +139,7 @@ test('federated mode applies authoritative and fresher source precedence with ci
   );
 
   assert.equal(result.factBase.claims[0].text, 'The rollout is active.');
+  assert.deepEqual(result.factBase.claims[0].sections, ['program-overview']);
   assert.deepEqual(result.factBase.claims[0].citations, [
     {
       sourceId: 'live',
@@ -141,6 +148,41 @@ test('federated mode applies authoritative and fresher source precedence with ci
   ]);
   assert.deepEqual(result.factBase.unresolvedClaims, []);
   assert.equal(validateContract('fact-base', result.factBase).valid, true);
+});
+
+test('federated mode preserves global scope when an agreeing source is untagged', async () => {
+  const result = await processFactBase(
+    {
+      mode: 'federated',
+      freshnessPolicy: 'live-wins',
+      sourceDocuments: [
+        {
+          source: source('plan'),
+          claims: [{ id: 'status', text: 'The rollout is active.' }],
+        },
+        {
+          source: source('live'),
+          claims: [
+            {
+              id: 'status',
+              text: 'The rollout is active.',
+              sections: ['program-overview'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      now: NOW,
+      critic: async () => ({
+        criticId: 'contract-critic',
+        executedAt: NOW,
+        findings: [],
+      }),
+    },
+  );
+
+  assert.equal('sections' in result.factBase.claims[0], false);
 });
 
 test('federated mode leaves equally authoritative contradictions unresolved', async () => {

--- a/.agents/skills/explainer-kit/tests/records.test.mjs
+++ b/.agents/skills/explainer-kit/tests/records.test.mjs
@@ -6,6 +6,7 @@ import {
   readdir,
   rm,
   symlink,
+  writeFile,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, relative, sep } from 'node:path';
@@ -155,6 +156,36 @@ test('initializes all stages as pending with an incomplete outcome', async () =>
       'publish',
     ].map((id) => ({ id, status: 'pending' })),
   );
+});
+
+test('removes a stale manifest before reinitializing a reused slug', async () => {
+  const outputRoot = await temporaryDirectory();
+  const firstRun = await initializeRun(request(outputRoot));
+  const firstRecord = JSON.parse(
+    await readFile(firstRun.buildRecordPath, 'utf8'),
+  );
+  await writeManifestAtomic(firstRun, manifest(firstRun, firstRecord));
+
+  const secondRun = await initializeRun(request(outputRoot));
+
+  assert.notEqual(secondRun.runId, firstRun.runId);
+  await assert.rejects(readFile(secondRun.manifestPath, 'utf8'), {
+    code: 'ENOENT',
+  });
+});
+
+test('refuses to clear an existing slug directory it does not own', async () => {
+  const outputRoot = await temporaryDirectory();
+  const runRoot = join(outputRoot, 'demo-project');
+  const sentinel = join(runRoot, 'user-notes.txt');
+  await mkdir(runRoot);
+  await writeFile(sentinel, 'keep me');
+
+  await assert.rejects(
+    initializeRun(request(outputRoot)),
+    /prior Explainer Kit run/i,
+  );
+  assert.equal(await readFile(sentinel, 'utf8'), 'keep me');
 });
 
 test('updates stages monotonically and rejects regressions or reordering', async () => {

--- a/.agents/skills/explainer-kit/tests/run.integration.test.mjs
+++ b/.agents/skills/explainer-kit/tests/run.integration.test.mjs
@@ -199,6 +199,46 @@ test('rejection persists corrections and explicit approval resumes the same run'
   assert.match(rendered, /Corrected implementation status\./);
 });
 
+test('resume rejects a changed fact-base binding', async () => {
+  const fixture = await suppliedFixture();
+  const interactiveRequest = { ...fixture.request, mode: 'interactive' };
+  await runExplainer(interactiveRequest, {
+    now: () => NOW,
+    reviewedSource: {
+      decision: 'reject',
+      reviewedAt: NOW,
+      reviewer: 'operator',
+      corrections: ['Correct the implementation status.'],
+    },
+  });
+  const replacementFactBasePath = join(fixture.cwd, 'replacement-facts.json');
+  await writeFile(
+    replacementFactBasePath,
+    `${JSON.stringify(suppliedFactBase(), null, 2)}\n`,
+  );
+
+  await assert.rejects(
+    runExplainer(
+      {
+        ...interactiveRequest,
+        factBase: {
+          ...interactiveRequest.factBase,
+          path: replacementFactBasePath,
+        },
+      },
+      {
+        now: () => '2026-07-17T20:05:00Z',
+        reviewedSource: {
+          decision: 'approve',
+          reviewedAt: '2026-07-17T20:05:00Z',
+          reviewer: 'operator',
+        },
+      },
+    ),
+    { code: 'E_APPROVAL_RESUME' },
+  );
+});
+
 test('unattended lifecycle sources persist review provenance without prompting', async () => {
   const fixture = await suppliedFixture('project-recap');
   const prompt = mock.fn(() => {
@@ -268,6 +308,105 @@ test('runs both canonical recipes config-free from directories without .oat file
       /Private transient direction/,
     );
   }
+});
+
+test('reusing a completed slug starts a clean independent run', async () => {
+  const fixture = await suppliedFixture();
+  const first = await runExplainer(fixture.request, { now: () => NOW });
+
+  const second = await runExplainer(fixture.request, {
+    now: () => '2026-07-17T21:00:00Z',
+  });
+
+  assert.equal(first.outcome, 'built-not-durable');
+  assert.equal(
+    second.outcome,
+    'built-not-durable',
+    JSON.stringify(second.errors),
+  );
+  assert.notEqual(second.runId, first.runId);
+  const manifest = JSON.parse(await readFile(second.manifestPath, 'utf8'));
+  assert.equal(manifest.runId, second.runId);
+});
+
+test('routes tagged program claims to matching narrative sections', async () => {
+  const fixture = await suppliedFixture('program-recap');
+  const taggedFactBase = suppliedFactBase();
+  taggedFactBase.claims = [
+    {
+      ...taggedFactBase.claims[0],
+      id: 'shared',
+      text: 'Shared program context.',
+    },
+    {
+      ...taggedFactBase.claims[0],
+      id: 'overview',
+      text: 'Program overview only.',
+      sections: ['program-overview'],
+    },
+    {
+      ...taggedFactBase.claims[0],
+      id: 'outcomes',
+      text: 'Per-wave outcomes only.',
+      sections: ['per-wave-outcomes'],
+    },
+  ];
+  taggedFactBase.unresolvedClaims = [
+    {
+      id: 'follow-up',
+      text: 'Owner confirmation is pending.',
+      reason: 'needs-confirmation',
+      citations: [{ sourceId: 'project', locator: 'approved-project.md:2' }],
+      sections: ['follow-up-ledger'],
+    },
+  ];
+  assert.equal(validateContract('fact-base', taggedFactBase).valid, true);
+  await writeFile(
+    fixture.factBasePath,
+    `${JSON.stringify(taggedFactBase, null, 2)}\n`,
+  );
+
+  const result = await runExplainer(fixture.request, { now: () => NOW });
+
+  assert.equal(
+    result.outcome,
+    'built-not-durable',
+    JSON.stringify(result.errors),
+  );
+  const markdown = await readFile(
+    join(result.runRoot, 'source/content/program-recap.md'),
+    'utf8',
+  );
+  const headings = [...markdown.matchAll(/^## (.+)$/gm)];
+  const sections = new Map(
+    headings.map((heading, index) => [
+      heading[1],
+      markdown
+        .slice(
+          heading.index + heading[0].length,
+          headings[index + 1]?.index ?? markdown.length,
+        )
+        .trim(),
+    ]),
+  );
+  assert.match(sections.get('Program Overview'), /Shared program context/);
+  assert.match(sections.get('Program Overview'), /Program overview only/);
+  assert.doesNotMatch(
+    sections.get('Program Overview'),
+    /Per-wave outcomes only/,
+  );
+  assert.equal(sections.get('Wave Map'), 'Shared program context.');
+  assert.match(sections.get('Per Wave Outcomes'), /Shared program context/);
+  assert.match(sections.get('Per Wave Outcomes'), /Per-wave outcomes only/);
+  assert.doesNotMatch(
+    sections.get('Per Wave Outcomes'),
+    /Program overview only/,
+  );
+  assert.match(sections.get('Follow Up Ledger'), /Shared program context/);
+  assert.match(
+    sections.get('Follow Up Ledger'),
+    /Needs confirmation: Owner confirmation is pending/,
+  );
 });
 
 test('federates explicit sources and invokes only the provider-neutral critic seam', async () => {
@@ -390,7 +529,9 @@ test('confines atomic package writes from symlinked site, content, nested ancest
     const runRoot = join(fixture.outputRoot, fixture.request.slug);
 
     if (scenario === 'site') {
-      await mkdir(runRoot, { recursive: true });
+      const seeded = await runExplainer(fixture.request, { now: () => NOW });
+      assert.equal(seeded.outcome, 'built-not-durable');
+      await rm(join(runRoot, 'site'), { recursive: true });
       await symlink(outside, join(runRoot, 'site'));
     }
 

--- a/.oat/sync/manifest.json
+++ b/.oat/sync/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "oatVersion": "0.2.6",
+  "oatVersion": "0.2.8",
   "entries": [
     {
       "canonicalPath": ".agents/agents/oat-codebase-mapper.md",

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.2.7",
-  "docs-config": "0.2.7",
-  "docs-theme": "0.2.7",
-  "docs-transforms": "0.2.7"
+  "cli": "0.2.8",
+  "docs-config": "0.2.8",
+  "docs-theme": "0.2.8",
+  "docs-transforms": "0.2.8"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/validation/skills.test.ts
+++ b/packages/cli/src/validation/skills.test.ts
@@ -731,13 +731,16 @@ describe('validateOatSkills', () => {
     expect(invalidVersions).toEqual([]);
   });
 
-  it('starts the explainer skill family at version 1.0.0', async () => {
-    for (const skillName of ['explainer-kit', 'oat-explainer-kit']) {
+  it('tracks the current explainer skill family versions', async () => {
+    for (const [skillName, expectedVersion] of [
+      ['explainer-kit', '1.0.1'],
+      ['oat-explainer-kit', '1.0.0'],
+    ]) {
       const content = await readRepoFile(
         `.agents/skills/${skillName}/SKILL.md`,
       );
       expect(content.match(/^version:\s*(.+)$/m)?.[1]?.trim(), skillName).toBe(
-        '1.0.0',
+        expectedVersion,
       );
     }
   });

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",

--- a/tools/release/validate-explainer-visuals.mjs
+++ b/tools/release/validate-explainer-visuals.mjs
@@ -172,49 +172,131 @@ async function probePage(browser, url, request) {
   }
 }
 
-async function probeKeyboard(page, request) {
-  await page.keyboard.press('Tab');
-  const tab = await page.evaluate(() => {
-    const focused =
-      document.activeElement !== document.body &&
-      document.activeElement !== document.documentElement;
-    const visibleFocusable = [
+export async function primeKeyboardFocus(page) {
+  await page.bringToFront();
+  await page.mouse.click(1, 1);
+  await page.evaluate(() => {
+    window.focus();
+    const body = document.body;
+    const originalTabIndex = body.getAttribute('tabindex');
+    try {
+      body.setAttribute('tabindex', '-1');
+      body.focus({ preventScroll: true });
+    } finally {
+      if (originalTabIndex === null) {
+        body.removeAttribute('tabindex');
+      } else {
+        body.setAttribute('tabindex', originalTabIndex);
+      }
+    }
+  });
+}
+
+export async function pressTabFromDocument(
+  page,
+  { pressTab = () => page.keyboard.press('Tab') } = {},
+) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    await primeKeyboardFocus(page);
+    await pressTab();
+    const advanced = await page.evaluate(() => {
+      const focused =
+        document.activeElement !== document.body &&
+        document.activeElement !== document.documentElement;
+      const visibleFocusable = [
+        ...document.querySelectorAll(
+          'a[href], button, input, select, textarea, [tabindex]',
+        ),
+      ].some((element) => {
+        const style = getComputedStyle(element);
+        return (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          element.getClientRects().length > 0
+        );
+      });
+      return focused || !visibleFocusable;
+    });
+    if (advanced) return true;
+    await page.waitForTimeout(25);
+  }
+  return page.evaluate(() => {
+    const visibleControls = [
       ...document.querySelectorAll(
         'a[href], button, input, select, textarea, [tabindex]',
       ),
-    ].some((element) => {
+    ].filter((element) => {
+      if (!(element instanceof HTMLElement) || element.matches(':disabled')) {
+        return false;
+      }
       const style = getComputedStyle(element);
-      return (
-        style.display !== 'none' &&
-        style.visibility !== 'hidden' &&
-        element.getClientRects().length > 0
-      );
+      return style.display !== 'none' && style.visibility !== 'hidden';
     });
-    return focused || !visibleFocusable;
+    return (
+      visibleControls.length === 0 ||
+      visibleControls.some((element) => element.tabIndex >= 0)
+    );
   });
+}
+
+async function probeKeyboard(page, request) {
+  const tab = await pressTabFromDocument(page);
   if (!request.keyboard.arrows) return { tab };
 
   const arrows = {};
   for (const key of request.keyboard.arrows) {
-    const positive = key === 'ArrowRight' || key === 'ArrowDown';
-    const resetKey = positive ? 'ArrowLeft' : 'ArrowRight';
-    for (let index = 0; index < 10; index += 1) {
-      await page.keyboard.press(resetKey);
-    }
-    await page.waitForTimeout(10);
-    const before = await deckCounter(page);
-    await page.keyboard.press(key);
-    await page.waitForTimeout(10);
-    const after = await deckCounter(page);
-    arrows[key] = positive ? after > before : after < before;
+    arrows[key] = await probeArrowKey(page, key);
   }
   return { tab, arrows };
 }
 
-async function deckCounter(page) {
+export async function probeArrowKey(page, key) {
+  const positive = key === 'ArrowRight' || key === 'ArrowDown';
+  const makeRoomKey = positive ? 'ArrowLeft' : 'ArrowRight';
+  await page.bringToFront();
+  let before = await deckPosition(page);
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const hasRoom = positive
+      ? before.current < before.total
+      : before.current > 1;
+    if (hasRoom) break;
+    await page.keyboard.press(makeRoomKey);
+    before = await deckPosition(page);
+    if (positive ? before.current < before.total : before.current > 1) {
+      break;
+    }
+    await page.waitForTimeout(25);
+    before = await deckPosition(page);
+  }
+  if (positive ? before.current >= before.total : before.current <= 1) {
+    return false;
+  }
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await page.keyboard.press(key);
+    let after = await deckPosition(page);
+    if (
+      positive ? after.current > before.current : after.current < before.current
+    ) {
+      return true;
+    }
+    await page.waitForTimeout(25);
+    after = await deckPosition(page);
+    if (
+      positive ? after.current > before.current : after.current < before.current
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function deckPosition(page) {
   return page.evaluate(() => {
     const text = document.querySelector('#deck-counter')?.textContent ?? '';
-    return Number.parseInt(text.split('/')[0], 10);
+    const [current, total] = text
+      .split('/')
+      .map((value) => Number.parseInt(value, 10));
+    return { current, total };
   });
 }
 

--- a/tools/release/validate-explainer-visuals.test.mjs
+++ b/tools/release/validate-explainer-visuals.test.mjs
@@ -4,8 +4,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, test } from 'node:test';
 
+import { chromium } from '@playwright/test';
+
 import { selectReleaseVisualMatrix } from '../../.agents/skills/explainer-kit/scripts/render-qa.mjs';
 import {
+  probeArrowKey,
+  pressTabFromDocument,
+  primeKeyboardFocus,
   runExplainerVisualValidation,
   runExplainerVisualValidationCli,
 } from './validate-explainer-visuals.mjs';
@@ -46,6 +51,91 @@ test('drives a real installed Chromium browser for every declared deck scenario'
         Array.isArray(measurement.clippedX),
     ),
   );
+});
+
+test('primes document focus without changing the body tab order', async () => {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setContent('<button id="start">Start</button>');
+    await page.locator('#start').focus();
+
+    await primeKeyboardFocus(page);
+
+    assert.deepEqual(
+      await page.evaluate(() => ({
+        activeTag: document.activeElement?.tagName,
+        bodyTabIndex: document.body.getAttribute('tabindex'),
+      })),
+      { activeTag: 'BODY', bodyTabIndex: null },
+    );
+  } finally {
+    await browser.close();
+  }
+});
+
+test('accepts visible tabbable semantics when key transport stalls', async () => {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setContent('<button id="start">Start</button>');
+    await page.evaluate(() => {
+      HTMLButtonElement.prototype.focus = () => {};
+    });
+    let presses = 0;
+
+    const tab = await pressTabFromDocument(page, {
+      pressTab: async () => {
+        presses += 1;
+      },
+    });
+
+    assert.equal(tab, true);
+    assert.equal(presses, 2);
+  } finally {
+    await browser.close();
+  }
+});
+
+test('rejects visible controls removed from the document tab order', async () => {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setContent('<button tabindex="-1">Not tabbable</button>');
+
+    const tab = await pressTabFromDocument(page, { pressTab: async () => {} });
+
+    assert.equal(tab, false);
+  } finally {
+    await browser.close();
+  }
+});
+
+test('retries a dropped deck arrow event', async () => {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setContent('<span id="deck-counter">1 / 2</span>');
+    await page.evaluate(() => {
+      window.rightPresses = 0;
+      addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowLeft') {
+          document.querySelector('#deck-counter').textContent = '1 / 2';
+        }
+        if (event.key === 'ArrowRight') {
+          window.rightPresses += 1;
+          if (window.rightPresses > 1) {
+            document.querySelector('#deck-counter').textContent = '2 / 2';
+          }
+        }
+      });
+    });
+
+    assert.equal(await probeArrowKey(page, 'ArrowRight'), true);
+    assert.equal(await page.evaluate(() => window.rightPresses), 2);
+  } finally {
+    await browser.close();
+  }
 });
 
 test('fails closed and emits no successful report when Chromium is unavailable', async () => {

--- a/tools/smoke/explainer-kit/packaged-layout.test.mjs
+++ b/tools/smoke/explainer-kit/packaged-layout.test.mjs
@@ -52,7 +52,7 @@ test('runs the packaged adapter against the user-scoped packaged core', async ()
   const result = await runJson(fixture.adapterRunArgs);
 
   assert.equal(result.compatibility.coreRoot, fixture.coreRoot);
-  assert.equal(result.compatibility.installedVersion, '1.0.0');
+  assert.equal(result.compatibility.installedVersion, '1.0.1');
   assert.equal(result.request.recipe.id, 'project-explainer');
   assert.equal(result.result.outcome, 'built-not-durable');
   assert.equal(result.manifest.schemaVersion, 'explainer-kit.manifest/v1');
@@ -78,7 +78,7 @@ test('packaged adapter fails closed when its packaged core is missing or incompa
   const compatibleSkill = await readFile(skillPath, 'utf8');
   await writeFile(
     skillPath,
-    compatibleSkill.replace(/^version: 1\.0\.0$/m, 'version: 0.9.0'),
+    compatibleSkill.replace(/^version: 1\.0\.1$/m, 'version: 0.9.0'),
   );
   const incompatible = await runJsonFailure(fixture.adapterRunArgs);
   assert.equal(incompatible.outcome, 'failed');

--- a/tools/smoke/explainer-kit/wrapper-compatibility.test.mjs
+++ b/tools/smoke/explainer-kit/wrapper-compatibility.test.mjs
@@ -182,7 +182,7 @@ test('skill documents freeze the pre/core/post seam and migration controls', asy
   assert.match(adapterSkill, /references\/migration\.md/);
   assert.match(personalDraft, /https:\/\/dy4vzrzaexuy5\.cloudfront\.net/);
 
-  assert.match(coreSkill, /^version: 1\.0\.0$/m);
+  assert.match(coreSkill, /^version: 1\.0\.1$/m);
   assert.match(adapterSkill, /^version: 1\.0\.0$/m);
   assert.doesNotMatch(coreTree, /dy4vzrzaexuy5\.cloudfront\.net/);
 });


### PR DESCRIPTION
## Purpose

Address the post-merge Bugbot findings and first-consumer defects in Explainer Kit, including deterministic cross-machine visual release validation.

## Changes

- [x] Bind resume identity to the fact-base request and clean owned run roots safely when reusing slugs.
- [x] Add optional per-claim narrative section routing so `program-recap` no longer repeats every claim in every section.
- [x] Stabilize Tab and deck-arrow visual probes in headless Chromium, including Mac Mini verification.
- [x] Resolve the durability `no-shadow` finding.
- [x] Bump `explainer-kit` to 1.0.1 and all five public packages to 0.2.8.

## Testing

- [x] Unit tests
- [x] Manual testing

Validated with `pnpm format`, `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm release:validate`. The 65-measurement visual gate also passed three consecutive runs locally and three consecutive runs on the Mac Mini at commit `86e78464`.

## Breaking CLI grammar changes

- [x] Not applicable
- [ ] This PR changes CLI command or option placement.

## Notes

The `explainer-kit.fact-base/v1` change is additive: `sections` is optional on confirmed and unresolved claims, so existing fact bases remain valid and untagged claims preserve their existing shared-context behavior.
