### PR TITLE
fix(cli): detect package manager for CLI auto-updates

### DIFF
--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.2.9",
-  "docs-config": "0.2.9",
-  "docs-theme": "0.2.9",
-  "docs-transforms": "0.2.9"
+  "cli": "0.2.10",
+  "docs-config": "0.2.10",
+  "docs-theme": "0.2.10",
+  "docs-transforms": "0.2.10"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/app/global-cli-installer.test.ts
+++ b/packages/cli/src/app/global-cli-installer.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  detectGlobalCliPackageManager,
+  formatGlobalCliInstallCommand,
+  resolveGlobalCliInstallerInvocation,
+} from './global-cli-installer';
+
+describe('detectGlobalCliPackageManager', () => {
+  it.each([
+    [
+      'pnpm global store',
+      [
+        '/Users/me/Library/pnpm/oat',
+        '/Users/me/Library/pnpm/global/5/node_modules/@open-agent-toolkit/cli/dist/index.js',
+      ],
+      {},
+      'pnpm',
+    ],
+    [
+      'pnpm home wrapper',
+      ['/Users/me/Library/pnpm/bin/oat'],
+      { PNPM_HOME: '/Users/me/Library/pnpm' },
+      'pnpm',
+    ],
+    [
+      'bun global install',
+      [
+        '/Users/me/.bun/install/global/node_modules/@open-agent-toolkit/cli/dist/index.js',
+      ],
+      {},
+      'bun',
+    ],
+    [
+      'yarn global install',
+      [
+        '/Users/me/.config/yarn/global/node_modules/@open-agent-toolkit/cli/dist/index.js',
+      ],
+      {},
+      'yarn',
+    ],
+    [
+      'npm global install',
+      [
+        '/Users/me/.nvm/versions/node/v22.17.0/bin/node',
+        '/Users/me/.nvm/versions/node/v22.17.0/lib/node_modules/@open-agent-toolkit/cli/dist/index.js',
+      ],
+      {},
+      'npm',
+    ],
+  ] satisfies Array<[string, string[], NodeJS.ProcessEnv, string]>)(
+    'detects %s',
+    (_name, argv, env, expected) => {
+      expect(detectGlobalCliPackageManager(argv, env)).toBe(expected);
+    },
+  );
+});
+
+describe('formatGlobalCliInstallCommand', () => {
+  it('formats pnpm and npm commands from the running entrypoint', () => {
+    expect(
+      formatGlobalCliInstallCommand(
+        '@open-agent-toolkit/cli@1.2.3',
+        ['/Users/me/Library/pnpm/oat'],
+        {},
+      ),
+    ).toBe('pnpm add -g @open-agent-toolkit/cli@1.2.3');
+    expect(
+      formatGlobalCliInstallCommand(
+        '@open-agent-toolkit/cli@latest',
+        [
+          '/Users/me/.nvm/versions/node/v22.17.0/bin/node',
+          '/Users/me/.nvm/versions/node/v22.17.0/lib/node_modules/@open-agent-toolkit/cli/dist/index.js',
+        ],
+        {},
+      ),
+    ).toBe('npm install --global @open-agent-toolkit/cli@latest');
+  });
+});
+
+describe('resolveGlobalCliInstallerInvocation', () => {
+  it('uses pnpm on POSIX when the running CLI is pnpm-managed', () => {
+    expect(
+      resolveGlobalCliInstallerInvocation('@open-agent-toolkit/cli@1.2.3', {
+        argv: ['/Users/me/Library/pnpm/oat'],
+        env: {},
+        platform: 'linux',
+        nodeExecutable: '/usr/bin/node',
+        fileExists: () => false,
+      }),
+    ).toEqual({
+      file: 'pnpm',
+      args: ['add', '-g', '@open-agent-toolkit/cli@1.2.3'],
+    });
+  });
+
+  it('uses npm on POSIX when the running CLI is npm-managed', () => {
+    expect(
+      resolveGlobalCliInstallerInvocation('@open-agent-toolkit/cli@1.2.3', {
+        argv: ['/usr/bin/node', '/opt/oat/dist/index.js'],
+        env: {},
+        platform: 'linux',
+        nodeExecutable: '/usr/bin/node',
+        fileExists: () => false,
+      }),
+    ).toEqual({
+      file: 'npm',
+      args: ['install', '--global', '@open-agent-toolkit/cli@1.2.3'],
+    });
+  });
+
+  it('launches the npm JavaScript CLI through Node on Windows', () => {
+    const npmCliPath = 'C:\\npm\\node_modules\\npm\\bin\\npm-cli.js';
+    expect(
+      resolveGlobalCliInstallerInvocation('@open-agent-toolkit/cli@1.2.3', {
+        argv: ['/usr/bin/node', 'C:\\opt\\oat\\dist\\index.js'],
+        env: { npm_execpath: npmCliPath },
+        platform: 'win32',
+        nodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
+        fileExists: (path) => path === npmCliPath,
+      }),
+    ).toEqual({
+      file: 'C:\\Program Files\\nodejs\\node.exe',
+      args: [
+        npmCliPath,
+        'install',
+        '--global',
+        '@open-agent-toolkit/cli@1.2.3',
+      ],
+    });
+  });
+
+  it('uses pnpm.cmd on Windows when the running CLI is pnpm-managed', () => {
+    expect(
+      resolveGlobalCliInstallerInvocation('@open-agent-toolkit/cli@1.2.3', {
+        argv: ['C:\\Users\\me\\AppData\\Local\\pnpm\\oat.cmd'],
+        env: {},
+        platform: 'win32',
+        nodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
+        fileExists: () => false,
+      }),
+    ).toEqual({
+      file: 'pnpm.cmd',
+      args: ['add', '-g', '@open-agent-toolkit/cli@1.2.3'],
+    });
+  });
+});

--- a/packages/cli/src/app/global-cli-installer.test.ts
+++ b/packages/cli/src/app/global-cli-installer.test.ts
@@ -24,6 +24,12 @@ describe('detectGlobalCliPackageManager', () => {
       'pnpm',
     ],
     [
+      'pnpm home without sibling prefix collision',
+      ['/users/me/library/pnpm-custom/bin/oat'],
+      { PNPM_HOME: '/Users/me/Library/pnpm' },
+      'npm',
+    ],
+    [
       'bun global install',
       [
         '/Users/me/.bun/install/global/node_modules/@open-agent-toolkit/cli/dist/index.js',
@@ -130,18 +136,26 @@ describe('resolveGlobalCliInstallerInvocation', () => {
     });
   });
 
-  it('uses pnpm.cmd on Windows when the running CLI is pnpm-managed', () => {
+  it('launches pnpm through cmd.exe on Windows', () => {
     expect(
       resolveGlobalCliInstallerInvocation('@open-agent-toolkit/cli@1.2.3', {
         argv: ['C:\\Users\\me\\AppData\\Local\\pnpm\\oat.cmd'],
-        env: {},
+        env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
         platform: 'win32',
         nodeExecutable: 'C:\\Program Files\\nodejs\\node.exe',
         fileExists: () => false,
       }),
     ).toEqual({
-      file: 'pnpm.cmd',
-      args: ['add', '-g', '@open-agent-toolkit/cli@1.2.3'],
+      file: 'C:\\Windows\\System32\\cmd.exe',
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        'pnpm',
+        'add',
+        '-g',
+        '@open-agent-toolkit/cli@1.2.3',
+      ],
     });
   });
 });

--- a/packages/cli/src/app/global-cli-installer.ts
+++ b/packages/cli/src/app/global-cli-installer.ts
@@ -16,7 +16,17 @@ export interface GlobalCliInstallerInvocation {
 }
 
 function normalizePathForDetection(path: string): string {
-  return path.replaceAll('\\', '/').toLowerCase();
+  return path.replaceAll('\\', '/').toLowerCase().replace(/\/+$/, '');
+}
+
+function isUnderNormalizedPath(
+  normalizedCandidate: string,
+  normalizedHome: string,
+): boolean {
+  return (
+    normalizedCandidate === normalizedHome ||
+    normalizedCandidate.startsWith(`${normalizedHome}/`)
+  );
 }
 
 function detectFromPath(
@@ -56,7 +66,12 @@ export function detectGlobalCliPackageManager(
   if (pnpmHome) {
     const normalizedHome = normalizePathForDetection(pnpmHome);
     for (const candidate of candidates) {
-      if (normalizePathForDetection(candidate).startsWith(normalizedHome)) {
+      if (
+        isUnderNormalizedPath(
+          normalizePathForDetection(candidate),
+          normalizedHome,
+        )
+      ) {
         return 'pnpm';
       }
     }
@@ -81,14 +96,30 @@ function installArgsForManager(
   }
 }
 
-function executableForManager(
-  manager: GlobalCliPackageManager,
-  platform: NodeJS.Platform,
-): string {
-  if (platform === 'win32') {
-    return `${manager}.cmd`;
-  }
+function executableForManager(manager: GlobalCliPackageManager): string {
   return manager;
+}
+
+function resolveWindowsManagerInvocation(
+  manager: GlobalCliPackageManager,
+  packageSpec: string,
+  options: GlobalCliInstallerOptions,
+): GlobalCliInstallerInvocation | null {
+  if (manager === 'npm') {
+    return resolveNpmWindowsInvocation(packageSpec, options);
+  }
+
+  const comspec = options.env.ComSpec?.trim() || 'cmd.exe';
+  return {
+    file: comspec,
+    args: [
+      '/d',
+      '/s',
+      '/c',
+      manager,
+      ...installArgsForManager(manager, packageSpec),
+    ],
+  };
 }
 
 function resolveNpmWindowsInvocation(
@@ -144,12 +175,12 @@ export function resolveGlobalCliInstallerInvocation(
   options: GlobalCliInstallerOptions,
 ): GlobalCliInstallerInvocation | null {
   const manager = detectGlobalCliPackageManager(options.argv, options.env);
-  if (manager === 'npm' && options.platform === 'win32') {
-    return resolveNpmWindowsInvocation(packageSpec, options);
+  if (options.platform === 'win32') {
+    return resolveWindowsManagerInvocation(manager, packageSpec, options);
   }
 
   return {
-    file: executableForManager(manager, options.platform),
+    file: executableForManager(manager),
     args: installArgsForManager(manager, packageSpec),
   };
 }

--- a/packages/cli/src/app/global-cli-installer.ts
+++ b/packages/cli/src/app/global-cli-installer.ts
@@ -1,0 +1,155 @@
+import { win32 } from 'node:path';
+
+export type GlobalCliPackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
+
+export interface GlobalCliInstallerOptions {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+  nodeExecutable: string;
+  fileExists: (path: string) => boolean;
+}
+
+export interface GlobalCliInstallerInvocation {
+  file: string;
+  args: string[];
+}
+
+function normalizePathForDetection(path: string): string {
+  return path.replaceAll('\\', '/').toLowerCase();
+}
+
+function detectFromPath(
+  normalizedPath: string,
+): GlobalCliPackageManager | null {
+  if (normalizedPath.includes('/pnpm/') || normalizedPath.includes('/.pnpm/')) {
+    return 'pnpm';
+  }
+  if (
+    normalizedPath.includes('/.bun/') ||
+    normalizedPath.includes('/bun/install/')
+  ) {
+    return 'bun';
+  }
+  if (
+    normalizedPath.includes('/.yarn/') ||
+    normalizedPath.includes('/yarn/global/')
+  ) {
+    return 'yarn';
+  }
+  return null;
+}
+
+export function detectGlobalCliPackageManager(
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+): GlobalCliPackageManager {
+  const candidates = argv.slice(0, 2).filter(Boolean);
+  for (const candidate of candidates) {
+    const detected = detectFromPath(normalizePathForDetection(candidate));
+    if (detected) {
+      return detected;
+    }
+  }
+
+  const pnpmHome = env.PNPM_HOME?.trim();
+  if (pnpmHome) {
+    const normalizedHome = normalizePathForDetection(pnpmHome);
+    for (const candidate of candidates) {
+      if (normalizePathForDetection(candidate).startsWith(normalizedHome)) {
+        return 'pnpm';
+      }
+    }
+  }
+
+  return 'npm';
+}
+
+function installArgsForManager(
+  manager: GlobalCliPackageManager,
+  packageSpec: string,
+): string[] {
+  switch (manager) {
+    case 'npm':
+      return ['install', '--global', packageSpec];
+    case 'pnpm':
+      return ['add', '-g', packageSpec];
+    case 'yarn':
+      return ['global', 'add', packageSpec];
+    case 'bun':
+      return ['install', '-g', packageSpec];
+  }
+}
+
+function executableForManager(
+  manager: GlobalCliPackageManager,
+  platform: NodeJS.Platform,
+): string {
+  if (platform === 'win32') {
+    return `${manager}.cmd`;
+  }
+  return manager;
+}
+
+function resolveNpmWindowsInvocation(
+  packageSpec: string,
+  options: GlobalCliInstallerOptions,
+): GlobalCliInstallerInvocation | null {
+  const npmArgs = installArgsForManager('npm', packageSpec);
+  const environmentPath = options.env.npm_execpath?.trim();
+  const standardPath = win32.join(
+    win32.dirname(options.nodeExecutable),
+    'node_modules',
+    'npm',
+    'bin',
+    'npm-cli.js',
+  );
+  const npmCliPath = [environmentPath, standardPath].find(
+    (candidate) =>
+      candidate !== undefined &&
+      win32.isAbsolute(candidate) &&
+      win32.basename(candidate).toLowerCase() === 'npm-cli.js' &&
+      options.fileExists(candidate),
+  );
+  if (!npmCliPath) {
+    return null;
+  }
+
+  return {
+    file: options.nodeExecutable,
+    args: [npmCliPath, ...npmArgs],
+  };
+}
+
+export function formatGlobalCliInstallCommand(
+  packageSpec: string,
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+): string {
+  const manager = detectGlobalCliPackageManager(argv, env);
+  switch (manager) {
+    case 'npm':
+      return `npm install --global ${packageSpec}`;
+    case 'pnpm':
+      return `pnpm add -g ${packageSpec}`;
+    case 'yarn':
+      return `yarn global add ${packageSpec}`;
+    case 'bun':
+      return `bun install -g ${packageSpec}`;
+  }
+}
+
+export function resolveGlobalCliInstallerInvocation(
+  packageSpec: string,
+  options: GlobalCliInstallerOptions,
+): GlobalCliInstallerInvocation | null {
+  const manager = detectGlobalCliPackageManager(options.argv, options.env);
+  if (manager === 'npm' && options.platform === 'win32') {
+    return resolveNpmWindowsInvocation(packageSpec, options);
+  }
+
+  return {
+    file: executableForManager(manager, options.platform),
+    args: installArgsForManager(manager, packageSpec),
+  };
+}

--- a/packages/cli/src/app/tool-bundle-update-guard.test.ts
+++ b/packages/cli/src/app/tool-bundle-update-guard.test.ts
@@ -202,6 +202,27 @@ describe('guardBundledToolMutation', () => {
     );
   });
 
+  it('uses pnpm when the running CLI is pnpm-managed', async () => {
+    const harness = createHarness({
+      confirmed: true,
+      options: {
+        argv: [
+          '/Users/me/Library/pnpm/oat',
+          '/Users/me/Library/pnpm/global/5/node_modules/@open-agent-toolkit/cli/dist/index.js',
+          'init',
+        ],
+      },
+    });
+
+    await guardBundledToolMutation(harness.options, harness.dependencies);
+
+    expect(harness.installCli).toHaveBeenCalledWith(
+      'pnpm',
+      ['add', '-g', '@open-agent-toolkit/cli@1.2.3'],
+      { shell: false, stdio: 'inherit' },
+    );
+  });
+
   it.each([
     ['named update', 'oat tools update oat-project-implement'],
     ['pack update', 'oat tools update --pack workflows'],

--- a/packages/cli/src/app/tool-bundle-update-guard.ts
+++ b/packages/cli/src/app/tool-bundle-update-guard.ts
@@ -1,7 +1,10 @@
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { win32 } from 'node:path';
 
+import {
+  formatGlobalCliInstallCommand,
+  resolveGlobalCliInstallerInvocation,
+} from '@app/global-cli-installer';
 import { resolveUpdateAvailability } from '@app/update-notifier';
 import { confirmAction } from '@commands/shared/shared.prompts';
 import { CliError } from '@errors/index';
@@ -126,46 +129,6 @@ export function isBundledToolMutationCommand(command: Command): boolean {
   return path[0] === 'tools' && (path[1] === 'install' || path[1] === 'update');
 }
 
-interface InstallerInvocation {
-  file: string;
-  args: string[];
-}
-
-function resolveInstallerInvocation(
-  options: ToolBundleUpdateGuardOptions,
-  dependencies: ToolBundleUpdateGuardDependencies,
-  packageVersion: string,
-): InstallerInvocation | null {
-  const npmArgs = ['install', '--global', packageVersion];
-  if (dependencies.platform !== 'win32') {
-    return { file: 'npm', args: npmArgs };
-  }
-
-  const environmentPath = options.env.npm_execpath?.trim();
-  const standardPath = win32.join(
-    win32.dirname(dependencies.nodeExecutable),
-    'node_modules',
-    'npm',
-    'bin',
-    'npm-cli.js',
-  );
-  const npmCliPath = [environmentPath, standardPath].find(
-    (candidate) =>
-      candidate !== undefined &&
-      win32.isAbsolute(candidate) &&
-      win32.basename(candidate).toLowerCase() === 'npm-cli.js' &&
-      dependencies.fileExists(candidate),
-  );
-  if (!npmCliPath) {
-    return null;
-  }
-
-  return {
-    file: dependencies.nodeExecutable,
-    args: [npmCliPath, ...npmArgs],
-  };
-}
-
 export async function guardBundledToolMutation(
   options: ToolBundleUpdateGuardOptions,
   overrides: Partial<ToolBundleUpdateGuardDependencies> = {},
@@ -187,7 +150,12 @@ export async function guardBundledToolMutation(
       'can only install its own bundled tool versions. The available CLI may ' +
       'bundle newer tool versions.',
   );
-  const installCommand = `npm install --global ${CLI_PACKAGE}@${availableVersion}`;
+  const packageSpec = `${CLI_PACKAGE}@${availableVersion}`;
+  const installCommand = formatGlobalCliInstallCommand(
+    packageSpec,
+    options.argv,
+    options.env,
+  );
   let accepted = false;
   try {
     accepted = await dependencies.confirmAction(
@@ -209,11 +177,13 @@ export async function guardBundledToolMutation(
     return false;
   }
 
-  const invocation = resolveInstallerInvocation(
-    options,
-    dependencies,
-    `${CLI_PACKAGE}@${availableVersion}`,
-  );
+  const invocation = resolveGlobalCliInstallerInvocation(packageSpec, {
+    argv: options.argv,
+    env: options.env,
+    platform: dependencies.platform,
+    nodeExecutable: dependencies.nodeExecutable,
+    fileExists: dependencies.fileExists,
+  });
   if (!invocation) {
     throw new CliError(
       'Could not locate npm-cli.js for a shell-free Windows update. ' +

--- a/packages/cli/src/app/update-notifier.test.ts
+++ b/packages/cli/src/app/update-notifier.test.ts
@@ -462,6 +462,29 @@ describe('maybeNotifyAboutUpdate', () => {
     expect(harness.logger.warn).toHaveBeenCalledOnce();
   });
 
+  it('suggests pnpm when the running CLI is pnpm-managed', async () => {
+    const harness = createHarness({
+      cache: {
+        checkedAt: NOW.toISOString(),
+        latestVersion: '2.0.0',
+      },
+      options: {
+        argv: [
+          '/Users/me/Library/pnpm/oat',
+          '/Users/me/Library/pnpm/global/5/node_modules/@open-agent-toolkit/cli/dist/index.js',
+          'status',
+        ],
+      },
+    });
+
+    await maybeNotifyAboutUpdate(harness.options, harness.dependencies);
+
+    expect(harness.logger.warn).toHaveBeenCalledWith(
+      'Update available: 1.0.0 → 2.0.0\n' +
+        'Run: pnpm add -g @open-agent-toolkit/cli@latest',
+    );
+  });
+
   it('emits the exact notice and atomically records the complete cache snapshot', async () => {
     const harness = createHarness({
       cache: {
@@ -474,7 +497,7 @@ describe('maybeNotifyAboutUpdate', () => {
 
     expect(harness.logger.warn).toHaveBeenCalledWith(
       'Update available: 1.0.0 → 2.0.0\n' +
-        'Run: npm install -g @open-agent-toolkit/cli@latest',
+        'Run: npm install --global @open-agent-toolkit/cli@latest',
     );
     expect(harness.atomicWriteJson).toHaveBeenCalledOnce();
     expect(harness.atomicWriteJson).toHaveBeenCalledWith(

--- a/packages/cli/src/app/update-notifier.ts
+++ b/packages/cli/src/app/update-notifier.ts
@@ -1,6 +1,7 @@
 import { readFile as readFileDefault } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { formatGlobalCliInstallCommand } from '@app/global-cli-installer';
 import { readUserConfig, type UserConfig } from '@config/oat-config';
 import { atomicWriteJson } from '@fs/io';
 import type { CliLogger } from '@ui/logger';
@@ -231,10 +232,15 @@ function shouldNotify(
   );
 }
 
-function formatNotice(currentVersion: string, latestVersion: string): string {
+function formatNotice(
+  currentVersion: string,
+  latestVersion: string,
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+): string {
   return (
     `Update available: ${currentVersion} → ${latestVersion}\n` +
-    'Run: npm install -g @open-agent-toolkit/cli@latest'
+    `Run: ${formatGlobalCliInstallCommand('@open-agent-toolkit/cli@latest', argv, env)}`
   );
 }
 
@@ -349,7 +355,12 @@ export async function maybeNotifyAboutUpdate(
     ) {
       try {
         options.logger.warn(
-          formatNotice(options.currentVersion, state.latestVersion),
+          formatNotice(
+            options.currentVersion,
+            state.latestVersion,
+            options.argv,
+            options.env,
+          ),
         );
         state.cache = {
           ...state.cache,

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- Detects the package manager used to install the running `oat` binary (npm, pnpm, yarn, or bun) from the entrypoint path and `PNPM_HOME`
- Uses the matching global install command in both the passive update notice and the `oat init` / `oat tools install|update` bundle mutation guard
- Fixes the update loop where pnpm users accepted the auto-update prompt but still ran the old pnpm-installed CLI because the guard only updated the npm global copy

## Test plan

- [x] `pnpm --filter @open-agent-toolkit/cli test -- src/app/global-cli-installer.test.ts src/app/tool-bundle-update-guard.test.ts src/app/update-notifier.test.ts`
- [x] `pnpm --filter @open-agent-toolkit/cli type-check`
- [x] Pre-push hooks: version bump check, type-check, lint, format
- [ ] After release: verify `oat init` auto-update on a pnpm-global install updates the same binary (`which oat` unchanged, version bumps)