### PR TITLE
feat(cli): initialize standalone decision guidance

### DIFF
--- a/apps/oat-docs/docs/cli-utilities/config-and-local-state.md
+++ b/apps/oat-docs/docs/cli-utilities/config-and-local-state.md
@@ -85,7 +85,7 @@ For full project-management repo-reference setup, use [`oat pjm init`](tool-pack
 
 Use the `oat decision` group for file-per-record decisions under `.oat/repo/reference/decisions/`. Each decision is its own file with a deterministic `DR-YYMMDD-slug` ID (the slug is capped at 30 characters at the last whole-word boundary, with trailing stop-words trimmed), and the human-facing index is a committed generated view.
 
-- `oat decision init` - scaffold `.oat/repo/reference/decisions/` and the managed decision index
+- `oat decision init` - scaffold `.oat/repo/reference/decisions/`, the managed decision index, decision-scoped `AGENTS.md` guidance, and an idempotent `OAT decisions` section in the repository-root `AGENTS.md`
 - `oat decision new <title>` - create a new decision record; supports `--status`, `--context`, `--decision`, `--consequences`, and `--created-at`
 - `oat decision regenerate-index` - rebuild the managed decision index table from record frontmatter
 - `oat decision migrate` - convert a legacy single `decision-record.md` into file-per-record decisions, preserving each old `ADR-NNN`/`DR-NNN` ID as `legacy_id`; applies by default, so pass `--dry-run` to preview the legacy-to-new mappings without writing, and `--delete-legacy` to remove the source file after a verified migration (unlike `oat pjm migrate`, which defaults to dry-run)
@@ -93,6 +93,8 @@ Use the `oat decision` group for file-per-record decisions under `.oat/repo/refe
 Pass `--context`, `--decision`, and `--consequences` together when creating a resolved decision so every substantive template section is complete in the same atomic creation step. Callers that omit them retain the template's placeholder content for later editing.
 
 The decision index uses managed marker pairs and is deterministic, so an index merge conflict can be resolved by re-running `oat decision regenerate-index` and staging the result. Decision records replace the legacy single `decision-record.md`; repos still on the old layout migrate with `oat decision migrate` (or the broader `oat pjm migrate`).
+
+`oat decision init` is the lightweight standalone setup path. It does not require the `project-management` tool pack and does not create current state, roadmap, or backlog artifacts. Its AGENTS guidance uses `oat decision` directly while also recognizing `oat-pjm-decision` when that optional skill is installed later.
 
 ## `oat local ...`
 

--- a/apps/oat-docs/docs/cli-utilities/tool-packs.md
+++ b/apps/oat-docs/docs/cli-utilities/tool-packs.md
@@ -140,6 +140,8 @@ The canonical surface splits active operational state (under `pjm/`) from durabl
 
 Decisions are now file-per-record under `reference/decisions/` (created and indexed with the [`oat decision`](config-and-local-state.md#oat-decision-) command group), replacing the legacy single `decision-record.md`. Repos still on the old `reference/` layout can migrate with `oat pjm migrate`.
 
+For decision records without the broader PJM surface, run `oat decision init` directly. It creates only the decision directory, generated index, and decision-specific AGENTS guidance; it does not require the `project-management` pack or create current state, roadmap, and backlog artifacts. If the pack is installed later, its root guidance is maintained as a separate managed section so the decision instructions remain independently reusable.
+
 `oat pjm init` is idempotent and non-destructive. Existing reference docs are skipped and left unchanged, so curated repo state is not overwritten on repeated runs.
 
 Run `oat pjm doctor` to check an existing surface after the `project-management` pack is enabled: it reports missing canonical files, leftover template frontmatter, and legacy/loose/second-roadmap drift, and accepts `--json` for machine-readable output. When the pack is disabled or not configured, doctor reports PJM as disabled and skips drift checks. The same gated checks also run under project-scope `oat doctor`.

--- a/apps/oat-docs/docs/reference/oat-directory-structure.md
+++ b/apps/oat-docs/docs/reference/oat-directory-structure.md
@@ -246,12 +246,16 @@ operational layer (`pjm/`) from durable references (`reference/`):
   reference/
     AGENTS.md
     decisions/
+      AGENTS.md
+      index.md
 ```
 
 Decisions are file-per-record under `reference/decisions/` (managed with the
 `oat decision` command group), replacing the legacy single
 `reference/decision-record.md`. Repos still on the old single-`reference/`
-layout migrate with `oat pjm migrate`.
+layout migrate with `oat pjm migrate`. Running `oat decision init` by itself
+creates the `decisions/` subtree and decision-specific AGENTS guidance without
+creating the broader `pjm/` surface.
 
 ## User scope (`~/.oat/`)
 

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.2.16",
-  "docs-config": "0.2.16",
-  "docs-theme": "0.2.16",
-  "docs-transforms": "0.2.16"
+  "cli": "0.2.17",
+  "docs-config": "0.2.17",
+  "docs-theme": "0.2.17",
+  "docs-transforms": "0.2.17"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/decision/agents-guidance.test.ts
+++ b/packages/cli/src/commands/decision/agents-guidance.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  buildDecisionAgentsSectionBody,
+  initializeDecisionAgentsGuidance,
+} from './agents-guidance';
+
+describe('decision AGENTS guidance', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+    tempDirs.length = 0;
+  });
+
+  it('builds guidance that works with or without the PJM skill', () => {
+    const body = buildDecisionAgentsSectionBody();
+
+    expect(body).toContain('.oat/repo/reference/decisions/AGENTS.md');
+    expect(body).toContain('.oat/repo/reference/decisions/index.md');
+    expect(body).toContain('oat-pjm-decision');
+    expect(body).toContain('otherwise use `oat decision new`');
+    expect(body).toContain('oat decision regenerate-index');
+    expect(body).toContain('oat decision init');
+  });
+
+  it('creates root and decision-scoped managed guidance idempotently', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'oat-decision-agents-'));
+    tempDirs.push(projectRoot);
+    const decisionsRoot = join(
+      projectRoot,
+      '.oat',
+      'repo',
+      'reference',
+      'decisions',
+    );
+
+    const first = await initializeDecisionAgentsGuidance({
+      projectRoot,
+      decisionsRoot,
+    });
+    const second = await initializeDecisionAgentsGuidance({
+      projectRoot,
+      decisionsRoot,
+    });
+
+    expect(first).toEqual({ root: 'created', scoped: 'created' });
+    expect(second).toEqual({ root: 'no-change', scoped: 'no-change' });
+
+    const rootGuidance = await readFile(join(projectRoot, 'AGENTS.md'), 'utf8');
+    expect(rootGuidance).toContain('<!-- OAT decisions -->');
+    expect(rootGuidance).toContain('`.oat/repo/reference/decisions/AGENTS.md`');
+
+    const scopedGuidance = await readFile(
+      join(decisionsRoot, 'AGENTS.md'),
+      'utf8',
+    );
+    expect(scopedGuidance).toContain('<!-- OAT decisions -->');
+    expect(scopedGuidance).toContain('# Decision Record Guidance');
+  });
+
+  it('points root guidance at a custom decisions directory', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'oat-decision-agents-'));
+    tempDirs.push(projectRoot);
+    const decisionsRoot = join(projectRoot, 'architecture', 'decisions');
+
+    await initializeDecisionAgentsGuidance({ projectRoot, decisionsRoot });
+
+    const rootGuidance = await readFile(join(projectRoot, 'AGENTS.md'), 'utf8');
+    expect(rootGuidance).toContain('`architecture/decisions/AGENTS.md`');
+    expect(rootGuidance).toContain('`architecture/decisions/index.md`');
+  });
+});

--- a/packages/cli/src/commands/decision/agents-guidance.ts
+++ b/packages/cli/src/commands/decision/agents-guidance.ts
@@ -1,0 +1,98 @@
+import { mkdir } from 'node:fs/promises';
+import { isAbsolute, relative, sep } from 'node:path';
+
+import {
+  type UpsertSectionResult,
+  upsertAgentsMdSection,
+} from '@commands/shared/agents-md';
+
+export const DECISION_AGENTS_SECTION_KEY = 'decisions';
+
+const DEFAULT_DECISIONS_PATH = '.oat/repo/reference/decisions';
+
+function portablePath(path: string): string {
+  return path.split(sep).join('/');
+}
+
+function displayDecisionsPath(
+  projectRoot: string,
+  decisionsRoot: string,
+): string {
+  const relativePath = relative(projectRoot, decisionsRoot);
+  if (
+    relativePath.length > 0 &&
+    !relativePath.startsWith('..') &&
+    !isAbsolute(relativePath)
+  ) {
+    return portablePath(relativePath);
+  }
+
+  return portablePath(decisionsRoot);
+}
+
+export function buildDecisionAgentsSectionBody(
+  decisionsPath = DEFAULT_DECISIONS_PATH,
+): string {
+  return [
+    '### Decision Records',
+    '',
+    `- Durable repository decisions live under \`${decisionsPath}/\`; read \`${decisionsPath}/AGENTS.md\` before working with them.`,
+    `- Before finalizing a durable repository decision, review \`${decisionsPath}/index.md\` and any relevant records.`,
+    '- When the user asks to record a durable decision or confirms a proposed capture, use `oat-pjm-decision` when that skill is installed; otherwise use `oat decision new`.',
+    '- Do not hand-edit the generated decision index; run `oat decision regenerate-index` after record changes or to resolve index conflicts.',
+    '- If the decision surface is missing, initialize it with `oat decision init`.',
+  ].join('\n');
+}
+
+export function buildScopedDecisionAgentsSectionBody(): string {
+  return [
+    '# Decision Record Guidance',
+    '',
+    '- This directory stores one Markdown file per durable repository decision plus a generated `index.md`.',
+    '- Review the index and relevant existing records before finalizing a decision.',
+    '- Create records with `oat decision new`; do not create IDs or filenames by hand.',
+    '- Keep context, the chosen decision, and consequences in the decision record.',
+    '- Do not hand-edit the generated table in `index.md`. Run `oat decision regenerate-index` after record changes or to resolve index conflicts.',
+  ].join('\n');
+}
+
+export interface InitializeDecisionAgentsGuidanceOptions {
+  projectRoot: string;
+  decisionsRoot: string;
+}
+
+export interface DecisionAgentsGuidanceResult {
+  root: UpsertSectionResult['action'];
+  scoped: UpsertSectionResult['action'];
+}
+
+export async function initializeScopedDecisionAgentsGuidance(
+  decisionsRoot: string,
+): Promise<UpsertSectionResult> {
+  await mkdir(decisionsRoot, { recursive: true });
+  return upsertAgentsMdSection(
+    decisionsRoot,
+    DECISION_AGENTS_SECTION_KEY,
+    buildScopedDecisionAgentsSectionBody(),
+  );
+}
+
+export async function initializeDecisionAgentsGuidance(
+  options: InitializeDecisionAgentsGuidanceOptions,
+): Promise<DecisionAgentsGuidanceResult> {
+  const scoped = await initializeScopedDecisionAgentsGuidance(
+    options.decisionsRoot,
+  );
+  const root = await upsertAgentsMdSection(
+    options.projectRoot,
+    DECISION_AGENTS_SECTION_KEY,
+    buildDecisionAgentsSectionBody(
+      displayDecisionsPath(options.projectRoot, options.decisionsRoot),
+    ),
+  );
+
+  return {
+    root: root.action,
+    scoped: scoped.action,
+  };
+}

--- a/packages/cli/src/commands/decision/index.test.ts
+++ b/packages/cli/src/commands/decision/index.test.ts
@@ -12,6 +12,7 @@ function createHarness(): {
   capture: LoggerCapture;
   command: Command;
   createDecisionRecord: ReturnType<typeof vi.fn>;
+  initializeDecisionAgentsGuidance: ReturnType<typeof vi.fn>;
   initializeDecisionRecords: ReturnType<typeof vi.fn>;
   migrateDecisionRecords: ReturnType<typeof vi.fn>;
   regenerateDecisionIndex: ReturnType<typeof vi.fn>;
@@ -19,6 +20,10 @@ function createHarness(): {
   resolveProjectRoot: ReturnType<typeof vi.fn>;
 } {
   const capture = createLoggerCapture();
+  const initializeDecisionAgentsGuidance = vi.fn(async () => ({
+    root: 'created' as const,
+    scoped: 'created' as const,
+  }));
   const initializeDecisionRecords = vi.fn(async (decisionsRoot: string) => ({
     decisionsRoot,
     created: ['index.md'],
@@ -64,6 +69,7 @@ function createHarness(): {
       logger: capture.logger,
     }),
     createDecisionRecord,
+    initializeDecisionAgentsGuidance,
     initializeDecisionRecords,
     migrateDecisionRecords,
     regenerateDecisionIndex,
@@ -75,6 +81,7 @@ function createHarness(): {
     capture,
     command,
     createDecisionRecord,
+    initializeDecisionAgentsGuidance,
     initializeDecisionRecords,
     migrateDecisionRecords,
     regenerateDecisionIndex,
@@ -119,20 +126,57 @@ describe('createDecisionCommand', () => {
   });
 
   it('initializes the default decisions root resolved from the project root', async () => {
-    const { command, capture, initializeDecisionRecords } = createHarness();
+    const {
+      command,
+      capture,
+      initializeDecisionAgentsGuidance,
+      initializeDecisionRecords,
+    } = createHarness();
 
     await runCommand(command, 'init', ['--json']);
 
     expect(initializeDecisionRecords).toHaveBeenCalledWith(
       '/tmp/workspace/repo/.oat/repo/reference/decisions',
     );
+    expect(initializeDecisionAgentsGuidance).toHaveBeenCalledWith({
+      projectRoot: '/tmp/workspace/repo',
+      decisionsRoot: '/tmp/workspace/repo/.oat/repo/reference/decisions',
+    });
     expect(capture.jsonPayloads[0]).toEqual({
       status: 'ok',
       decisionsRoot: '/tmp/workspace/repo/.oat/repo/reference/decisions',
       created: ['index.md'],
       skipped: [],
+      guidance: {
+        root: 'created',
+        scoped: 'created',
+      },
     });
     expect(process.exitCode).toBe(0);
+  });
+
+  it('reports a decision init failure when AGENTS guidance cannot be written', async () => {
+    const {
+      command,
+      capture,
+      initializeDecisionAgentsGuidance,
+      initializeDecisionRecords,
+    } = createHarness();
+    initializeDecisionAgentsGuidance.mockRejectedValueOnce(
+      new Error('permission denied'),
+    );
+
+    await runCommand(command, 'init', ['--json']);
+
+    expect(initializeDecisionRecords).toHaveBeenCalledOnce();
+    expect(capture.jsonPayloads).toEqual([
+      {
+        status: 'error',
+        message:
+          'Decision index initialized at /tmp/workspace/repo/.oat/repo/reference/decisions, but AGENTS.md guidance could not be written: permission denied. Fix the guidance write error and rerun `oat decision init`.',
+      },
+    ]);
+    expect(process.exitCode).toBe(1);
   });
 
   it('regenerates the managed decision index', async () => {

--- a/packages/cli/src/commands/decision/index.ts
+++ b/packages/cli/src/commands/decision/index.ts
@@ -6,6 +6,7 @@ import { resolveAssetsRoot } from '@fs/assets';
 import { resolveProjectRoot } from '@fs/paths';
 import { Command } from 'commander';
 
+import { initializeDecisionAgentsGuidance } from './agents-guidance';
 import { initializeDecisionRecords } from './init';
 import { migrateDecisionRecords } from './migrate';
 import { createDecisionRecord } from './new';
@@ -38,6 +39,7 @@ interface DecisionCommandDependencies {
   buildCommandContext: typeof buildCommandContext;
   resolveProjectRoot: typeof resolveProjectRoot;
   resolveAssetsRoot: typeof resolveAssetsRoot;
+  initializeDecisionAgentsGuidance: typeof initializeDecisionAgentsGuidance;
   initializeDecisionRecords: typeof initializeDecisionRecords;
   regenerateDecisionIndex: typeof regenerateDecisionIndex;
   createDecisionRecord: typeof createDecisionRecord;
@@ -48,6 +50,7 @@ const DEFAULT_DEPENDENCIES: DecisionCommandDependencies = {
   buildCommandContext,
   resolveProjectRoot,
   resolveAssetsRoot,
+  initializeDecisionAgentsGuidance,
   initializeDecisionRecords,
   regenerateDecisionIndex,
   createDecisionRecord,
@@ -120,9 +123,23 @@ export function createDecisionCommand(
         );
         const result =
           await dependencies.initializeDecisionRecords(decisionsRoot);
+        let guidance;
+        try {
+          guidance = await dependencies.initializeDecisionAgentsGuidance({
+            projectRoot,
+            decisionsRoot,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `Decision index initialized at ${result.decisionsRoot}, but AGENTS.md guidance could not be written: ${message}. Fix the guidance write error and rerun \`oat decision init\`.`,
+            { cause: error },
+          );
+        }
 
         if (context.json) {
-          context.logger.json({ status: 'ok', ...result });
+          context.logger.json({ status: 'ok', ...result, guidance });
         } else {
           context.logger.info(
             `Initialized decision scaffold at ${result.decisionsRoot}`,
@@ -135,6 +152,9 @@ export function createDecisionCommand(
               `Skipped existing: ${result.skipped.join(', ')}`,
             );
           }
+          context.logger.info(
+            `AGENTS.md guidance: root=${guidance.root}, decisions=${guidance.scoped}`,
+          );
         }
         process.exitCode = 0;
       } catch (error) {

--- a/packages/cli/src/commands/init/tools/index.test.ts
+++ b/packages/cli/src/commands/init/tools/index.test.ts
@@ -1,5 +1,6 @@
 import type { CommandContext, GlobalOptions } from '@app/command-context';
 import { createLoggerCapture } from '@commands/__tests__/helpers';
+import { buildDecisionAgentsSectionBody } from '@commands/decision/agents-guidance';
 import type {
   MultiSelectChoice,
   SelectChoice,
@@ -1165,14 +1166,14 @@ describe('createInitToolsCommand', () => {
     );
   });
 
-  it('writes tool-pack and project-management AGENTS sections', async () => {
+  it('writes tool-pack, project-management, and decision AGENTS sections', async () => {
     const { command, upsertAgentsMdSection } = createHarness({
       interactive: false,
     });
 
     await runCommand(command, [], ['--scope', 'all']);
 
-    expect(upsertAgentsMdSection).toHaveBeenCalledTimes(2);
+    expect(upsertAgentsMdSection).toHaveBeenCalledTimes(3);
     expect(upsertAgentsMdSection).toHaveBeenNthCalledWith(
       1,
       '/tmp/workspace',
@@ -1183,6 +1184,12 @@ describe('createInitToolsCommand', () => {
       2,
       '/tmp/workspace',
       'project-management',
+      expect.stringContaining('### Project Management'),
+    );
+    expect(upsertAgentsMdSection).toHaveBeenNthCalledWith(
+      3,
+      '/tmp/workspace',
+      'decisions',
       expect.stringContaining('### Decision Records'),
     );
   });
@@ -1276,7 +1283,7 @@ describe('createInitToolsCommand', () => {
 
     await runCommand(command, [], ['--scope', 'user']);
 
-    expect(upsertAgentsMdSection).toHaveBeenCalledTimes(2);
+    expect(upsertAgentsMdSection).toHaveBeenCalledTimes(3);
     const body = upsertAgentsMdSection.mock.calls[0]?.[2] as string;
     expect(body).toContain('_(user scope)_');
     expect(body).toContain('`~/.agents/skills/`');
@@ -1764,19 +1771,22 @@ describe('buildToolPacksSectionBody', () => {
     expect(body).not.toContain('configured HiLL checkpoint');
   });
 
-  it('builds the project-management routing and decision guidance', () => {
-    const body = buildProjectManagementAgentsSectionBody();
+  it('builds independent project-management and decision guidance', () => {
+    const projectManagementBody = buildProjectManagementAgentsSectionBody();
+    const decisionBody = buildDecisionAgentsSectionBody();
 
-    expect(body).toContain('### Project Management');
-    expect(body).toContain('.oat/repo/AGENTS.md');
-    expect(body).toContain('`pjm/` for active state');
-    expect(body).toContain('`reference/` for durable records');
-    expect(body).toContain('### Decision Records');
-    expect(body).toContain('.oat/repo/reference/decisions/index.md');
-    expect(body).toContain('oat-pjm-decision');
-    expect(body).toContain('oat decision new');
-    expect(body).toContain('oat pjm init');
-    expect(body).toContain('oat decision regenerate-index');
+    expect(projectManagementBody).toContain('### Project Management');
+    expect(projectManagementBody).toContain('.oat/repo/AGENTS.md');
+    expect(projectManagementBody).toContain('`pjm/` for active state');
+    expect(projectManagementBody).toContain('`reference/` for durable records');
+    expect(projectManagementBody).toContain('oat pjm init');
+    expect(projectManagementBody).not.toContain('### Decision Records');
+
+    expect(decisionBody).toContain('### Decision Records');
+    expect(decisionBody).toContain('.oat/repo/reference/decisions/index.md');
+    expect(decisionBody).toContain('oat-pjm-decision');
+    expect(decisionBody).toContain('oat decision new');
+    expect(decisionBody).toContain('oat decision regenerate-index');
   });
 
   it('keeps PJM guidance out of the tool-pack listing section', () => {

--- a/packages/cli/src/commands/init/tools/index.ts
+++ b/packages/cli/src/commands/init/tools/index.ts
@@ -7,6 +7,10 @@ import {
   type GlobalOptions,
   type ScopeSelectionMode,
 } from '@app/command-context';
+import {
+  buildDecisionAgentsSectionBody,
+  DECISION_AGENTS_SECTION_KEY,
+} from '@commands/decision/agents-guidance';
 import { copyDirWithStatus } from '@commands/init/tools/shared/copy-helpers';
 import { applyGitignore } from '@commands/local/apply';
 import { addLocalPaths } from '@commands/local/manage';
@@ -1317,6 +1321,13 @@ export async function runInitTools(
           buildProjectManagementAgentsSectionBody(),
         )
       : null;
+    const decisionSectionResult = selectedPacks.includes('project-management')
+      ? await dependencies.upsertAgentsMdSection(
+          projectRoot,
+          DECISION_AGENTS_SECTION_KEY,
+          buildDecisionAgentsSectionBody(),
+        )
+      : null;
     // Migrate: remove legacy <!-- OAT workflows --> section if present
     await dependencies.removeAgentsMdSection(projectRoot, 'workflows');
 
@@ -1332,6 +1343,15 @@ export async function runInitTools(
     ) {
       context.logger.info(
         `AGENTS.md project-management section ${projectManagementSectionResult.action}.`,
+      );
+    }
+    if (
+      !context.json &&
+      decisionSectionResult !== null &&
+      decisionSectionResult.action !== 'no-change'
+    ) {
+      context.logger.info(
+        `AGENTS.md decisions section ${decisionSectionResult.action}.`,
       );
     }
 

--- a/packages/cli/src/commands/init/tools/project-management/agents-guidance.ts
+++ b/packages/cli/src/commands/init/tools/project-management/agents-guidance.ts
@@ -8,11 +8,5 @@ export function buildProjectManagementAgentsSectionBody(): string {
     '- Consult it when prioritizing or planning work, checking the backlog, starting or closing tracked work, or looking for established repository context.',
     '- Start with `.oat/repo/AGENTS.md`; it routes to `pjm/` for active state and `reference/` for durable records.',
     '- If the surface is missing, initialize it with `oat pjm init`.',
-    '',
-    '### Decision Records',
-    '',
-    '- Before finalizing a durable repository decision, review `.oat/repo/reference/decisions/index.md` and any relevant records.',
-    '- When the user asks to record a durable decision or confirms a proposed capture, use `oat-pjm-decision`; use `oat decision new` for the CLI path.',
-    '- Do not hand-edit the generated decision index; run `oat decision regenerate-index` after record changes.',
   ].join('\n');
 }

--- a/packages/cli/src/commands/init/tools/project-management/index.test.ts
+++ b/packages/cli/src/commands/init/tools/project-management/index.test.ts
@@ -187,7 +187,7 @@ describe('createInitToolsProjectManagementCommand — scope conflict rejection',
     );
     expect(upsertAgentsMdSection).toHaveBeenCalledWith(
       '/test/project',
-      'project-management',
+      'decisions',
       expect.stringContaining('### Decision Records'),
     );
   });

--- a/packages/cli/src/commands/init/tools/project-management/index.ts
+++ b/packages/cli/src/commands/init/tools/project-management/index.ts
@@ -4,6 +4,10 @@ import {
   type GlobalOptions,
 } from '@app/command-context';
 import {
+  buildDecisionAgentsSectionBody,
+  DECISION_AGENTS_SECTION_KEY,
+} from '@commands/decision/agents-guidance';
+import {
   type UpsertSectionResult,
   upsertAgentsMdSection,
 } from '@commands/shared/agents-md';
@@ -95,15 +99,25 @@ export function createInitToolsProjectManagementCommand(
           });
           didInstall = true;
 
-          let agentsGuidanceAction: UpsertSectionResult['action'] | undefined;
+          let projectManagementGuidanceAction:
+            | UpsertSectionResult['action']
+            | undefined;
+          let decisionGuidanceAction: UpsertSectionResult['action'] | undefined;
           let agentsGuidanceWarning: string | undefined;
           try {
-            const agentsGuidanceResult = await upsertAgentsMdSection(
+            const projectManagementGuidanceResult = await upsertAgentsMdSection(
               targetRoot,
               PROJECT_MANAGEMENT_AGENTS_SECTION_KEY,
               buildProjectManagementAgentsSectionBody(),
             );
-            agentsGuidanceAction = agentsGuidanceResult.action;
+            projectManagementGuidanceAction =
+              projectManagementGuidanceResult.action;
+            const decisionGuidanceResult = await upsertAgentsMdSection(
+              targetRoot,
+              DECISION_AGENTS_SECTION_KEY,
+              buildDecisionAgentsSectionBody(),
+            );
+            decisionGuidanceAction = decisionGuidanceResult.action;
           } catch (error) {
             const message =
               error instanceof Error ? error.message : String(error);
@@ -131,11 +145,19 @@ export function createInitToolsProjectManagementCommand(
               `Templates: copied=${result.copiedTemplates.length}, updated=${result.updatedTemplates.length}, skipped=${result.skippedTemplates.length}`,
             );
             if (
-              agentsGuidanceAction !== undefined &&
-              agentsGuidanceAction !== 'no-change'
+              projectManagementGuidanceAction !== undefined &&
+              projectManagementGuidanceAction !== 'no-change'
             ) {
               context.logger.info(
-                `AGENTS.md project-management section ${agentsGuidanceAction}.`,
+                `AGENTS.md project-management section ${projectManagementGuidanceAction}.`,
+              );
+            }
+            if (
+              decisionGuidanceAction !== undefined &&
+              decisionGuidanceAction !== 'no-change'
+            ) {
+              context.logger.info(
+                `AGENTS.md decisions section ${decisionGuidanceAction}.`,
               );
             }
             if (agentsGuidanceWarning !== undefined) {

--- a/packages/cli/src/commands/pjm/index.test.ts
+++ b/packages/cli/src/commands/pjm/index.test.ts
@@ -33,6 +33,7 @@ const EXPECTED_FILES = [
   'pjm/backlog/completed.md',
   'pjm/backlog/items/.gitkeep',
   'pjm/backlog/archived/.gitkeep',
+  'reference/decisions/AGENTS.md',
   'reference/decisions/index.md',
 ] as const;
 

--- a/packages/cli/src/commands/pjm/init.test.ts
+++ b/packages/cli/src/commands/pjm/init.test.ts
@@ -10,6 +10,8 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { initializeDecisionAgentsGuidance } from '@commands/decision/agents-guidance';
+import { initializeDecisionRecords } from '@commands/decision/init';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { initializeRepoReference, INSTRUCTIONS_SYNC_HINT } from './init';
@@ -54,6 +56,7 @@ const EXPECTED_FILES = [
   'pjm/backlog/completed.md',
   'pjm/backlog/items/.gitkeep',
   'pjm/backlog/archived/.gitkeep',
+  'reference/decisions/AGENTS.md',
   'reference/decisions/index.md',
 ] as const;
 
@@ -199,6 +202,38 @@ describe('initializeRepoReference', () => {
 
     expect(second.created).toEqual([]);
     expect(second.skipped).toEqual(EXPECTED_FILES);
+  });
+
+  it('composes with an existing standalone decision scaffold', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'oat-pjm-init-'));
+    tempDirs.push(projectRoot);
+    const assetsRoot = join(projectRoot, 'assets');
+    const repoRoot = join(projectRoot, '.oat', 'repo');
+    const decisionsRoot = join(repoRoot, 'reference', 'decisions');
+    await seedTemplates(join(assetsRoot, 'templates'));
+    await initializeDecisionRecords(decisionsRoot);
+    await initializeDecisionAgentsGuidance({
+      projectRoot,
+      decisionsRoot,
+    });
+    const standaloneGuidance = await readFile(
+      join(decisionsRoot, 'AGENTS.md'),
+      'utf8',
+    );
+
+    const result = await initializeRepoReference({ assetsRoot, repoRoot });
+
+    expect(result.skipped).toContain('reference/decisions/AGENTS.md');
+    expect(result.skipped).toContain('reference/decisions/index.md');
+    await expect(
+      readFile(join(decisionsRoot, 'AGENTS.md'), 'utf8'),
+    ).resolves.toBe(standaloneGuidance);
+    await expect(
+      access(join(repoRoot, 'reference', 'AGENTS.md')),
+    ).resolves.toBeUndefined();
+    await expect(
+      access(join(repoRoot, 'pjm', 'current-state.md')),
+    ).resolves.toBeUndefined();
   });
 
   it('prefers repo-local templates and falls back to bundled assets', async () => {

--- a/packages/cli/src/commands/pjm/init.test.ts
+++ b/packages/cli/src/commands/pjm/init.test.ts
@@ -173,21 +173,36 @@ describe('initializeRepoReference', () => {
     tempDirs.push(root);
     const assetsRoot = join(root, 'assets');
     const repoRoot = join(root, 'repo');
-    const sentinel = '# Curated roadmap\n';
+    const roadmapSentinel = '# Curated roadmap\n';
+    const decisionGuidanceSentinel = '# Curated decision guidance\n';
     await seedTemplates(join(assetsRoot, 'templates'));
     await mkdir(join(repoRoot, 'pjm'), { recursive: true });
-    await writeFile(join(repoRoot, 'pjm', 'roadmap.md'), sentinel, {
+    await mkdir(join(repoRoot, 'reference', 'decisions'), { recursive: true });
+    await writeFile(join(repoRoot, 'pjm', 'roadmap.md'), roadmapSentinel, {
       encoding: 'utf8',
       flag: 'wx',
     });
+    await writeFile(
+      join(repoRoot, 'reference', 'decisions', 'AGENTS.md'),
+      decisionGuidanceSentinel,
+      {
+        encoding: 'utf8',
+        flag: 'wx',
+      },
+    );
 
     const result = await initializeRepoReference({ assetsRoot, repoRoot });
 
     await expect(
       readFile(join(repoRoot, 'pjm', 'roadmap.md'), 'utf8'),
-    ).resolves.toBe(sentinel);
+    ).resolves.toBe(roadmapSentinel);
+    await expect(
+      readFile(join(repoRoot, 'reference', 'decisions', 'AGENTS.md'), 'utf8'),
+    ).resolves.toBe(decisionGuidanceSentinel);
     expect(result.skipped).toContain('pjm/roadmap.md');
+    expect(result.skipped).toContain('reference/decisions/AGENTS.md');
     expect(result.created).not.toContain('pjm/roadmap.md');
+    expect(result.created).not.toContain('reference/decisions/AGENTS.md');
   });
 
   it('is idempotent on rerun', async () => {

--- a/packages/cli/src/commands/pjm/init.ts
+++ b/packages/cli/src/commands/pjm/init.ts
@@ -47,8 +47,9 @@ const BACKLOG_PATHS = [
   'pjm/backlog/archived/.gitkeep',
 ] as const;
 
+const DECISION_AGENTS_PATH = 'reference/decisions/AGENTS.md';
 const DECISION_PATHS = [
-  'reference/decisions/AGENTS.md',
+  DECISION_AGENTS_PATH,
   'reference/decisions/index.md',
 ] as const;
 
@@ -181,9 +182,11 @@ export async function initializeRepoReference(
   await initializeDecisionRecords(
     join(options.repoRoot, 'reference', 'decisions'),
   );
-  await initializeScopedDecisionAgentsGuidance(
-    join(options.repoRoot, 'reference', 'decisions'),
-  );
+  if (!existingDecisionPaths.has(DECISION_AGENTS_PATH)) {
+    await initializeScopedDecisionAgentsGuidance(
+      join(options.repoRoot, 'reference', 'decisions'),
+    );
+  }
 
   for (const relativePath of DECISION_PATHS) {
     if (existingDecisionPaths.has(relativePath)) {

--- a/packages/cli/src/commands/pjm/init.ts
+++ b/packages/cli/src/commands/pjm/init.ts
@@ -2,6 +2,7 @@ import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
 import { initializeBacklog } from '@commands/backlog/init';
+import { initializeScopedDecisionAgentsGuidance } from '@commands/decision/agents-guidance';
 import { initializeDecisionRecords } from '@commands/decision/init';
 import { stripTemplateFrontmatter } from '@commands/shared/strip-template-frontmatter';
 
@@ -46,7 +47,10 @@ const BACKLOG_PATHS = [
   'pjm/backlog/archived/.gitkeep',
 ] as const;
 
-const DECISION_PATHS = ['reference/decisions/index.md'] as const;
+const DECISION_PATHS = [
+  'reference/decisions/AGENTS.md',
+  'reference/decisions/index.md',
+] as const;
 
 export const CANONICAL_REPO_REFERENCE_PATHS = [
   ...TEMPLATE_TARGETS.map((target) => target.target),
@@ -175,6 +179,9 @@ export async function initializeRepoReference(
   }
 
   await initializeDecisionRecords(
+    join(options.repoRoot, 'reference', 'decisions'),
+  );
+  await initializeScopedDecisionAgentsGuidance(
     join(options.repoRoot, 'reference', 'decisions'),
   );
 

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- make `oat decision init` create independent root and decision-scoped AGENTS guidance
- keep decision guidance composable with project-management installation and initialization
- document standalone setup and bump the public package set to 0.2.15

## Test plan
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm build:docs`
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm format`
- [x] `pnpm docs:check-links`
- [x] `pnpm release:validate`