### PR TITLE
fix(cli): pass pnpm store-dir when auto-updating global CLI

### DIFF
--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.2.15",
-  "docs-config": "0.2.15",
-  "docs-theme": "0.2.15",
-  "docs-transforms": "0.2.15"
+  "cli": "0.2.16",
+  "docs-config": "0.2.16",
+  "docs-theme": "0.2.16",
+  "docs-transforms": "0.2.16"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/app/global-cli-installer.test.ts
+++ b/packages/cli/src/app/global-cli-installer.test.ts
@@ -115,6 +115,47 @@ describe('resolveGlobalCliInstallerInvocation', () => {
     });
   });
 
+  it('passes the pnpm global store dir when the running CLI is pnpm-managed', () => {
+    const modulesYaml =
+      '/Users/me/Library/pnpm/global/5/node_modules/.modules.yaml';
+    expect(
+      resolveGlobalCliInstallerInvocation('@open-agent-toolkit/cli@1.2.3', {
+        argv: [
+          '/Users/me/Library/pnpm/oat',
+          '/Users/me/Library/pnpm/global/5/node_modules/@open-agent-toolkit/cli/dist/index.js',
+        ],
+        env: {},
+        platform: 'linux',
+        nodeExecutable: '/usr/bin/node',
+        fileExists: (path) => path === modulesYaml,
+        readFile: () => 'storeDir: /Users/me/Library/pnpm/store/v10\n',
+      }),
+    ).toEqual({
+      file: 'pnpm',
+      args: [
+        'add',
+        '-g',
+        '@open-agent-toolkit/cli@1.2.3',
+        '--store-dir',
+        '/Users/me/Library/pnpm/store/v10',
+      ],
+    });
+    expect(
+      formatGlobalCliInstallCommand(
+        '@open-agent-toolkit/cli@1.2.3',
+        [
+          '/Users/me/Library/pnpm/oat',
+          '/Users/me/Library/pnpm/global/5/node_modules/@open-agent-toolkit/cli/dist/index.js',
+        ],
+        {},
+        (path) => path === modulesYaml,
+        () => 'storeDir: /Users/me/Library/pnpm/store/v10\n',
+      ),
+    ).toBe(
+      'pnpm add -g @open-agent-toolkit/cli@1.2.3 --store-dir /Users/me/Library/pnpm/store/v10',
+    );
+  });
+
   it('launches the npm JavaScript CLI through Node on Windows', () => {
     const npmCliPath = 'C:\\npm\\node_modules\\npm\\bin\\npm-cli.js';
     expect(

--- a/packages/cli/src/app/global-cli-installer.ts
+++ b/packages/cli/src/app/global-cli-installer.ts
@@ -1,4 +1,5 @@
-import { win32 } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { join, win32 } from 'node:path';
 
 export type GlobalCliPackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun';
 
@@ -8,6 +9,7 @@ export interface GlobalCliInstallerOptions {
   platform: NodeJS.Platform;
   nodeExecutable: string;
   fileExists: (path: string) => boolean;
+  readFile?: (path: string) => string;
 }
 
 export interface GlobalCliInstallerInvocation {
@@ -80,15 +82,89 @@ export function detectGlobalCliPackageManager(
   return 'npm';
 }
 
+function readPnpmStoreDir(
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+  fileExists: (path: string) => boolean,
+  readFile: (path: string) => string,
+): string | null {
+  const modulesYamlPath = resolvePnpmGlobalModulesYamlPath(
+    argv,
+    env,
+    fileExists,
+  );
+  if (!modulesYamlPath) {
+    return null;
+  }
+
+  try {
+    const match = readFile(modulesYamlPath).match(/^storeDir:\s*(.+)$/m);
+    return match?.[1]?.trim() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function resolvePnpmGlobalModulesYamlPath(
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+  fileExists: (path: string) => boolean,
+): string | null {
+  for (const arg of argv.slice(0, 3)) {
+    const normalized = arg.replaceAll('\\', '/');
+    const match = normalized.match(/^(.*\/global\/\d+)\//);
+    if (match?.[1]) {
+      const candidate = `${match[1]}/node_modules/.modules.yaml`;
+      if (fileExists(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  const pnpmHome = env.PNPM_HOME?.trim();
+  if (pnpmHome) {
+    const candidate = join(
+      pnpmHome,
+      'global',
+      '5',
+      'node_modules',
+      '.modules.yaml',
+    );
+    if (fileExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function resolvePnpmInstallContext(
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+  fileExists: (path: string) => boolean,
+  readFile?: (path: string) => string,
+): { storeDir: string | null } {
+  const read = readFile ?? ((path: string) => readFileSync(path, 'utf8'));
+  return {
+    storeDir: readPnpmStoreDir(argv, env, fileExists, read),
+  };
+}
+
 function installArgsForManager(
   manager: GlobalCliPackageManager,
   packageSpec: string,
+  pnpmStoreDir?: string | null,
 ): string[] {
   switch (manager) {
     case 'npm':
       return ['install', '--global', packageSpec];
-    case 'pnpm':
-      return ['add', '-g', packageSpec];
+    case 'pnpm': {
+      const args = ['add', '-g', packageSpec];
+      if (pnpmStoreDir) {
+        args.push('--store-dir', pnpmStoreDir);
+      }
+      return args;
+    }
     case 'yarn':
       return ['global', 'add', packageSpec];
     case 'bun':
@@ -109,6 +185,15 @@ function resolveWindowsManagerInvocation(
     return resolveNpmWindowsInvocation(packageSpec, options);
   }
 
+  const pnpmStoreDir =
+    manager === 'pnpm'
+      ? resolvePnpmInstallContext(
+          options.argv,
+          options.env,
+          options.fileExists,
+          options.readFile,
+        ).storeDir
+      : null;
   const comspec = options.env.ComSpec?.trim() || 'cmd.exe';
   return {
     file: comspec,
@@ -117,7 +202,7 @@ function resolveWindowsManagerInvocation(
       '/s',
       '/c',
       manager,
-      ...installArgsForManager(manager, packageSpec),
+      ...installArgsForManager(manager, packageSpec, pnpmStoreDir),
     ],
   };
 }
@@ -156,13 +241,22 @@ export function formatGlobalCliInstallCommand(
   packageSpec: string,
   argv: string[],
   env: NodeJS.ProcessEnv,
+  fileExists: (path: string) => boolean = () => false,
+  readFile?: (path: string) => string,
 ): string {
   const manager = detectGlobalCliPackageManager(argv, env);
+  const pnpmStoreDir =
+    manager === 'pnpm'
+      ? resolvePnpmInstallContext(argv, env, fileExists, readFile).storeDir
+      : null;
+  const pnpmStoreFlag =
+    pnpmStoreDir === null ? '' : ` --store-dir ${quoteShellWord(pnpmStoreDir)}`;
+
   switch (manager) {
     case 'npm':
       return `npm install --global ${packageSpec}`;
     case 'pnpm':
-      return `pnpm add -g ${packageSpec}`;
+      return `pnpm add -g ${packageSpec}${pnpmStoreFlag}`;
     case 'yarn':
       return `yarn global add ${packageSpec}`;
     case 'bun':
@@ -170,17 +264,32 @@ export function formatGlobalCliInstallCommand(
   }
 }
 
+function quoteShellWord(value: string): string {
+  return /[\s"'`$\\]/.test(value)
+    ? `'${value.replaceAll("'", `'"'"'`)}'`
+    : value;
+}
+
 export function resolveGlobalCliInstallerInvocation(
   packageSpec: string,
   options: GlobalCliInstallerOptions,
 ): GlobalCliInstallerInvocation | null {
   const manager = detectGlobalCliPackageManager(options.argv, options.env);
+  const pnpmStoreDir =
+    manager === 'pnpm'
+      ? resolvePnpmInstallContext(
+          options.argv,
+          options.env,
+          options.fileExists,
+          options.readFile,
+        ).storeDir
+      : null;
   if (options.platform === 'win32') {
     return resolveWindowsManagerInvocation(manager, packageSpec, options);
   }
 
   return {
     file: executableForManager(manager),
-    args: installArgsForManager(manager, packageSpec),
+    args: installArgsForManager(manager, packageSpec, pnpmStoreDir),
   };
 }

--- a/packages/cli/src/app/tool-bundle-update-guard.ts
+++ b/packages/cli/src/app/tool-bundle-update-guard.ts
@@ -155,6 +155,7 @@ export async function guardBundledToolMutation(
     packageSpec,
     options.argv,
     options.env,
+    dependencies.fileExists,
   );
   let accepted = false;
   try {
@@ -199,7 +200,7 @@ export async function guardBundledToolMutation(
   } catch {
     throw new CliError(
       `Failed to update the OAT CLI to ${availableVersion}. ` +
-        `No tools were changed. Fix the npm installation issue and run: ${installCommand}`,
+        `No tools were changed. Fix the package manager installation issue and run: ${installCommand}`,
       2,
     );
   }

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary

- Reads `storeDir` from the pnpm global `.modules.yaml` for the running `oat` install
- Passes `--store-dir` to `pnpm add -g` so auto-updates use the same store as the existing global packages
- Fixes `ERR_PNPM_UNEXPECTED_STORE` when PATH resolves to a different pnpm version/store than the one that installed global `oat`
- Updates failure copy from "npm installation issue" to "package manager installation issue"

## Test plan

- [x] `pnpm --filter @open-agent-toolkit/cli test -- src/app/global-cli-installer.test.ts`
- [x] Pre-push hooks: version bump, type-check, lint, format