### PR TITLE
Fix phase implementer base anchoring

### DIFF
--- a/.agents/agents/oat-phase-implementer.md
+++ b/.agents/agents/oat-phase-implementer.md
@@ -1,6 +1,6 @@
 ---
 name: oat-phase-implementer
-version: 1.0.9
+version: 1.0.10
 description: Implements one plan phase end-to-end, commits each task separately, self-checks between tasks, and handles bounded review fixes when resumed by oat-project-implement.
 tools: Read, Write, Edit, Bash, Grep, Glob, Task
 color: cyan
@@ -105,9 +105,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-luna-high.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-luna-high.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-luna-low.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-luna-low.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-luna-medium.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-luna-medium.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-luna-xhigh.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-luna-xhigh.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-sol-high.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-sol-high.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-sol-low.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-sol-low.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-sol-max.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-sol-max.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-sol-medium.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-sol-medium.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-sol-xhigh.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-sol-xhigh.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-terra-high.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-terra-high.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-terra-low.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-terra-low.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-terra-medium.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-terra-medium.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer-gpt-5-6-terra-xhigh.toml
+++ b/.codex/agents/oat-phase-implementer-gpt-5-6-terra-xhigh.toml
@@ -104,9 +104,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.codex/agents/oat-phase-implementer.toml
+++ b/.codex/agents/oat-phase-implementer.toml
@@ -101,9 +101,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-claude-fable-5-thinking-high.md
+++ b/.cursor/agents/oat-phase-implementer-claude-fable-5-thinking-high.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-claude-fable-5-thinking-xhigh.md
+++ b/.cursor/agents/oat-phase-implementer-claude-fable-5-thinking-xhigh.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-claude-sonnet-5-high.md
+++ b/.cursor/agents/oat-phase-implementer-claude-sonnet-5-high.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-composer-2-5.md
+++ b/.cursor/agents/oat-phase-implementer-composer-2-5.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-cursor-grok-4-5-high.md
+++ b/.cursor/agents/oat-phase-implementer-cursor-grok-4-5-high.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-gpt-5-6-luna-high.md
+++ b/.cursor/agents/oat-phase-implementer-gpt-5-6-luna-high.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-gpt-5-6-luna-xhigh.md
+++ b/.cursor/agents/oat-phase-implementer-gpt-5-6-luna-xhigh.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-gpt-5-6-sol-high.md
+++ b/.cursor/agents/oat-phase-implementer-gpt-5-6-sol-high.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-gpt-5-6-sol-max.md
+++ b/.cursor/agents/oat-phase-implementer-gpt-5-6-sol-max.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-gpt-5-6-sol-medium.md
+++ b/.cursor/agents/oat-phase-implementer-gpt-5-6-sol-medium.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-gpt-5-6-sol-xhigh.md
+++ b/.cursor/agents/oat-phase-implementer-gpt-5-6-sol-xhigh.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.cursor/agents/oat-phase-implementer-gpt-5-6-terra-high.md
+++ b/.cursor/agents/oat-phase-implementer-gpt-5-6-terra-high.md
@@ -108,9 +108,12 @@ replaces every task and phase verification command below.
 
 ### 1. Verify Phase Base
 
-Confirm the current worktree is clean and its HEAD equals `phase_base_head` or
-is an allowed descendant of `expected_base_sha`. For a plan-declared parallel
-group, verify this before any task edit.
+Confirm the current worktree is clean and its HEAD exactly equals
+`phase_base_head`. When `expected_base_sha` is supplied, separately confirm
+that `phase_base_head` equals it or is an explicitly allowed descendant. Never
+use ancestry from `expected_base_sha` as a substitute for the exact
+`phase_base_head` check. For a plan-declared parallel group, verify this before
+any task edit.
 
 When smoke containment, ownership registration, expected base, or fixture
 readiness proves the run invalid, return `INVALID_RUN_ABORT` with the evidence.

--- a/.oat/sync/manifest.json
+++ b/.oat/sync/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "oatVersion": "0.2.18",
+  "oatVersion": "0.2.19",
   "entries": [
     {
       "canonicalPath": ".agents/agents/oat-codebase-mapper.md",

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.2.18",
-  "docs-config": "0.2.18",
-  "docs-theme": "0.2.18",
-  "docs-transforms": "0.2.18"
+  "cli": "0.2.19",
+  "docs-config": "0.2.19",
+  "docs-theme": "0.2.19",
+  "docs-transforms": "0.2.19"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/validation/skills.test.ts
+++ b/packages/cli/src/validation/skills.test.ts
@@ -2081,7 +2081,7 @@ describe('validateOatSkills', () => {
 
   it('keeps the complete artifact hygiene block equivalent at every runtime boundary', async () => {
     const runtimeSurfaces = [
-      ['.agents/agents/oat-phase-implementer.md', '1.0.9'],
+      ['.agents/agents/oat-phase-implementer.md', '1.0.10'],
       ['.agents/agents/oat-reviewer.md', '1.1.9'],
       ['.agents/skills/oat-project-review-provide/SKILL.md', '1.3.22'],
       ['.agents/skills/oat-project-review-receive/SKILL.md', '1.5.9'],
@@ -2333,7 +2333,7 @@ describe('validateOatSkills', () => {
       '.agents/skills/oat-project-implement/SKILL.md',
     );
 
-    expect(agent.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('1.0.9');
+    expect(agent.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('1.0.10');
     expect(agent.match(/^description:\s*(.+)$/m)?.[1]).toMatch(
       /implements one plan phase end-to-end/i,
     );
@@ -2344,6 +2344,9 @@ describe('validateOatSkills', () => {
     );
     expect(agent).toMatch(/one\s+verified\s+commit per task/i);
     expect(agent).toContain('between-task transition check');
+    expect(agent).toMatch(
+      /HEAD exactly equals\s+`phase_base_head`[\s\S]{0,300}Never\s+use ancestry from `expected_base_sha` as a substitute/i,
+    );
     expect(agent).toContain('git -c core.hooksPath=/dev/null commit');
     expect(agent).toContain('`--no-verify`');
     expect(agent).toContain('Phase-Wide Self-Review');

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- require phase implementers to start exactly at the orchestrator-recorded `phase_base_head`
- keep `expected_base_sha` ancestry as a separate consistency check
- regenerate provider variants and bump lockstep public packages to 0.2.18

## Test plan
- [x] Run phase implementer validation tests
- [x] Run formatting, lint, and type checks
- [x] Run public package release validation
- [x] Verify provider sync has no drift