### PR TITLE
docs(agents): gate the definition of done on the checks CI runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,12 +17,34 @@
 
 ### Essential Commands
 
+- `pnpm check` - Lint and format checks per package, plus markdownlint over `apps/oat-docs/docs`
 - `pnpm build` - Build all packages and applications (excludes docs for speed)
 - `pnpm build:docs` - Build the docs site and its dependencies
-- `pnpm lint` - Lint code using oxlint
-- `pnpm format` - Check formatting (oxfmt --check); use `pnpm format:fix` to auto-fix
+- `pnpm lint` - Lint code using oxlint, plus `tools/smoke`
+- `pnpm format` - Check formatting (oxfmt --check), plus `.agents/skills/**/*.md` and `tools/smoke`; use `pnpm format:fix` to auto-fix
 - `pnpm type-check` - TypeScript type checking across all packages
 - `pnpm test` - Run tests across the workspace
+
+`pnpm check` and the `pnpm lint`/`pnpm format` pair overlap, but neither
+contains the other, so passing one does not predict the other. Only `pnpm check`
+runs markdownlint over the docs app, which is what catches docs violations such
+as a fenced code block with no language or a skipped heading level. Only
+`pnpm lint` and `pnpm format` reach `tools/smoke` and `.agents/skills/**/*.md`.
+
+### Definition of Done
+
+Every change runs the checks CI gates on, in this order:
+
+1. `pnpm check`
+2. `pnpm type-check`
+3. `pnpm test`
+4. `pnpm build`
+
+CI runs none of `pnpm lint`, `pnpm format`, or `pnpm build:docs`. Run `pnpm lint`
+and `pnpm format` whenever a change touches `tools/smoke` or `.agents/skills`,
+since nothing else covers them, and `pnpm build:docs` when it touches the docs
+app. Changes to publishable packages add `pnpm release:validate`, described
+under Package Management.
 
 ### Development Workflow
 


### PR DESCRIPTION
## Summary

`AGENTS.md` named `pnpm lint` and `pnpm format` as the essential checks, but CI runs neither. It gates on `pnpm check`, which the file never mentioned, so an agent following the documented commands could finish a change that fails CI.

That is not hypothetical. It happened on #178: markdownlint runs only under `pnpm check`, so two docs violations (a fenced code block with no language, a heading skipping h2 to h4) passed local `pnpm lint` and `pnpm format` and failed CI.

## Changes

- Add `pnpm check` to Essential Commands.
- Add a Definition of Done listing the four checks CI actually gates on, in CI's order: `pnpm check`, `pnpm type-check`, `pnpm test`, `pnpm build`.
- Note what each command uniquely covers, since the overlap is partial in both directions.

## Why both commands stay

`pnpm check` and the `pnpm lint`/`pnpm format` pair are not interchangeable:

- Only `pnpm check` runs markdownlint over `apps/oat-docs/docs`.
- Only `pnpm lint` and `pnpm format` reach `tools/smoke` and `.agents/skills/**/*.md`. The root scripts append those globs explicitly, and `packages/cli/assets/**` is oxfmt-ignored, so the bundled skill copies are not a second path to that coverage.

CI runs `pnpm check` but not `pnpm lint` or `pnpm format`, so skill and smoke-tool formatting is currently verified only by whoever runs the local command. This PR documents that rather than changing it; closing the gap in CI is a separate decision.

## Test plan

- [x] `pnpm check`
- [x] `pnpm type-check`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm lint` and `pnpm format`
- [x] Verified against `.github/workflows/ci.yml` that the documented sequence matches the gated steps