### PR TITLE
chore(backlog): track unenforced implementer effort classification

### DIFF
--- a/.oat/repo/pjm/backlog/index.md
+++ b/.oat/repo/pjm/backlog/index.md
@@ -85,33 +85,34 @@
 
 <!-- OAT BACKLOG-INDEX -->
 
-| ID                                       | Title                                                                  | Status | Priority | Scope   | Estimate |
-| ---------------------------------------- | ---------------------------------------------------------------------- | ------ | -------- | ------- | -------- |
-| BL-260711-add-activity-aware-gate        | Add activity-aware gate timeouts                                       | open   | high     | feature | M        |
-| BL-260718-add-oat-wave-lifecycle-cli     | Add oat wave lifecycle CLI command family                              | open   | high     | feature | L        |
-| BL-260720-add-oat-project-complete-auto  | Add oat-project-complete-auto companion skill for autonomous closeouts | open   | high     | task    | M        |
-| BL-260711-add-root-owned-dispatch-broker | Add root-owned dispatch broker for exact OAT subagent launches         | open   | high     | feature | M        |
-| BL-260718-harden-full-surface-gate       | Harden full-surface gate reviews against budget and recursive dispatch | open   | high     | feature | M        |
-| BL-260718-mandatory-skill-load-clause    | Mandatory skill-load clause for lifecycle steps that name skills       | open   | high     | task    | S        |
-| BL-260712-serialize-cli-asset-bundling   | Serialize CLI asset bundling with atomic staging                       | open   | high     | task    | S        |
-| BL-260711-skip-re-review-for-bookkeeping | Skip re-review for bookkeeping-only review findings                    | open   | high     | feature | M        |
-| BL-260718-warn-when-oat-sync-uses        | Warn when oat sync uses a different producing CLI version              | open   | high     | feature | S        |
-| BL-260718-add-generated-runbook          | Add generated-runbook verification command pass                        | open   | medium   | feature | M        |
-| BL-260719-add-pinned-recon-agents        | Add pinned recon agents for reusable orchestration                     | open   | medium   | feature | M        |
-| BL-260718-document-execution-program     | Document execution-program artifact as stable OAT contract             | open   | medium   | feature | M        |
-| BL-260714-executable-backstops           | Executable backstops for contract claims — authoring guidance          | open   | medium   | task    | S        |
-| BL-260718-fix-oat-docs-generate-index    | Fix oat docs generate-index cwd-relative defaults in monorepos         | open   | medium   | task    |          |
-| BL-260706-front-load-recurring-gate      | Front-load recurring gate-finding classes into implementer briefs      | open   | medium   | feature | L        |
-| BL-260712-per-project-override           | Per-project override to disable configured external gates              | open   | medium   | feature | M        |
-| BL-260718-rewrite-worktree-bootstrap     | Rewrite worktree bootstrap-group as tested TypeScript command          | open   | medium   | feature | M        |
-| BL-260713-root-agent-judgment-logging    | Root-agent judgment logging responsibility for project log             | open   | medium   | feature | S        |
-| BL-260718-support-fumadocs-in-oat-docs   | Support Fumadocs in oat docs nav sync (currently MkDocs-only)          | open   | medium   | task    |          |
-| BL-260724-support-provider-directory     | Support provider directory symlinks as full collection sync            | open   | medium   | feature | M        |
-| BL-260726-validate-cursor-pin-effort     | Validate Cursor pin effort rungs at sync time                          | open   | medium   | task    | S        |
-| BL-260726-validate-structured-output     | Validate structured-output contract in gate skill commands             | open   | medium   | task    |          |
-| BL-260708-verify-cursor-gpt-5-6-subagent | Verify Cursor GPT-5.6 subagent model slugs                             | open   | medium   | task    | S        |
-| BL-260725-classify-general-sync-owned    | Classify general sync-owned dirt in project-start preflight            | open   | low      | task    | M        |
-| BL-260719-evaluate-broader-final-gate    | Evaluate broader final-gate freshness policy after narrow optimization | open   | low      | feature | M        |
+| ID                                       | Title                                                                         | Status | Priority | Scope   | Estimate |
+| ---------------------------------------- | ----------------------------------------------------------------------------- | ------ | -------- | ------- | -------- |
+| BL-260711-add-activity-aware-gate        | Add activity-aware gate timeouts                                              | open   | high     | feature | M        |
+| BL-260718-add-oat-wave-lifecycle-cli     | Add oat wave lifecycle CLI command family                                     | open   | high     | feature | L        |
+| BL-260720-add-oat-project-complete-auto  | Add oat-project-complete-auto companion skill for autonomous closeouts        | open   | high     | task    | M        |
+| BL-260711-add-root-owned-dispatch-broker | Add root-owned dispatch broker for exact OAT subagent launches                | open   | high     | feature | M        |
+| BL-260718-harden-full-surface-gate       | Harden full-surface gate reviews against budget and recursive dispatch        | open   | high     | feature | M        |
+| BL-260718-mandatory-skill-load-clause    | Mandatory skill-load clause for lifecycle steps that name skills              | open   | high     | task    | S        |
+| BL-260712-serialize-cli-asset-bundling   | Serialize CLI asset bundling with atomic staging                              | open   | high     | task    | S        |
+| BL-260711-skip-re-review-for-bookkeeping | Skip re-review for bookkeeping-only review findings                           | open   | high     | feature | M        |
+| BL-260718-warn-when-oat-sync-uses        | Warn when oat sync uses a different producing CLI version                     | open   | high     | feature | S        |
+| BL-260718-add-generated-runbook          | Add generated-runbook verification command pass                               | open   | medium   | feature | M        |
+| BL-260719-add-pinned-recon-agents        | Add pinned recon agents for reusable orchestration                            | open   | medium   | feature | M        |
+| BL-260718-document-execution-program     | Document execution-program artifact as stable OAT contract                    | open   | medium   | feature | M        |
+| BL-260714-executable-backstops           | Executable backstops for contract claims — authoring guidance                 | open   | medium   | task    | S        |
+| BL-260718-fix-oat-docs-generate-index    | Fix oat docs generate-index cwd-relative defaults in monorepos                | open   | medium   | task    |          |
+| BL-260706-front-load-recurring-gate      | Front-load recurring gate-finding classes into implementer briefs             | open   | medium   | feature | L        |
+| BL-260712-per-project-override           | Per-project override to disable configured external gates                     | open   | medium   | feature | M        |
+| BL-260718-rewrite-worktree-bootstrap     | Rewrite worktree bootstrap-group as tested TypeScript command                 | open   | medium   | feature | M        |
+| BL-260713-root-agent-judgment-logging    | Root-agent judgment logging responsibility for project log                    | open   | medium   | feature | S        |
+| BL-260718-support-fumadocs-in-oat-docs   | Support Fumadocs in oat docs nav sync (currently MkDocs-only)                 | open   | medium   | task    |          |
+| BL-260724-support-provider-directory     | Support provider directory symlinks as full collection sync                   | open   | medium   | feature | M        |
+| BL-260727-surface-implementer-dispatches | Surface implementer dispatches that sit at the ceiling without classification | open   | medium   | task    | M        |
+| BL-260726-validate-cursor-pin-effort     | Validate Cursor pin effort rungs at sync time                                 | open   | medium   | task    | S        |
+| BL-260726-validate-structured-output     | Validate structured-output contract in gate skill commands                    | open   | medium   | task    |          |
+| BL-260708-verify-cursor-gpt-5-6-subagent | Verify Cursor GPT-5.6 subagent model slugs                                    | open   | medium   | task    | S        |
+| BL-260725-classify-general-sync-owned    | Classify general sync-owned dirt in project-start preflight                   | open   | low      | task    | M        |
+| BL-260719-evaluate-broader-final-gate    | Evaluate broader final-gate freshness policy after narrow optimization        | open   | low      | feature | M        |
 
 <!-- END OAT BACKLOG-INDEX -->
 

--- a/.oat/repo/pjm/backlog/items/BL-260727-surface-implementer-dispatches.md
+++ b/.oat/repo/pjm/backlog/items/BL-260727-surface-implementer-dispatches.md
@@ -1,0 +1,66 @@
+---
+id: BL-260727-surface-implementer-dispatches
+title: Surface implementer dispatches that sit at the ceiling without classification
+status: open
+priority: medium
+scope: task
+scope_estimate: M
+labels:
+  - dispatch
+  - observability
+assignee: null
+created: 2026-07-27T22:27:24.550Z
+updated: 2026-07-27T22:27:24.550Z
+associated_issues: []
+external_plans: []
+---
+
+## Description
+
+Implementer dispatch is supposed to classify a phase's preferred effort from its
+scope, then select `min(preferred, cap)`. `oat-project-implement`'s
+`references/dispatch-and-dry-run.md` defines the classification bands: `low` for
+trivial docs-only, narrow single-file, or mechanical changes; `medium` for normal
+multi-file work; `high` for broad architecture, security boundaries, or repeated
+substantive review failures.
+
+Nothing enforces that step. The resolver validates only that a candidate is
+present in the configured ladder and is not above the ceiling. It has no way to
+tell that a candidate is higher than the phase warrants, so a root that skips
+classification and passes the ceiling as its candidate resolves cleanly and
+leaves no trace of the omission. The failure is silent and produces no error,
+which makes it indistinguishable after the fact from a phase that genuinely
+needed the top rung.
+
+Verified against the resolver on 2026-07-27: under `--ceiling-tier high`,
+candidates from `economy`, `balanced`, and `high` were all accepted, each
+reporting its true `candidateTier`, while an above-ceiling candidate was
+rejected. Downshifting works. The gap is that choosing not to downshift costs
+nothing and is not visible.
+
+This is an observability request, not a proposal to have the resolver overrule
+the root. Classification depends on phase content the resolver cannot see, so
+the root must remain the decider. The aim is to make the decision legible enough
+that a pattern of always dispatching at the cap becomes apparent.
+
+Related: `Dispatch Report V1` already carries per-dispatch report context
+(`--report-scope`, `--report-action`), so it is a plausible home for the
+classification field.
+
+## Acceptance Criteria
+
+- Implementer and fix resolver invocations accept an explicit classified
+  preferred effort or tier, distinct from the ceiling and from the selected
+  candidate.
+- The dispatch report records the classified preference alongside the selected
+  candidate, so `preferred == cap` is distinguishable from an unclassified
+  dispatch that defaulted to the cap.
+- A dispatch whose candidate equals the ceiling without an accompanying
+  classification is reported as such. Warn rather than block; the root retains
+  authority to dispatch at the cap when the phase warrants it.
+- Guidance in `dispatch-and-dry-run.md` states that the ceiling is a maximum
+  rather than a default target, and that passing the cap unclassified is a
+  defect rather than a neutral shortcut.
+- Regression coverage asserts that a below-ceiling candidate from a lower tier
+  resolves successfully and that its classified preference survives into the
+  dispatch report.


### PR DESCRIPTION
## Summary

Files one backlog item. No functional change.

Implementer dispatch is supposed to classify a phase's preferred effort from its scope, then select `min(preferred, cap)`. The classification bands are defined in `oat-project-implement/references/dispatch-and-dry-run.md`: `low` for trivial docs-only or mechanical work, `medium` for normal multi-file, `high` for architecture or security boundaries.

Nothing enforces that step. The resolver validates only that a candidate exists in the configured ladder and is not above the ceiling. It cannot tell that a candidate is higher than the phase warrants, so a root that skips classification and passes the ceiling resolves cleanly and leaves no trace of the omission.

## Evidence

Checked against the resolver rather than inferred from the docs. Under `--ceiling-tier high`:

| candidate | result |
|---|---|
| `gpt-5.6-luna-high` | accepted, `candidateTier=economy` |
| `gpt-5.6-terra-high` | accepted, `candidateTier=balanced` |
| `gpt-5.6-sol-medium` | accepted, `candidateTier=high` |
| `gpt-5.6-sol-max` | rejected, above the `high` ceiling |

Downshifting is fully supported. The gap is that declining to downshift is free and invisible, not that it is blocked.

## Scope

Deliberately an observability request rather than a proposal to have the resolver overrule the root. Classification depends on phase content the resolver cannot see, so the root stays the decider; the aim is to make the decision legible enough that a pattern of always dispatching at the cap becomes apparent.

## Test plan

- [x] `pnpm check`
- [x] Backlog index regenerated with `oat backlog regenerate-index` and stable against `main`