### PR TITLE
chore(ci): update GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
@@ -42,7 +42,7 @@ jobs:
         run: pnpm build:docs
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
@@ -51,4 +51,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: Release ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
## Update GitHub Actions to Node 24-compatible versions

GitHub Actions runners have [deprecated Node.js 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Runs in this repo emit a warning listing actions that still target Node 20 (and some target the even older Node 16/12); they are currently being force-run on Node 24.

Each action below was bumped to its **latest major version**, verified to declare `runs.using: node24` in its `action.yml`:

| Action | From | To |
|---|---|---|
| `actions/checkout` | `v4` | `v7` |
| `actions/configure-pages` | `v5` | `v6` |
| `actions/deploy-pages` | `v4` | `v5` |
| `softprops/action-gh-release` | `v2` | `v3` |

4 reference(s) across 2 file(s).

### Please review before merging

These are **major version bumps**, so some carry breaking changes beyond the Node runtime (notably `slackapi/slack-github-action`, `actions/upload-artifact` / `download-artifact`, `aws-actions/configure-aws-credentials`, and `google-github-actions/auth`). Check the affected workflows still behave as expected.