### PR TITLE
docs(pjm): track native subagent transcript corroboration

### DIFF
--- a/.oat/repo/pjm/backlog/index.md
+++ b/.oat/repo/pjm/backlog/index.md
@@ -4,6 +4,11 @@
 
 ## Curated Overview
 
+- Provider transcript corroboration (2026-08-26) is tracked in
+  `BL-260826-populate-native-subagent`, linked to GitHub issue #211. Codex and
+  Claude can populate the existing optional runtime-observation layer from
+  sanitized metadata, while Cursor remains `not-reported`; this work does not
+  replace materialized roles or any pre-launch dispatch control.
 - GitHub issue triage (2026-08-19) added three high-priority lifecycle
   reliability records: `BL-260820-bind-each-gate-review` (Bind each gate review
   disposition to its exact received ledger event) from #194,
@@ -143,6 +148,7 @@
 | BL-260729-implement-reviewplan-first     | Implement ReviewPlan-first reviewer workflow                                               | open   | high     | feature | L        |
 | BL-260727-make-explainer-run-durability  | Make explainer run durability survive ephemeral environments                               | open   | high     | task    | M        |
 | BL-260718-mandatory-skill-load-clause    | Mandatory skill-load clause for lifecycle steps that name skills                           | open   | high     | task    | S        |
+| BL-260826-populate-native-subagent       | Populate native subagent runtime identity from provider transcript metadata                | open   | high     | feature | M        |
 | BL-260711-skip-re-review-for-bookkeeping | Skip re-review for bookkeeping-only review findings                                        | open   | high     | feature | M        |
 | BL-260820-track-pr-closeout-evidence     | Track PR-closeout evidence freshness against the current head                              | open   | high     | feature | L        |
 | BL-260718-warn-when-oat-sync-uses        | Warn when oat sync uses a different producing CLI version                                  | open   | high     | feature | S        |

--- a/.oat/repo/pjm/backlog/items/BL-260826-populate-native-subagent.md
+++ b/.oat/repo/pjm/backlog/items/BL-260826-populate-native-subagent.md
@@ -1,0 +1,52 @@
+---
+id: BL-260826-populate-native-subagent
+title: Populate native subagent runtime identity from provider transcript metadata
+status: open
+priority: high
+scope: feature
+scope_estimate: M
+labels:
+  - subagents
+  - dispatch
+  - provenance
+  - codex
+  - claude
+assignee: null
+created: 2026-08-26T05:15:31.163Z
+updated: 2026-08-26T05:15:31.163Z
+associated_issues: []
+external_plans: []
+---
+
+## Description
+
+Populate the existing optional runtime-observation layer from sanitized,
+provider-specific native-agent transcript metadata. Codex rollout session and
+turn records can corroborate child lineage, role, model, effort, and service
+tier when present; current Claude native-child transcripts also report model,
+effort, and service tier, while Cursor remains not-reported. Preserve immutable
+configured invocation evidence and every pre-launch policy, ceiling, role,
+authority, fork, and fallback control. Source:
+[GitHub issue #211](https://github.com/voxmedia/open-agent-toolkit/issues/211).
+
+## Acceptance Criteria
+
+- Codex parsing returns source-qualified child lineage, role, model, effort,
+  service tier when present, and the applicable turn without reading
+  conversation content.
+- Codex correlation covers roots, depth-1 and depth-2 children, fork-free
+  launches, and forked histories containing embedded parent records.
+- Claude parsing returns source-qualified child model, effort, and service tier
+  when present while retaining `not-exposed` for an unselectable native effort
+  axis.
+- Cursor runtime identity remains explicitly `not-reported`; requested tool
+  arguments and materialized-pin acceptance never become runtime observation.
+- Dispatch reports preserve immutable configured invocation and record matching,
+  missing, and mismatching observations separately. A post-acceptance mismatch
+  cannot trigger replacement, fallback, or retry.
+- Metadata-only fixtures and a current Codex depth-2 integration check cover the
+  parsers without storing prompts or message content.
+- Documentation distinguishes harness-applied settings from provider-backend
+  attestation and uses provenance values implemented by the production schema.
+- Codex materialized roles and all provider policy, ceiling, selection,
+  authority, fork, and fallback controls remain unchanged.


### PR DESCRIPTION
## Purpose

Track the verified provider-transcript follow-up from #211 in the repository backlog without changing dispatch runtime behavior.

## Changes

- [x] Add `BL-260826-populate-native-subagent` with provider-specific constraints and acceptance criteria.
- [x] Regenerate the managed backlog index and add the item to the curated overview.

## Testing

- [x] `pnpm check`
- [x] `pnpm type-check`
- [ ] `pnpm test` — core package tests completed, but the aggregate command stalled in the existing smoke cleanup SIGTERM harness after subtest 69; the command was stopped after confirming no progress. This is tracked by `BL-260818-bound-the-smoke-cleanup`.
- [x] `pnpm build`
- [x] `pnpm run check:skill-bumps`
- [x] `pnpm release:check-versions`
- [x] `pnpm release:validate`
- [x] `pnpm build:docs`
- [x] `pnpm test:skills`
- [x] `pnpm test:release`
- [x] Backlog index regeneration, targeted Markdown lint, YAML validation, and `git diff --check`

## Breaking CLI grammar changes

- [x] Not applicable
- [ ] This PR changes CLI command or option placement.

## Notes

Tracks #211. This PR is planning/backlog only; it does not implement transcript parsing or change provider dispatch behavior.