### PR TITLE
chore(pjm): distinguish external plan readiness

### DIFF
--- a/.oat/repo/pjm/backlog/index.md
+++ b/.oat/repo/pjm/backlog/index.md
@@ -4,6 +4,11 @@
 
 ## Curated Overview
 
+- External planning now distinguishes plan readiness from execution readiness:
+  well-scoped items remain eligible for dated, current-main-pinned plans while
+  hard dependencies keep execution explicitly blocked. The missing
+  `oat-repo-improve` skill and template enforcement is tracked in
+  `BL-260830-distinguish-external-plan`.
 - `BL-260830-migrate-the-legacy-pjm` completed the repository's administrative
   reference-layout cleanup: all 23 legacy decisions were migrated, 13 residual
   work records and five product-decision records received canonical backlog
@@ -191,6 +196,7 @@
 | BL-260711-add-root-owned-dispatch-broker | Add root-owned dispatch broker for exact OAT subagent launches                                        | open   | high     | feature    | M        |
 | BL-260820-bind-each-gate-review          | Bind each gate review disposition to its exact received ledger event                                  | open   | high     | task       | M        |
 | BL-260830-clarify-quick-mode-resume      | Clarify quick-mode resume routing from oat-project-plan                                               | open   | high     | feature    | S        |
+| BL-260830-distinguish-external-plan      | Distinguish external-plan readiness from execution readiness                                          | open   | high     | task       | M        |
 | BL-260820-emit-source-qualified          | Emit source-qualified provenance envelopes for review and gate receipts                               | open   | high     | feature    | M        |
 | BL-260806-fail-closed-when-configured    | Fail closed when configured closeout snapshot is absent                                               | open   | high     | task       | M        |
 | BL-260826-gate-targets-must-not-yield    | Gate targets must not yield on background work in headless mode                                       | open   | high     | task       | M        |

--- a/.oat/repo/pjm/backlog/items/BL-260830-distinguish-external-plan.md
+++ b/.oat/repo/pjm/backlog/items/BL-260830-distinguish-external-plan.md
@@ -1,0 +1,45 @@
+---
+id: BL-260830-distinguish-external-plan
+title: Distinguish external-plan readiness from execution readiness
+status: open
+priority: high
+scope: task
+scope_estimate: M
+labels:
+  - repo-improve
+  - external-plans
+  - dependencies
+  - planning
+  - workflow
+assignee: null
+created: 2026-08-30T23:01:52.697Z
+updated: 2026-08-30T23:01:52.697Z
+associated_issues: []
+external_plans: []
+---
+
+## Description
+
+Extend the oat-repo-improve external-plan contract so a well-scoped backlog item can be planned while execution remains blocked on named hard dependencies. Require bidirectional source-plan links, linked dependency evidence, hard-versus-soft classification, named unblock states, current-main provenance, and explicit revalidation triggers before import or execution.
+
+## Acceptance Criteria
+
+- `oat-repo-improve` evaluates `plan_ready` separately from
+  `execution_ready`; an unshipped dependency does not disqualify a coherent,
+  well-scoped item from receiving an external plan.
+- Every generated plan and its source backlog item reverse-link each other.
+  The plan also links related backlog items, projects, pull requests, and
+  external plans by stable ID, title, repository path, or URL.
+- Dependencies are classified as hard or soft. A plan with an unsatisfied hard
+  dependency marks execution `BLOCKED` and names the exact dependency state
+  required to unblock it; soft dependencies state their expected effect.
+- Dated plan filenames and plan provenance record the exact current
+  `origin/main` commit at planning time, rather than an arbitrary working-tree
+  HEAD.
+- The contract requires revalidation before import or execution when enough
+  time has elapsed to exceed the named freshness policy, `origin/main`
+  advances, cited source surfaces change, backlog or issue intent changes, or a
+  dependency lands after planning.
+- Candidate-table, plan-template, and verification fixtures cover a plan-ready
+  item whose execution is blocked by a hard dependency and a plan-ready item
+  with only a soft dependency.

--- a/.oat/repo/pjm/backlog/reviews/priority-alignment.md
+++ b/.oat/repo/pjm/backlog/reviews/priority-alignment.md
@@ -3,7 +3,7 @@
 <!-- markdownlint-disable MD013 -->
 
 **Date:** 2026-08-30 (America/Chicago)
-**Status:** Active — Post-PR #242 alignment. The provider-root contract shipped;
+**Status:** Active — Post-PR #244 alignment. The provider-root contract shipped;
 the scope/provider umbrella and scope-adoption diagnostics are active in
 separate worktrees; ReviewPlan remains an existing project; and the two bounded
 gate projects remain independent launch candidates.
@@ -44,6 +44,31 @@ scope/provider umbrella, not an active lane.
 - The headless and structured-output projects remain independent probes. They
   support review/gate integrity without taking ownership of its lifecycle model.
 
+## External-plan readiness
+
+Plan readiness and execution readiness are separate decisions. A coherent,
+well-scoped backlog item may receive an external plan even when execution is
+blocked by an unshipped hard dependency. Dependency state alone is not a reason
+to exclude an item from the next `oat-repo-improve` pass.
+
+For every dependency-aware external plan:
+
+- reverse-link the source backlog item and plan;
+- link related backlog items, projects, pull requests, and external plans by
+  stable ID, title, repository path, or URL;
+- classify each dependency as hard or soft;
+- mark execution `BLOCKED` for unsatisfied hard dependencies and name the exact
+  state that unblocks execution;
+- use a dated filename and record the exact current `origin/main` commit; and
+- revalidate before import or execution when the freshness window expires,
+  `origin/main` advances, cited surfaces change, backlog or issue intent
+  changes, or a dependency lands after planning.
+
+[BL-260830-distinguish-external-plan](../items/BL-260830-distinguish-external-plan.md)
+owns the missing `oat-repo-improve` skill and plan-template enforcement. Until
+that item ships, apply this section as the operator rule for candidate
+selection and plan review.
+
 ## Recommended concurrent stack
 
 These lanes are peers except where the dependencies above say otherwise:
@@ -54,9 +79,10 @@ These lanes are peers except where the dependencies above say otherwise:
 3. Reconcile the existing ReviewPlan project and PR #190.
 4. Launch the existing headless and structured-output projects when capacity
    allows.
-5. Use oat-repo-improve only for remaining well-scoped backlog items that do
-   not already belong to one of these projects and do not require deeper
-   discovery.
+5. Use oat-repo-improve for remaining well-scoped backlog items that do not
+   already belong to one of these projects and do not require deeper discovery.
+   Include plan-ready items whose execution is dependency-blocked, with the
+   dependency and revalidation controls above.
 
 ## Priority clusters
 
@@ -97,10 +123,14 @@ The legacy tree has been retired. Eighteen reviewed records now have canonical
   project-split dogfood, persisted instruction-sync strategy, strict YAML skill
   validation, remote respond/summarize skills, and the provide-remote helper
   CLI wiring.
-- Revalidate scope or dependency before plan generation: per-CLAUDE adoption
-  opt-out (soft-depends on persisted strategy), residual CLI P2/P3 cleanup,
-  documentation-aware discovery policy from #205, and control-plane-backed
-  plan/implementation reads.
+- Plan now when scope is coherent, even if execution is dependency-blocked:
+  per-CLAUDE adoption opt-out (soft-depends on persisted strategy) and the
+  documentation-aware discovery policy from #205. Record dependency links,
+  readiness state, named unblock conditions, and revalidation triggers.
+- Revalidate scope before plan generation where the work itself may have
+  drifted: residual CLI P2/P3 cleanup and control-plane-backed
+  plan/implementation reads. Unshipped dependencies alone do not make these
+  items plan-ineligible.
 - Exclude from implementation planning while labeled `needs-discussion`:
   bounded durable-reference reads, generic Jira refinement ownership,
   listProjects fast-path approval, dependency-intelligence ownership,
@@ -108,7 +138,7 @@ The legacy tree has been retired. Eighteen reviewed records now have canonical
 
 ## Shared-file coordination
 
-- This cleanup PR owns .oat/repo/pjm/, legacy .oat/repo/reference/ layout
+- PR #244 owns the completed `.oat/repo/pjm/` and legacy reference-layout
   migration, removal of obsolete native-read Cursor skill mirrors, and the
   verifying issue-triage record.
 - Active implementation projects own their project artifacts and implementation
@@ -121,6 +151,7 @@ The legacy tree has been retired. Eighteen reviewed records now have canonical
 
 | Date       | Update                                                                                                                                                                                                                     |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-08-30 | Separated plan readiness from execution readiness for the upcoming improve pass and captured the missing skill/template enforcement in `BL-260830-distinguish-external-plan`.                                              |
 | 2026-08-30 | Promoted 18 reviewed legacy records into the canonical backlog, folded six terminal records into completed history, removed the parallel legacy tree, and separated improve-ready work from needs-discussion decisions.    |
 | 2026-08-30 | Archived the PR #242 provider-root prerequisite, recorded active project ownership, moved legacy PJM cleanup into the direct administrative lane, and reserved future oat-repo-improve work for unowned well-scoped items. |
 | 2026-08-29 | Replaced the stale 2026-08-19 alignment with a post-PR #231 grouping and sequencing view.                                                                                                                                  |


### PR DESCRIPTION
## Summary

- distinguish external-plan readiness from execution readiness in the active backlog alignment
- capture `BL-260830-distinguish-external-plan` for the missing `oat-repo-improve` skill and plan-template enforcement
- allow coherent dependency-blocked items to receive plans while requiring hard/soft dependency links, named unblock states, current-main provenance, and revalidation triggers
- update the post-#244 ownership language; the retired `reference/legacy-pjm` tree remains absent

## Verification

- `pnpm run cli -- pjm doctor --json`
- `pnpm check`
- push hooks: release version check, skill bump check, type-check, lint, and format

## Context

PR #244 already merged the legacy PJM migration and removed the parallel legacy tree. This follow-up records the operator rule for the upcoming `oat-repo-improve` pass without changing the skill implementation in the alignment PR.