### PR TITLE
fix: stop user-scope sync from aborting on duplicate Cursor roles

### DIFF
--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.2.52",
-  "docs-config": "0.2.52",
-  "docs-theme": "0.2.52",
-  "docs-transforms": "0.2.52"
+  "cli": "0.2.53",
+  "docs-config": "0.2.53",
+  "docs-theme": "0.2.53",
+  "docs-transforms": "0.2.53"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/__tests__/synced-fixture.ts
+++ b/packages/cli/src/__tests__/synced-fixture.ts
@@ -17,6 +17,13 @@ function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
 }
 
+const TEMP_TREE_RM_OPTIONS = {
+  recursive: true,
+  force: true,
+  maxRetries: 5,
+  retryDelay: 50,
+} as const;
+
 function configureClone(cloneDir: string): void {
   git(cloneDir, ['config', 'user.email', 'synced-fixture@example.com']);
   git(cloneDir, ['config', 'user.name', 'Synced Fixture']);
@@ -46,7 +53,7 @@ export async function createSyncedFixture(
       configureClone(cloneB);
     }
   } catch (error) {
-    await rm(rootDir, { recursive: true, force: true });
+    await rm(rootDir, TEMP_TREE_RM_OPTIONS);
     throw error;
   }
 
@@ -55,7 +62,7 @@ export async function createSyncedFixture(
     originDir,
     cloneA,
     cloneB,
-    cleanup: () => rm(rootDir, { recursive: true, force: true }),
+    cleanup: () => rm(rootDir, TEMP_TREE_RM_OPTIONS),
   };
 }
 

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -76,6 +76,7 @@ import {
   type HookInstallInfo,
   installHook,
   isHookInstalled,
+  mergeUserScopeMaterializationEntries,
   scanBundledManagedAgents,
   scanCanonical,
   uninstallHook,
@@ -317,7 +318,10 @@ async function collectStraysDefault(
   );
   const materializationCanonicalEntries =
     scope === 'user' && hasMaterializationAdapter
-      ? [...canonicalEntries, ...(await scanBundledManagedAgents())]
+      ? mergeUserScopeMaterializationEntries(
+          canonicalEntries,
+          await scanBundledManagedAgents(),
+        )
       : canonicalEntries;
   const codexExtensionPlan = adaptersToScan.some(
     (adapter) => adapter.name === 'codex',

--- a/packages/cli/src/commands/project/list.integration.test.ts
+++ b/packages/cli/src/commands/project/list.integration.test.ts
@@ -94,7 +94,14 @@ describe('oat project list coordination integration', () => {
 
   afterEach(async () => {
     await Promise.all(
-      tempDirs.map(async (dir) => rm(dir, { recursive: true, force: true })),
+      tempDirs.map(async (dir) =>
+        rm(dir, {
+          recursive: true,
+          force: true,
+          maxRetries: 5,
+          retryDelay: 50,
+        }),
+      ),
     );
     tempDirs.length = 0;
   });

--- a/packages/cli/src/commands/status/index.ts
+++ b/packages/cli/src/commands/status/index.ts
@@ -81,6 +81,7 @@ import {
   type CanonicalEntry,
   HOOK_DRIFT_WARNING,
   HOOK_STRAY_INFO,
+  mergeUserScopeMaterializationEntries,
   scanBundledManagedAgents,
   scanCanonical,
 } from '@engine/index';
@@ -975,10 +976,10 @@ async function collectScopeReports(
     scope === 'user' &&
     (activeExtensionProviders.has('codex') ||
       activeExtensionProviders.has('cursor'))
-      ? [
-          ...canonicalEntries,
-          ...(await dependencies.scanBundledManagedAgents()),
-        ]
+      ? mergeUserScopeMaterializationEntries(
+          canonicalEntries,
+          await dependencies.scanBundledManagedAgents(),
+        )
       : canonicalEntries;
   const codexExtensionPlan = activeExtensionProviders.has('codex')
     ? await dependencies.computeCodexProjectExtensionPlan(

--- a/packages/cli/src/commands/sync/index.test.ts
+++ b/packages/cli/src/commands/sync/index.test.ts
@@ -67,6 +67,7 @@ interface HarnessOptions {
   useDiskCodexExtension?: boolean;
   useDiskScanner?: boolean;
   useDiskBundledCodexAgents?: boolean;
+  bundledManagedAgents?: CanonicalEntry[];
   extraMaterializationExtensions?: SyncMaterializationExtension[];
 }
 
@@ -426,7 +427,7 @@ function createHarness(options: HarnessOptions = {}): {
     scanCanonical,
     scanBundledManagedAgents: options.useDiskBundledCodexAgents
       ? vi.fn(scanBundledManagedAgentsFromDisk)
-      : vi.fn(async () => []),
+      : vi.fn(async () => options.bundledManagedAgents ?? []),
     getAdapters: () => adapters,
     getConfigAwareAdapters,
     ...(options.providerContextResolver
@@ -3352,6 +3353,48 @@ describe('createSyncCommand', () => {
         message: `Cannot remove canonical provider views while source exists: ${removed}`,
       });
       expect(computeSyncPlan).not.toHaveBeenCalled();
+    });
+
+    it('prefers bundled managed agents over user copies for user-scope extensions', async () => {
+      const adapter = createCodexAdapter();
+      const bundledReviewer: CanonicalEntry = {
+        name: 'oat-reviewer.md',
+        type: 'agent',
+        canonicalPath: '/bundle/agents/oat-reviewer.md',
+        isFile: true,
+      };
+      const { command, computeCodexProjectExtensionPlan } = createHarness({
+        adapters: [adapter],
+        configAwareResults: [
+          {
+            activeAdapters: [adapter],
+            detectedUnset: [],
+            detectedDisabled: [],
+          },
+        ],
+        canonicalEntriesByScope: {
+          user: [
+            createAgentCanonicalEntry('oat-reviewer.md', '/tmp/home'),
+            createAgentCanonicalEntry('oat-codebase-mapper.md', '/tmp/home'),
+          ],
+        },
+        bundledManagedAgents: [bundledReviewer],
+      });
+
+      await runSyncCommand(command, {
+        globalArgs: ['--scope', 'user'],
+        commandArgs: ['--dry-run'],
+      });
+
+      expect(computeCodexProjectExtensionPlan).toHaveBeenCalledWith(
+        '/tmp/home',
+        [
+          bundledReviewer,
+          createAgentCanonicalEntry('oat-codebase-mapper.md', '/tmp/home'),
+        ],
+        undefined,
+        expect.objectContaining({ userConfigDir: '/tmp/home/.oat' }),
+      );
     });
 
     it('forwards the exact filter into user-scope materialization extension planning', async () => {

--- a/packages/cli/src/commands/sync/index.ts
+++ b/packages/cli/src/commands/sync/index.ts
@@ -21,6 +21,7 @@ import {
 import {
   computeSyncPlan,
   executeSyncPlan,
+  mergeUserScopeMaterializationEntries,
   scanBundledManagedAgents,
   scanCanonical,
 } from '@engine/index';
@@ -456,7 +457,10 @@ async function computePlans(
 
     const extensionCanonical =
       scope === 'user' && enabledExtensions.length > 0
-        ? [...canonical, ...(await dependencies.scanBundledManagedAgents())]
+        ? mergeUserScopeMaterializationEntries(
+            canonical,
+            await dependencies.scanBundledManagedAgents(),
+          )
         : canonical;
     const materializationExtensionPlans = await Promise.all(
       enabledExtensions.map((extension) =>

--- a/packages/cli/src/engine/index.ts
+++ b/packages/cli/src/engine/index.ts
@@ -36,6 +36,8 @@ export {
 export { assertSafeProviderMutationPath } from './provider-path-safety';
 export type { CanonicalEntry } from './scanner';
 export {
+  materializationCanonicalPathAllowed,
+  mergeUserScopeMaterializationEntries,
   scanBundledManagedAgents,
   scanBundledManagedCodexAgents,
   scanCanonical,

--- a/packages/cli/src/engine/scanner.test.ts
+++ b/packages/cli/src/engine/scanner.test.ts
@@ -4,7 +4,13 @@ import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { scanBundledManagedAgents, scanCanonical } from './scanner';
+import {
+  materializationCanonicalPathAllowed,
+  mergeUserScopeMaterializationEntries,
+  scanBundledManagedAgents,
+  scanCanonical,
+  type CanonicalEntry,
+} from './scanner';
 
 describe('scanCanonical', () => {
   const tempDirs: string[] = [];
@@ -119,6 +125,66 @@ describe('scanCanonical', () => {
       'oat-reviewer.md',
     ]);
     expect(entries.every((entry) => entry.type === 'agent')).toBe(true);
+  });
+
+  it('drops user copies of bundled managed roles and keeps other canonical agents', () => {
+    const userReviewer: CanonicalEntry = {
+      name: 'oat-reviewer.md',
+      type: 'agent',
+      canonicalPath: '/home/user/.agents/agents/oat-reviewer.md',
+      isFile: true,
+    };
+    const userMapper: CanonicalEntry = {
+      name: 'oat-codebase-mapper.md',
+      type: 'agent',
+      canonicalPath: '/home/user/.agents/agents/oat-codebase-mapper.md',
+      isFile: true,
+    };
+    const bundledReviewer: CanonicalEntry = {
+      name: 'oat-reviewer.md',
+      type: 'agent',
+      canonicalPath: '/bundle/agents/oat-reviewer.md',
+      isFile: true,
+    };
+    const bundledImplementer: CanonicalEntry = {
+      name: 'oat-phase-implementer.md',
+      type: 'agent',
+      canonicalPath: '/bundle/agents/oat-phase-implementer.md',
+      isFile: true,
+    };
+
+    const merged = mergeUserScopeMaterializationEntries(
+      [userReviewer, userMapper],
+      [bundledImplementer, bundledReviewer],
+    );
+
+    expect(merged.filter((entry) => entry.name === 'oat-reviewer.md')).toEqual([
+      bundledReviewer,
+    ]);
+    expect(merged).toEqual(
+      expect.arrayContaining([bundledImplementer, userMapper]),
+    );
+    expect(merged).not.toContainEqual(userReviewer);
+  });
+
+  it('treats bundled managed agents as matching home-relative install filters', () => {
+    const bundledReviewer: CanonicalEntry = {
+      name: 'oat-reviewer.md',
+      type: 'agent',
+      canonicalPath: '/bundle/agents/oat-reviewer.md',
+      isFile: true,
+    };
+
+    expect(
+      materializationCanonicalPathAllowed('/home/user', bundledReviewer, [
+        '.agents/agents/oat-reviewer.md',
+      ]),
+    ).toBe(true);
+    expect(
+      materializationCanonicalPathAllowed('/home/user', bundledReviewer, [
+        '.agents/agents/oat-phase-implementer.md',
+      ]),
+    ).toBe(false);
   });
 
   it('returns empty array when .agents/ does not exist', async () => {

--- a/packages/cli/src/engine/scanner.ts
+++ b/packages/cli/src/engine/scanner.ts
@@ -99,6 +99,64 @@ export async function scanBundledManagedAgents(): Promise<CanonicalEntry[]> {
   }));
 }
 
+/**
+ * User-scope Codex/Cursor materialization reads the bundled managed role files,
+ * not the installed copies under `~/.agents/agents/`. Concatenating both lists
+ * produces the same Cursor/Codex role name twice and aborts the whole sync.
+ */
+export function mergeUserScopeMaterializationEntries(
+  canonicalEntries: CanonicalEntry[],
+  bundledManagedAgents: CanonicalEntry[],
+): CanonicalEntry[] {
+  const bundledNames = new Set(bundledManagedAgents.map((entry) => entry.name));
+  const merged: CanonicalEntry[] = [];
+  const seenBundledNames = new Set<string>();
+
+  for (const entry of bundledManagedAgents) {
+    if (seenBundledNames.has(entry.name)) {
+      continue;
+    }
+    seenBundledNames.add(entry.name);
+    merged.push(entry);
+  }
+
+  for (const entry of canonicalEntries) {
+    if (entry.type === 'agent' && bundledNames.has(entry.name)) {
+      continue;
+    }
+    merged.push(entry);
+  }
+
+  return merged;
+}
+
+export function materializationCanonicalPathAllowed(
+  scopeRoot: string,
+  canonicalEntry: CanonicalEntry,
+  allowedCanonicalPaths?: string[],
+): boolean {
+  if (!allowedCanonicalPaths?.length) {
+    return true;
+  }
+
+  const allowed = new Set(allowedCanonicalPaths);
+  const relativePath = relative(
+    scopeRoot,
+    canonicalEntry.canonicalPath,
+  ).replaceAll('\\', '/');
+  if (allowed.has(relativePath)) {
+    return true;
+  }
+
+  return (
+    canonicalEntry.type === 'agent' &&
+    canonicalEntry.isFile &&
+    allowed.has(
+      join('.agents', 'agents', canonicalEntry.name).replaceAll('\\', '/'),
+    )
+  );
+}
+
 /** @deprecated Use scanBundledManagedAgents for provider-neutral materialization. */
 export const scanBundledManagedCodexAgents = scanBundledManagedAgents;
 

--- a/packages/cli/src/providers/codex/codec/sync-extension.ts
+++ b/packages/cli/src/providers/codex/codec/sync-extension.ts
@@ -16,7 +16,10 @@ import {
   type WorkflowDispatchRouteTarget,
 } from '@config/oat-config';
 import { resolveEffectiveConfig } from '@config/resolve';
-import type { CanonicalEntry } from '@engine/index';
+import {
+  materializationCanonicalPathAllowed,
+  type CanonicalEntry,
+} from '@engine/index';
 import { CliError } from '@errors/index';
 import { ensureDir, fileExists } from '@fs/io';
 import { validateRealPathWithinScope } from '@fs/paths';
@@ -93,6 +96,7 @@ interface DesiredCodexRole {
   configFile: string;
   rolePath: string;
   content: string;
+  sourcePath: string;
 }
 
 interface CodexMaterializationTarget {
@@ -128,16 +132,11 @@ function canonicalPathAllowed(
   canonicalEntry: CanonicalEntry,
   allowedCanonicalPaths?: string[],
 ): boolean {
-  if (!allowedCanonicalPaths?.length) {
-    return true;
-  }
-
-  const allowedSet = new Set(allowedCanonicalPaths);
-  const relativeCanonicalPath = toRelativePath(
+  return materializationCanonicalPathAllowed(
     scopeRoot,
-    canonicalEntry.canonicalPath,
+    canonicalEntry,
+    allowedCanonicalPaths,
   );
-  return allowedSet.has(relativeCanonicalPath);
 }
 
 async function readOptionalFile(path: string): Promise<string | null> {
@@ -183,6 +182,7 @@ async function desiredRolesFromCanonical(
       configFile: exported.configFile,
       rolePath: join(scopeRoot, '.codex', exported.configFile),
       content: exported.content,
+      sourcePath: entry.canonicalPath,
     });
 
     if (CODEX_MATERIALIZED_BASE_ROLES.has(exported.roleName)) {
@@ -201,20 +201,23 @@ async function desiredRolesFromCanonical(
             materialized.content,
             target.owner,
           ),
+          sourcePath: entry.canonicalPath,
         });
       }
     }
   }
 
   const roleContents = new Map<string, string>();
+  const sourceByRoleName = new Map<string, string>();
   for (const role of roles) {
     const existing = roleContents.get(role.roleName);
     if (existing !== undefined && existing !== role.content) {
       throw new CliError(
-        `Distinct Codex targets produced the same role name ${role.roleName}. Refusing ambiguous role writes.`,
+        `Duplicate Codex role name ${role.roleName} from ${sourceByRoleName.get(role.roleName) ?? 'an earlier canonical agent'} and ${role.sourcePath}. Refusing ambiguous role writes.`,
       );
     }
     roleContents.set(role.roleName, role.content);
+    sourceByRoleName.set(role.roleName, role.sourcePath);
   }
 
   return roles.sort((left, right) =>

--- a/packages/cli/src/providers/cursor/codec/sync-extension.test.ts
+++ b/packages/cli/src/providers/cursor/codec/sync-extension.test.ts
@@ -445,6 +445,32 @@ describe('cursor sync extension', () => {
     ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('names both canonical paths when two agents produce the same Cursor role', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'oat-cursor-dup-home-'));
+    const bundle = await mkdtemp(join(tmpdir(), 'oat-cursor-dup-bundle-'));
+    tempDirs.push(home, bundle);
+    const userEntries = await createCanonicalEntries(home);
+    const bundledEntries = await createCanonicalEntries(bundle, [
+      'oat-reviewer',
+    ]);
+    await mkdir(join(home, '.oat'), { recursive: true });
+    await writeFile(
+      join(home, '.oat', 'config.json'),
+      configWithCursorCandidates(['claude-fable-5-xhigh']),
+    );
+
+    await expect(
+      computeCursorProjectExtensionPlan(
+        home,
+        [...userEntries, ...bundledEntries],
+        undefined,
+        { userConfigDir: join(home, '.oat') },
+      ),
+    ).rejects.toThrow(
+      `Duplicate Cursor role name oat-reviewer-claude-fable-5-xhigh from ${join(home, '.agents', 'agents', 'oat-reviewer.md')} and ${join(bundle, '.agents', 'agents', 'oat-reviewer.md')}. Refusing ambiguous role writes.`,
+    );
+  });
+
   it('materializes user-scope canonical agents under the user provider root only', async () => {
     const home = await mkdtemp(join(tmpdir(), 'oat-cursor-user-scope-'));
     tempDirs.push(home);

--- a/packages/cli/src/providers/cursor/codec/sync-extension.ts
+++ b/packages/cli/src/providers/cursor/codec/sync-extension.ts
@@ -19,7 +19,10 @@ import {
 } from '@config/dispatch-matrix';
 import { normalizeProjectPath, resolveActiveProject } from '@config/oat-config';
 import { resolveEffectiveConfig } from '@config/resolve';
-import type { CanonicalEntry } from '@engine/index';
+import {
+  materializationCanonicalPathAllowed,
+  type CanonicalEntry,
+} from '@engine/index';
 import { CliError } from '@errors/index';
 import { ensureDir, fileExists } from '@fs/io';
 import { validateRealPathWithinScope } from '@fs/paths';
@@ -354,11 +357,10 @@ function canonicalPathAllowed(
   canonicalEntry: CanonicalEntry,
   allowedCanonicalPaths?: string[],
 ): boolean {
-  if (!allowedCanonicalPaths?.length) {
-    return true;
-  }
-  return new Set(allowedCanonicalPaths).has(
-    toRelativePath(scopeRoot, canonicalEntry.canonicalPath),
+  return materializationCanonicalPathAllowed(
+    scopeRoot,
+    canonicalEntry,
+    allowedCanonicalPaths,
   );
 }
 
@@ -367,6 +369,7 @@ async function desiredRolesFromCanonical(
   targets: CursorMaterializationTarget[],
 ): Promise<CursorMaterializedAgent[]> {
   const desired: CursorMaterializedAgent[] = [];
+  const sourceByRoleName = new Map<string, string>();
   for (const entry of canonicalEntries) {
     if (
       entry.type !== 'agent' ||
@@ -384,25 +387,22 @@ async function desiredRolesFromCanonical(
       continue;
     }
     for (const target of targets) {
-      desired.push(
-        materializeCursorAgent({
-          agent,
-          mapping: target.mapping,
-          owner: target.owner,
-        }),
-      );
+      const role = materializeCursorAgent({
+        agent,
+        mapping: target.mapping,
+        owner: target.owner,
+      });
+      const existingSource = sourceByRoleName.get(role.roleName);
+      if (existingSource) {
+        throw new CliError(
+          `Duplicate Cursor role name ${role.roleName} from ${existingSource} and ${entry.canonicalPath}. Refusing ambiguous role writes.`,
+        );
+      }
+      sourceByRoleName.set(role.roleName, entry.canonicalPath);
+      desired.push(role);
     }
   }
 
-  const names = new Set<string>();
-  for (const role of desired) {
-    if (names.has(role.roleName)) {
-      throw new CliError(
-        `Distinct Cursor targets produced the same Cursor role name ${role.roleName}. Refusing ambiguous role writes.`,
-      );
-    }
-    names.add(role.roleName);
-  }
   return desired.sort((left, right) =>
     left.roleName.localeCompare(right.roleName),
   );

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Summary
- User-scope `oat sync` concatenated `~/.agents/agents` with the bundled managed roles (`oat-phase-implementer`, `oat-reviewer`). Cursor then produced the same role name twice and aborted the entire sync, which also blocked `oat tools update --pack … --scope user`.
- Prefer the bundled copies of those roles for Codex/Cursor materialization, keep other user agents, and name both canonical paths if a real collision remains.
- Lockstep public packages 0.2.52 → 0.2.53.

## Test plan
- [ ] `oat sync --scope user` with Cursor candidates in `~/.oat/config.json` and home copies of `oat-phase-implementer.md` / `oat-reviewer.md` completes without the duplicate-role abort
- [ ] `oat tools update --pack workflows --scope user` gets past auto-sync
- [ ] Remaining true collisions still fail and name both canonical paths
- [ ] `pnpm --filter @open-agent-toolkit/cli exec vitest run src/engine/scanner.test.ts src/providers/cursor/codec/sync-extension.test.ts src/commands/sync/index.test.ts`