### PR TITLE
docs(pjm): close wave 3 of the execution program

### DIFF
--- a/.oat/repo/pjm/backlog/archived/BL-260906-wave-3-external-plan.md
+++ b/.oat/repo/pjm/backlog/archived/BL-260906-wave-3-external-plan.md
@@ -1,7 +1,7 @@
 ---
 id: BL-260906-wave-3-external-plan
 title: Wave 3 external-plan corrections for the program refresh
-status: open
+status: closed
 priority: low
 scope: task
 scope_estimate: XS
@@ -10,7 +10,7 @@ labels:
   - external-plans
 assignee: null
 created: 2026-09-06T14:10:09.587Z
-updated: 2026-09-06T14:10:09.587Z
+updated: '2026-09-06T16:06:40Z'
 associated_issues: []
 external_plans: []
 ---

--- a/.oat/repo/pjm/backlog/completed.md
+++ b/.oat/repo/pjm/backlog/completed.md
@@ -8,6 +8,7 @@
 
 ## Completed Items
 
+- 2026-09-06 — BL-260906-wave-3-external-plan — Wave 3 external-plan corrections for the program refresh — Applied in the wave-3 close program refresh: call-site plan In-scope and :608 alignment record; sync --scope project convention on all three plans; execution records appended
 - 2026-09-06 — BL-260714-executable-backstops — Executable backstops for contract claims — authoring guidance — Wave 3 p03: create-oat-skill and oat-project-design require every standing claim to name its executable owner and ship its backstop in the same PR; skills.test.ts pins the rule with fence-, comment-, and indent-aware extraction
 - 2026-09-06 — BL-260826-deterministic-smoke-tier-leaks — Deterministic smoke tier leaks worktrees on interrupted runs — Wave 3 p02: smoke runner reserves nested resources before git worktree add, cleanup reconciles reserved entries with re-derived ownership invariants, every deletion path re-reads the tip; residual window documented and pinned
 - 2026-09-06 — BL-260818-require-repo-wide-call-site — Require repo-wide call-site sweeps for cross-cutting options in phase-implementer guidance — Wave 3 p01: oat-phase-implementer requires a repo-wide call-site sweep for cross-cutting options with an effective task boundary and a stop-and-report branch; pinned by six negative probes and a deny-list in post-implement-sequence-contracts.test.ts

--- a/.oat/repo/pjm/backlog/index.md
+++ b/.oat/repo/pjm/backlog/index.md
@@ -307,7 +307,6 @@
 | BL-260906-run-scripts-worktree-init-test | Run scripts/worktree/init.test.mjs under a repository gate                                            | open   | low      | task       | XS       |
 | BL-260904-stabilize-the-collection       | Stabilize the collection-detach engine integration test                                               | open   | low      | task       | S        |
 | BL-260903-verify-the-packs-inventory     | Verify the packs:inventory path-redaction claim in troubleshooting docs                               | open   | low      | task       | XS       |
-| BL-260906-wave-3-external-plan           | Wave 3 external-plan corrections for the program refresh                                              | open   | low      | task       | XS       |
 | BL-260903-project-document-should-prompt | project-document should prompt a re-run when review fixes change a shipped contract                   | open   | low      | task       | S        |
 
 <!-- END OAT BACKLOG-INDEX -->

--- a/.oat/repo/pjm/current-state.md
+++ b/.oat/repo/pjm/current-state.md
@@ -38,7 +38,7 @@ copying their content here. -->
 <!-- Summarize shipped capabilities and important repo conventions here. -->
 
 - CLI `0.2.58` (wave 3 of the 2026-08-31 execution program, wrapper project
-  `wave-3-execution`, "workflow durability and containment") makes the
+  `wave-3-execution`, "workflow durability and containment", merged as PR #269) makes the
   phase-implementer contract sweep the repository for every consumer of a
   changed cross-cutting option (effective task boundary; stop-and-report for
   cross-owner expansions; pinned in `post-implement-sequence-contracts.test.ts`),

--- a/.oat/repo/pjm/roadmap.md
+++ b/.oat/repo/pjm/roadmap.md
@@ -11,7 +11,7 @@ and title so this map remains readable without a board lookup.
 - **BL-YYMMDD-slug: {title}** — brief description. Project: {name} (if linked)
 -->
 
-- **2026-08-31 execution program (31 external plans, W1–W6)** — W1 merged as PR #262 (CLI 0.2.56); W2 merged as PR #267 (CLI 0.2.57); W3 (workflow durability and containment) implemented as wrapper project `wave-3-execution` (CLI 0.2.58), PR pending merge; W4–W6 pending in program order. Program: `.oat/repo/reference/external-plans/2026-08-31-execution-program.md`.
+- **2026-08-31 execution program (31 external plans, W1–W6)** — W1 merged as PR #262 (CLI 0.2.56); W2 merged as PR #267 (CLI 0.2.57); W3 (workflow durability and containment) merged as PR #269 (CLI 0.2.58); W4–W6 pending in program order. Program: `.oat/repo/reference/external-plans/2026-08-31-execution-program.md`.
 - **BL-260708-verify-cursor-gpt-5-6-subagent: Verify Cursor GPT-5.6 subagent model slugs** — Re-run structured controls after a Cursor client rollout exposes Task in headless mode or support confirms the private requests; review by 2026-08-08. Current recommended candidates remain configured but unvalidated.
 - **BL-260711-add-root-owned-dispatch-broker: Add root-owned dispatch broker for exact OAT subagent launches** — Preserve phase coordination and exact target provenance without nested provider initialization or broad coordinator permissions.
 - **BL-260711-add-activity-aware-gate: Add activity-aware gate timeouts** — Build adaptive idle-kill and early-artifact semantics on the shipped scope-aware hard budgets, transcript liveness evidence, and correlated timeout recovery.

--- a/.oat/repo/reference/external-plans/2026-08-30-journal-deterministic-smoke-worktrees-before-creation.md
+++ b/.oat/repo/reference/external-plans/2026-08-30-journal-deterministic-smoke-worktrees-before-creation.md
@@ -327,6 +327,10 @@ Stop and report instead of improvising when:
 - an existing leaked resource would be modified; or
 - a named verification gate fails twice after one bounded correction.
 
+## Execution record (2026-09-06, wave 3)
+
+Executed as wave-3 p02 (PR wave-3-execution): reservation before `git worktree add`, reserved-origin invariants re-derived in cleanup, tip re-read before `git branch --delete --force`, `reservedAt` required for schema-v2 reserved entries; the dedicated deletion-safety review ran sixteen adversarial probes (all refuse) and required the probe→`worktree add -b` window to be documented honestly in code, CONTRACT.md, and a pinning test (a foreign branch created in that window at the exact reserved baseline is deleted; no sound Git discriminator exists). Direct registration keeps its looser containment for `scripts/worktree/init.sh`. Follow-ups: project reservation state into the evidence bundle; run `scripts/worktree/init.test.mjs` under a gate. Sync convention (program rule from wave 3): where this plan says `oat sync --scope all`, lanes run `pnpm run cli -- sync --scope project`; `--scope all` also rewrites the operator's user-scope provider views and manifest and is operator-only.
+
 ## Revalidation Before Execution
 
 Revalidate against current `origin/main`, the source backlog item, PR #215, the

--- a/.oat/repo/reference/external-plans/2026-08-30-require-executable-backstops-for-contract-claims.md
+++ b/.oat/repo/reference/external-plans/2026-08-30-require-executable-backstops-for-contract-claims.md
@@ -246,6 +246,10 @@ Stop and report instead of improvising when:
 - a named verification gate fails twice after one bounded correction; or
 - scope expands beyond the two canonical skills and their contract test.
 
+## Execution record (2026-09-06, wave 3)
+
+Executed as wave-3 p03 (PR wave-3-execution): `create-oat-skill` 1.5.0 → 1.5.1 and `oat-project-design` 2.3.2 → 2.3.3 (two pins) with a fence- and comment-aware extraction in `skills.test.ts`; the runtime example was corrected to "a rollup never reports success when a required ledger write fails" (true against `rollup.ts:284`); the address-now sweep made both blocks name their executable owner, `existsSync`-checks cited precedent paths, drops indented code, and rejects weakening vocabulary. Sync convention (program rule from wave 3): where this plan says `oat sync --scope all`, lanes run `pnpm run cli -- sync --scope project`; `--scope all` also rewrites the operator's user-scope provider views and manifest and is operator-only.
+
 ## Revalidation Before Execution
 
 Revalidate against current `origin/main`, the source backlog item, both cited

--- a/.oat/repo/reference/external-plans/2026-08-30-require-repo-wide-call-site-sweeps.md
+++ b/.oat/repo/reference/external-plans/2026-08-30-require-repo-wide-call-site-sweeps.md
@@ -240,6 +240,10 @@ Stop and report instead of improvising when:
 - the negative probe does not fail when a required property is removed; or
 - a named verification gate fails twice after one bounded correction.
 
+## Execution record (2026-09-06, wave 3)
+
+Executed as wave-3 p01 (PR wave-3-execution, CLI 0.2.58): `oat-phase-implementer.md` 1.1.2 → 1.1.3 with its three `skills.test.ts` pins (this file belongs in the In-scope list: steps 4–5 move the pins); contract assertions plus six negative probes in `post-implement-sequence-contracts.test.ts`; `oat-project-implement` not bumped because the agent-level rule is reachable through the existing dispatch contract. Reported owner decision, not applied by the lane: `oat-project-implement/references/phase-execution.md:608` still says a task commit "changes only declared files" while `:493` and `:652` already say "declared or mechanically derived"; aligning `:608` costs an `oat-project-implement` bump plus seven pins and belongs to that skill's owner (recorded for a later lane). Docs mirror `apps/oat-docs/docs/workflows/projects/implementation-execution.md:91` updated at the wave's document step. Sync convention (program rule from wave 3): where this plan says `oat sync --scope all`, lanes run `pnpm run cli -- sync --scope project`; `--scope all` also rewrites the operator's user-scope provider views and manifest and is operator-only.
+
 ## Revalidation Before Execution
 
 Revalidate against current `origin/main`, the source backlog item, both cited

--- a/.oat/repo/reference/external-plans/2026-08-31-execution-program.md
+++ b/.oat/repo/reference/external-plans/2026-08-31-execution-program.md
@@ -29,13 +29,13 @@ predecessor record and the operator.
 ## Status Ledger
 
 Execution approval: operator approved the composition and autonomous execution
-(including merges) on 2026-09-05. W1 and W2 merged 2026-09-06; W3 is next.
+(including merges) on 2026-09-05. W1, W2, and W3 merged 2026-09-06; W4 is next.
 
 | Wave | Theme                                | Lanes | Status   | Record                                                                                                                                                                                                                                                                                                                                        |
 | ---- | ------------------------------------ | ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | W1   | CLI resolution and asset correctness | 4     | merged   | PR #262 → `6db0457c095e4384e5ac2f464ee1c4d5a47d0179` (squash, 2026-09-06T02:19:50Z); wrapper project `.oat/projects/shared/wave-1-execution` (lifecycle complete 2026-09-06; completion record `summary.md` + `implementation.md` § Final Summary; CLI 0.2.56); completion tail: deferred to program close; recap: deferred to program close. |
 | W2   | Skill contract truthfulness          | 5     | merged   | PR #267 → `ca71c00a014a6eba00cb4cd4c46974fc6aa58139` (squash, 2026-09-06T10:47:59Z); wrapper project `.oat/projects/shared/wave-2-execution` (lifecycle complete 2026-09-06; completion record `summary.md` + `implementation.md` § Final Summary; CLI 0.2.57); completion tail: deferred to program close; recap: deferred to program close. |
-| W3   | Workflow durability and containment  | 3     | composed | Awaiting operator composition approval; no execution started.                                                                                                                                                                                                                                                                                 |
+| W3   | Workflow durability and containment  | 3     | merged   | PR #269 → `ed75370db9f7cf43cd884572bd58502aa71f22bd` (squash, 2026-09-06T16:06:38Z); wrapper project `.oat/projects/shared/wave-3-execution` (lifecycle complete 2026-09-06; completion record `summary.md` + `implementation.md` § Final Summary; CLI 0.2.58); completion tail: deferred to program close; recap: deferred to program close. |
 | W4   | Delivered-project follow-ups         | 3     | composed | Awaiting operator composition approval; no execution started.                                                                                                                                                                                                                                                                                 |
 | W5   | Program-intake follow-ups            | 11    | composed | Awaiting operator composition approval; no execution started.                                                                                                                                                                                                                                                                                 |
 | W6   | Truthfulness residue                 | 5     | composed | Awaiting operator composition approval; no execution started.                                                                                                                                                                                                                                                                                 |
@@ -52,9 +52,9 @@ Execution approval: operator approved the composition and autonomous execution
 | [Harden codex-skill anaphora guard](./2026-08-30-harden-codex-skill-anaphora-guard.md)                                                                    | [Wave 3 index](./2026-08-30-backlog-review-wave-3-plan-index.md) | W2   | group 2 after bundled-skill repair revalidation                                                                                           | done    |
 | [Guard docs-app mirrors of skill prose](./2026-08-30-guard-docs-app-mirrors-of-skill-prose.md)                                                            | [Wave 3 index](./2026-08-30-backlog-review-wave-3-plan-index.md) | W2   | group 2 after bundled-skill repair revalidation                                                                                           | done    |
 | [Require named lifecycle skills to be loaded](./2026-08-30-require-named-lifecycle-skills-to-be-loaded.md)                                                | [Wave 2 index](./2026-08-30-backlog-review-wave-2-plan-index.md) | W2   | group 2; revalidate if draft PR #190 changes first                                                                                        | done    |
-| [Require repo-wide call-site sweeps](./2026-08-30-require-repo-wide-call-site-sweeps.md)                                                                  | [Wave 3 index](./2026-08-30-backlog-review-wave-3-plan-index.md) | W3   | parallel group 1                                                                                                                          | pending |
-| [Journal deterministic smoke worktrees](./2026-08-30-journal-deterministic-smoke-worktrees-before-creation.md)                                            | [Wave 3 index](./2026-08-30-backlog-review-wave-3-plan-index.md) | W3   | parallel group 1; dedicated safety review                                                                                                 | pending |
-| [Require executable backstops](./2026-08-30-require-executable-backstops-for-contract-claims.md)                                                          | [Wave 3 index](./2026-08-30-backlog-review-wave-3-plan-index.md) | W3   | group 2 after concrete guard examples and call-site sweep                                                                                 | pending |
+| [Require repo-wide call-site sweeps](./2026-08-30-require-repo-wide-call-site-sweeps.md)                                                                  | [Wave 3 index](./2026-08-30-backlog-review-wave-3-plan-index.md) | W3   | parallel group 1                                                                                                                          | done    |
+| [Journal deterministic smoke worktrees](./2026-08-30-journal-deterministic-smoke-worktrees-before-creation.md)                                            | [Wave 3 index](./2026-08-30-backlog-review-wave-3-plan-index.md) | W3   | parallel group 1; dedicated safety review                                                                                                 | done    |
+| [Require executable backstops](./2026-08-30-require-executable-backstops-for-contract-claims.md)                                                          | [Wave 3 index](./2026-08-30-backlog-review-wave-3-plan-index.md) | W3   | group 2 after concrete guard examples and call-site sweep                                                                                 | done    |
 | [Disable configured gates per project](./2026-08-30-disable-configured-gates-per-project.md)                                                              | [Wave 2 index](./2026-08-30-backlog-review-wave-2-plan-index.md) | W4   | parallel group 1; preserve PR #246 contracts; owns the `oat-project-next` disposition consumer                                            | pending |
 | [Warn on non-sync manifest restamps](./2026-08-30-warn-on-non-sync-manifest-restamps.md)                                                                  | [Wave 1 index](./2026-08-30-backlog-review-wave-1-plan-index.md) | W4   | parallel group 1; READY since PR #255 merged (refreshed 2026-09-03 against Manifest V2); preserve PR #249 diagnostics                     | pending |
 | [Recover committed review artifacts after post-selection gate failures](./2026-09-02-recover-committed-review-artifacts-after-post-selection-failures.md) | [Wave 4 index](./2026-09-02-backlog-review-wave-4-plan-index.md) | W5   | group 1; land before the index-lock plan                                                                                                  | pending |
@@ -199,7 +199,7 @@ Execution approval: operator approved the composition and autonomous execution
 - **Group 2:** Emit the dispatch stamp with resolver JSON, after the
   gate-override lane: both write `review-skill-contracts.test.ts` and the
   version pins in `validation/skills.test.ts` (regrouped 2026-09-05).
-- **Cross-wave prerequisites:** W3 merged. The manifest-restamp and
+- **Cross-wave prerequisites:** W3 merged (PR #269, 2026-09-06) — satisfied. The manifest-restamp and
   dispatch-stamp plans were refreshed and set `READY` on 2026-09-03 after
   PR #255 merged; re-anchor the gate-override plan's `oat-project-plan-writing` and
   `user-sync-config.ts` citations. Revalidate all three against live
@@ -333,6 +333,26 @@ unset`; its optional seam keys live in `BL-260904-add-recap-seam-config-keys`.
   and #255 were refreshed. Review record:
   `.oat/repo/reference/reviews/2026-09-04-external-plan-independent-review.md`.
 
+- **2026-09-06 (W3 closed)** — Wave 3 executed as wrapper project
+  `wave-3-execution` (three lanes, two groups, one lockstep bump to 0.2.58 with
+  the sync-manifest restamp in the same commit) and merged as PR #269
+  (`ed75370db9f7cf43cd884572bd58502aa71f22bd`). All three W3 rows flip to `done`. Review economics: p01 and
+  p02 each needed one fix round (the deletion-safety review found an
+  undocumented residual the lane had labelled documented); p03 passed outright
+  with an address-now sweep. Program-wide rules adopted: lanes sync
+  `--scope project` only (`--scope all` rewrites the operator's user-scope
+  provider views — every plan step that says `oat sync --scope all` is read as
+  `--scope project`); probe restores use `mktemp -d` backups, never
+  `git checkout --` on uncommitted work; reviewer briefs demand the exact
+  documentation location for any "documented residual" and a probe of the
+  residual itself. Plan corrections applied in this refresh: the call-site
+  plan's In-scope list gains `packages/cli/src/validation/skills.test.ts`
+  (its steps 4–5 move the agent pins) and records the reported owner decision
+  for `phase-execution.md:608`; the sync-scope convention on all three plans.
+  Follow-ups filed: extend `check:skill-bumps` to canonical agent files;
+  negation-aware sweep-contract tests; project reservation state into the
+  smoke evidence bundle; run `scripts/worktree/init.test.mjs` under a gate.
+  W4 unblocked.
 - **2026-09-06 (W2 closed)** — Wave 2 executed as wrapper project
   `wave-2-execution` (five lanes, three groups, one lockstep bump to 0.2.57)
   and merged as PR #267 (`ca71c00a014a6eba00cb4cd4c46974fc6aa58139`). All five W2 rows flip to `done`. Review


### PR DESCRIPTION
## Wave 3 close (execution program bookkeeping)

Closes wave 3 of the [2026-08-31 execution program](.oat/repo/reference/external-plans/2026-08-31-execution-program.md) after PR #269 merged (`ed75370db`, CLI 0.2.58).

- Status ledger: W3 row → `merged` with the squash SHA and the wrapper's completion record; three W3 plan rows → `done`; W4's cross-wave prerequisite marked satisfied; 2026-09-06 (W3 closed) revalidation entry with the rules adopted for later waves (lanes sync `--scope project`; `mktemp -d` probe backups; reviewer briefs demand documentation location and a probe for any "documented residual").
- External-plan corrections queued by the wave reviews (`BL-260906-wave-3-external-plan`, archived here): the call-site plan's In-scope list and the recorded `phase-execution.md:608` alignment; the sync-scope convention on all three plans; an execution record under each plan's `## Revalidation Before Execution`.
- PJM: roadmap and current-state note the merge.

No product code changes.

https://claude.ai/code/session_01EmcmFVUX4m8eYfpM47d9BX
