### PR TITLE
docs(skills): review necessity in artifact reviews and let the wave plan gate raise it

### DIFF
--- a/.agents/agents/oat-reviewer.md
+++ b/.agents/agents/oat-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: oat-reviewer
-version: 1.2.3
+version: 1.2.4
 description: Unified reviewer for OAT projects - mode-aware verification of requirements/design alignment and code quality. Writes a review artifact to disk by default, or returns structured findings in-memory when dispatched in structured-output mode.
 tools: Read, Bash, Grep, Glob, Write, Task
 color: yellow
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Task atomicity and verifiability: each task is independently committable, has bounded file scope, and has executable verification intent. Require a proportionate implementation and proof strategy only when the applicable workflow plan contract declares it; otherwise review the task's existing verification commands and evidence.
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
+
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
 
 ### Step 5: Verify Design Alignment
 

--- a/.agents/skills/oat-wave-execute/SKILL.md
+++ b/.agents/skills/oat-wave-execute/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: false
 user-invocable: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 metadata:
-  version: 1.9.2
+  version: 1.9.3
 ---
 
 # Execute a Wave of External Plans
@@ -235,9 +235,18 @@ writes and stay on the orchestrator's own model class, the same rule
 
 Run the cross-runtime artifact gate with a **bounded** prompt (rule 6): review the
 wrapper artifacts for plan invariants, contract consistency, frontmatter validity,
-and whether any task restates/narrows its source plan — the external plans are
-immutable inputs, NOT review targets. Disposition findings in-artifact
-(gate-invoked artifact review) and commit. A plan gate MAY PROCEED at
+and whether any task restates/narrows its source plan. The external plans'
+content is immutable to the wave (the gate never rewrites a plan), but a plan is
+a legitimate target for one question: whether its proposed mechanism materially
+serves the requested outcome. A reviewer who finds substantial machinery with no
+identifiable consumer — an agent acting on a named instruction, a human reading
+a named surface, or code at a named call site — or a smaller approach that
+preserves the requirements, reports it as a necessity finding. The root returns
+that plan to its author (`oat-repo-improve`) for disposition and defers it from
+this wave until dispositioned; it never silently drops or narrows it, and an
+explicitly stated user requirement is honored over a preference for simplicity.
+Disposition the remaining findings in-artifact (gate-invoked artifact review)
+and commit. A plan gate MAY PROCEED at
 `fixes_completed` per the wave-0/1 precedent, but that is a proceed point, not a
 terminal state. Every gate row MUST flip to `passed` once all fix dispositions
 carry the stored verification records required by the fix-disposition contract below;

--- a/.codex/agents/oat-reviewer-gpt-5-6-luna-high.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-luna-high.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-luna-low.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-luna-low.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-luna-medium.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-luna-medium.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-luna-xhigh.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-luna-xhigh.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-sol-high.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-sol-high.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-sol-low.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-sol-low.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-sol-max.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-sol-max.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-sol-medium.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-sol-medium.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-sol-xhigh.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-sol-xhigh.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-terra-high.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-terra-high.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-terra-low.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-terra-low.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-terra-medium.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-terra-medium.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer-gpt-5-6-terra-xhigh.toml
+++ b/.codex/agents/oat-reviewer-gpt-5-6-terra-xhigh.toml
@@ -234,6 +234,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.codex/agents/oat-reviewer.toml
+++ b/.codex/agents/oat-reviewer.toml
@@ -231,6 +231,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-claude-fable-5-thinking-high.md
+++ b/.cursor/agents/oat-reviewer-claude-fable-5-thinking-high.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-claude-fable-5-thinking-xhigh.md
+++ b/.cursor/agents/oat-reviewer-claude-fable-5-thinking-xhigh.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-claude-opus-4-8-thinking-xhigh.md
+++ b/.cursor/agents/oat-reviewer-claude-opus-4-8-thinking-xhigh.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-claude-opus-5-thinking-high.md
+++ b/.cursor/agents/oat-reviewer-claude-opus-5-thinking-high.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-claude-opus-5-thinking-low.md
+++ b/.cursor/agents/oat-reviewer-claude-opus-5-thinking-low.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-claude-opus-5-thinking-max.md
+++ b/.cursor/agents/oat-reviewer-claude-opus-5-thinking-max.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-claude-opus-5-thinking-medium.md
+++ b/.cursor/agents/oat-reviewer-claude-opus-5-thinking-medium.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-claude-opus-5-thinking-xhigh.md
+++ b/.cursor/agents/oat-reviewer-claude-opus-5-thinking-xhigh.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-claude-sonnet-5-high.md
+++ b/.cursor/agents/oat-reviewer-claude-sonnet-5-high.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-composer-2-5.md
+++ b/.cursor/agents/oat-reviewer-composer-2-5.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-cursor-grok-4-5-high.md
+++ b/.cursor/agents/oat-reviewer-cursor-grok-4-5-high.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-gpt-5-6-luna-high.md
+++ b/.cursor/agents/oat-reviewer-gpt-5-6-luna-high.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-gpt-5-6-luna-xhigh.md
+++ b/.cursor/agents/oat-reviewer-gpt-5-6-luna-xhigh.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-gpt-5-6-sol-high.md
+++ b/.cursor/agents/oat-reviewer-gpt-5-6-sol-high.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-gpt-5-6-sol-max.md
+++ b/.cursor/agents/oat-reviewer-gpt-5-6-sol-max.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-gpt-5-6-sol-medium.md
+++ b/.cursor/agents/oat-reviewer-gpt-5-6-sol-medium.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-gpt-5-6-sol-xhigh.md
+++ b/.cursor/agents/oat-reviewer-gpt-5-6-sol-xhigh.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.cursor/agents/oat-reviewer-gpt-5-6-terra-high.md
+++ b/.cursor/agents/oat-reviewer-gpt-5-6-terra-high.md
@@ -239,6 +239,25 @@ Treat the artifact as a product deliverable. Verify it is:
    - Coverage of design/discovery: every in-scope design component or discovery decision is mapped to at least one task or explicitly deferred/out of scope.
    - Parallelism-claim sanity: any parallel phase group or parallelism statement is consistent with declared file boundaries and dependency order.
 
+6. **Necessary**
+   - Evaluate whether the proposed approach materially serves the requested
+     outcome. For substantial added machinery — a script, schema, persisted
+     record, gate, provider seam, or new document that someone will have to
+     own — identify its consumer (an agent acting on a named instruction, a
+     human reading a named surface, or code at a named call site) and consider
+     whether a smaller approach preserves the requirements.
+   - Judge prose by the behavior it meaningfully guides. An instruction whose
+     consumer is the agent that reads it is a real consumer; missing automated
+     enforcement of that instruction is not proof of uselessness.
+   - A mechanism whose only consumer is its own tests, its own plan, or a
+     deferred future reader is grounds to investigate, not an automatic
+     severity: grade the finding by wasted effort, maintenance burden, or
+     failure to meet the requested outcome, and say which.
+   - Report justified concerns in the existing findings sections. Do not
+     produce an inventory of unproblematic mechanisms, and do not override an
+     explicitly stated user requirement with a preference for simplicity;
+     name the conflict instead.
+
 ### Step 5: Verify Design Alignment
 
 This step applies to **code reviews** only.

--- a/.oat/sync/manifest.json
+++ b/.oat/sync/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "oatVersion": "0.2.68",
+  "oatVersion": "0.2.69",
   "entries": [
     {
       "canonicalPath": ".agents/agents/oat-codebase-mapper.md",

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.2.68",
-  "docs-config": "0.2.68",
-  "docs-theme": "0.2.68",
-  "docs-transforms": "0.2.68"
+  "cli": "0.2.69",
+  "docs-config": "0.2.69",
+  "docs-theme": "0.2.69",
+  "docs-transforms": "0.2.69"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.2.68",
+  "version": "0.2.69",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
+++ b/packages/cli/src/commands/init/tools/shared/review-skill-contracts.test.ts
@@ -356,7 +356,7 @@ describe('review skill contracts', () => {
 
     // The `oat-reviewer` AGENT role is out of scope for the skill version
     // migration and keeps its top-level declaration, so this read stays direct.
-    expect(content.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('1.2.3');
+    expect(content.match(/^version:\s*(.+)$/m)?.[1]?.trim()).toBe('1.2.4');
     expect(content).toContain(
       'must represent the same instant from the same `date -u` capture',
     );

--- a/packages/cli/src/validation/skills.test.ts
+++ b/packages/cli/src/validation/skills.test.ts
@@ -1605,7 +1605,7 @@ describe('validateOatSkills', () => {
     const content = await readRepoFile('.agents/agents/oat-reviewer.md');
     const tools = content.match(/^tools:\s*(.+)$/m)?.[1] ?? '';
 
-    expect(readDeclaredVersion(content)).toBe('1.2.3');
+    expect(readDeclaredVersion(content)).toBe('1.2.4');
     expect(tools).toContain('Task');
     for (const broadReview of [
       'final code reviews',
@@ -3178,7 +3178,7 @@ describe('validateOatSkills', () => {
   it('keeps the complete artifact hygiene block equivalent at every runtime boundary', async () => {
     const runtimeSurfaces = [
       ['.agents/agents/oat-phase-implementer.md', '1.1.5'],
-      ['.agents/agents/oat-reviewer.md', '1.2.3'],
+      ['.agents/agents/oat-reviewer.md', '1.2.4'],
       ['.agents/skills/oat-project-review-provide/SKILL.md', '1.5.8'],
       ['.agents/skills/oat-project-review-receive/SKILL.md', '1.6.3'],
       ['.agents/skills/oat-project-summary/SKILL.md', '1.5.5'],
@@ -6169,7 +6169,7 @@ describe('validateOatSkills', () => {
   it('pins portable user-default agents to installed-root sibling reads', async () => {
     const agents = [
       ['.agents/agents/oat-phase-implementer.md', '1.1.5'],
-      ['.agents/agents/oat-reviewer.md', '1.2.3'],
+      ['.agents/agents/oat-reviewer.md', '1.2.4'],
       ['.agents/agents/oat-codebase-mapper.md', '1.0.1'],
     ] as const;
 

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.2.68",
+  "version": "0.2.69",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.2.68",
+  "version": "0.2.69",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.2.68",
+  "version": "0.2.69",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.2.68",
+  "version": "0.2.69",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Review necessity in artifact reviews; let the wave plan gate raise it

Prose only, two skills, following the 2026-09-09 dispatch-record incident and the audit of the execution program (four write-only mechanisms and four unenforced rules shipped through gates that never asked who consumes an artifact).

- **`oat-reviewer` Step 4 (artifact reviews) gains a "Necessary" item.** Evaluate whether the proposed approach materially serves the requested outcome. For substantial added machinery — a script, schema, persisted record, gate, provider seam, or new document someone will own — identify its consumer (an agent acting on a named instruction, a human reading a named surface, or code at a named call site) and consider whether a smaller approach preserves the requirements. Judge prose by the behavior it meaningfully guides; missing automated enforcement of an instruction is not proof of uselessness. A mechanism whose only consumer is its own tests, its own plan, or a deferred future reader is grounds to investigate, graded by wasted effort, maintenance burden, or unmet outcome — never an automatic severity. Report in the existing findings sections; no inventory of unproblematic mechanisms; never override an explicit user requirement with a preference for simplicity.
- **`oat-wave-execute` Step 4 (plan gate).** External-plan content stays immutable to the wave, but a plan is now a legitimate target for the necessity question. A necessity finding returns the plan to its author (`oat-repo-improve`) for disposition and defers it from the wave; nothing is silently dropped or narrowed. Previously the gate text said the plans were "NOT review targets", which is how a plan that noticed the unread dispatch recorder on 2026-09-03 was told the question was out of scope.

Deliberately not added: a required complexity ledger, a gate that checks such a ledger exists, or tests that pin these sentences. The sentences are consumed by the reviewer and the author; if they do not change verdicts they get edited.

Bumps: `oat-reviewer` 1.2.3 → 1.2.4 (pins moved), `oat-wave-execute` 1.9.2 → 1.9.3; lockstep 0.2.68 → 0.2.69 with the sync manifest restamped. Focused contract suites: 487 tests, exit 0. Full gates run on the branch after push.

https://claude.ai/code/session_0179iPfrKLUFBJTE2mq1dSSs
