### PR TITLE
docs(skills): receiving a review is the caller's judgment, never delegated below its class

### DIFF
--- a/.agents/skills/oat-project-review-receive/SKILL.md
+++ b/.agents/skills/oat-project-review-receive/SKILL.md
@@ -5,7 +5,7 @@ disable-model-invocation: false
 user-invocable: true
 allowed-tools: Read, Write, Bash(git:*), Bash(oat:*), Glob, Grep, AskUserQuestion
 metadata:
-  version: 1.6.3
+  version: 1.6.4
 ---
 
 # Receive Review
@@ -35,6 +35,17 @@ When a project review target is resolvable, summarize the selected review path, 
 **OAT MODE: Receive Review**
 
 **Purpose:** Convert review findings into plan tasks for systematic gap closure.
+
+**Judgment stays with the caller.** Receiving a review is disposition judgment,
+not reconnaissance: the agent running this skill reads the artifact, weighs each
+finding against the project's artifacts and code, and decides fix, defer, or
+reject in the current context on its own model class. Do not dispatch subagents
+to read, parse, summarize, or disposition review artifacts, and never route any
+part of a receive to a lower model class than the caller's — the same rule
+`oat-repo-improve` applies to plan writes. Bounded read-only lookups (a grep, a
+file:line check) may be delegated only as recon whose result the caller still
+judges; the dispositions, the ledger row, and the bookkeeping commit are always
+written by the caller.
 
 ## Progress Indicators (User-Facing)
 

--- a/.oat/sync/manifest.json
+++ b/.oat/sync/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "oatVersion": "0.2.69",
+  "oatVersion": "0.2.71",
   "entries": [
     {
       "canonicalPath": ".agents/agents/oat-codebase-mapper.md",

--- a/packages/cli/assets/public-package-versions.json
+++ b/packages/cli/assets/public-package-versions.json
@@ -1,6 +1,6 @@
 {
-  "cli": "0.2.69",
-  "docs-config": "0.2.69",
-  "docs-theme": "0.2.69",
-  "docs-transforms": "0.2.69"
+  "cli": "0.2.71",
+  "docs-config": "0.2.71",
+  "docs-theme": "0.2.71",
+  "docs-transforms": "0.2.71"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/cli",
-  "version": "0.2.69",
+  "version": "0.2.71",
   "private": false,
   "description": "Open Agent Toolkit CLI",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/cli",

--- a/packages/cli/src/validation/skills.test.ts
+++ b/packages/cli/src/validation/skills.test.ts
@@ -3180,7 +3180,7 @@ describe('validateOatSkills', () => {
       ['.agents/agents/oat-phase-implementer.md', '1.1.5'],
       ['.agents/agents/oat-reviewer.md', '1.2.4'],
       ['.agents/skills/oat-project-review-provide/SKILL.md', '1.5.8'],
-      ['.agents/skills/oat-project-review-receive/SKILL.md', '1.6.3'],
+      ['.agents/skills/oat-project-review-receive/SKILL.md', '1.6.4'],
       ['.agents/skills/oat-project-summary/SKILL.md', '1.5.5'],
       ['.agents/skills/oat-project-document/SKILL.md', '1.8.3'],
       ['.agents/skills/oat-project-pr-final/SKILL.md', '1.6.4'],
@@ -4696,7 +4696,7 @@ describe('validateOatSkills', () => {
     const expectedVersions = [
       ['oat-project-plan-writing', '1.2.25'],
       ['oat-project-review-provide', '1.5.8'],
-      ['oat-project-review-receive', '1.6.3'],
+      ['oat-project-review-receive', '1.6.4'],
       ['oat-project-review-receive-remote', '1.5.2'],
       ['oat-project-implement', '2.3.8'],
       ['oat-project-pr-final', '1.6.4'],
@@ -4777,7 +4777,7 @@ describe('validateOatSkills', () => {
       receive.indexOf('### Step 2: Parse Findings into Buckets'),
     );
 
-    expect(readDeclaredVersion(receive)).toBe('1.6.3');
+    expect(readDeclaredVersion(receive)).toBe('1.6.4');
     expect(resolver).toContain(
       'oat review latest --project "$PROJECT_PATH" --actionable-project --json',
     );

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/control-plane",
-  "version": "0.2.69",
+  "version": "0.2.71",
   "private": false,
   "description": "Read-only OAT control-plane library for structured project state",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/control-plane",

--- a/packages/docs-config/package.json
+++ b/packages/docs-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-config",
-  "version": "0.2.69",
+  "version": "0.2.71",
   "private": false,
   "description": "Configuration factories for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-config",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-theme",
-  "version": "0.2.69",
+  "version": "0.2.71",
   "private": false,
   "description": "Theme components for OAT documentation sites",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-theme",

--- a/packages/docs-transforms/package.json
+++ b/packages/docs-transforms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-agent-toolkit/docs-transforms",
-  "version": "0.2.69",
+  "version": "0.2.71",
   "private": false,
   "description": "Remark/unified transforms for OAT documentation",
   "homepage": "https://github.com/voxmedia/open-agent-toolkit/tree/main/packages/docs-transforms",


### PR DESCRIPTION
## Receiving a review is the caller's judgment, never delegated below its class

A Codex session running `oat-project-review-receive` on the recon-rework plan review spawned two lower-class "intelligent-recon" lanes (gpt-5.6-terra at high) to parse the two review artifacts, reading the generic subagent-orchestration guidance ("delegate reconnaissance") as applying to disposition. The receive skill had no language either way.

It now states the rule under its Mode Assertion: receiving a review is disposition judgment, not reconnaissance. The caller reads the artifact, weighs each finding against the project's artifacts and code, and decides fix / defer / reject in the current context on its own model class. Subagents may not read, parse, summarize, or disposition review artifacts, and nothing in a receive routes to a lower model class than the caller's — the same rule `oat-repo-improve` applies to plan writes. Bounded read-only lookups (a grep, a file:line check) may still be delegated as recon whose result the caller judges; the dispositions, the ledger row, and the bookkeeping commit are always the caller's.

Prose only; consumer is the agent running the skill. No test pins the sentence. Bump `oat-project-review-receive` 1.6.3 → 1.6.4 (pins moved); lockstep 0.2.69 → 0.2.71 because 0.2.70 is taken by the open #291.

Focused contract suites green; full gates run on the branch after push.

https://claude.ai/code/session_0179iPfrKLUFBJTE2mq1dSSs
