### PR TITLE
chore(pjm): oat-doctor collaborative router backlog item

### DIFF
--- a/.oat/repo/pjm/backlog/index.md
+++ b/.oat/repo/pjm/backlog/index.md
@@ -219,112 +219,111 @@
   are prerequisites, not substitutes for this work.
 
 <!-- OAT BACKLOG-INDEX -->
-
-| ID                                       | Title                                                                                                 | Status | Priority | Scope      | Estimate |
-| ---------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------ | -------- | ---------- | -------- |
-| BL-260711-skip-re-review-for-bookkeeping | Skip re-review for bookkeeping-only review findings                                                   | open   | urgent   | feature    | L        |
-| BL-260711-add-activity-aware-gate        | Add activity-aware gate timeouts                                                                      | open   | high     | feature    | M        |
-| BL-260718-add-oat-wave-lifecycle-cli     | Add oat wave lifecycle CLI command family                                                             | open   | high     | feature    | L        |
-| BL-260720-add-oat-project-complete-auto  | Add oat-project-complete-auto companion skill for autonomous closeouts                                | open   | high     | task       | M        |
-| BL-260711-add-root-owned-dispatch-broker | Add root-owned dispatch broker for exact OAT subagent launches                                        | open   | high     | feature    | M        |
-| BL-260820-bind-each-gate-review          | Bind each gate review disposition to its exact received ledger event                                  | open   | high     | task       | M        |
-| BL-260820-emit-source-qualified          | Emit source-qualified provenance envelopes for review and gate receipts                               | open   | high     | feature    | M        |
-| BL-260806-fail-closed-when-configured    | Fail closed when configured closeout snapshot is absent                                               | open   | high     | task       | M        |
-| BL-260909-give-the-dispatch-record       | Give the dispatch record a consumer or remove it                                                      | open   | high     | task       | S        |
-| BL-260906-harden-dispatch-launch         | Harden dispatch launch baselines and terminal reconciliation                                          | open   | high     | feature    | M        |
-| BL-260718-harden-full-surface-gate       | Harden full-surface gate reviews against budget and recursive dispatch                                | open   | high     | feature    | M        |
-| BL-260729-implement-reviewplan-first     | Implement ReviewPlan-first reviewer workflow                                                          | open   | high     | feature    | L        |
-| BL-260727-make-explainer-run-durability  | Make explainer run durability survive ephemeral environments                                          | open   | high     | task       | M        |
-| BL-260829-order-phase-bookkeeping-before | Order phase bookkeeping before per-phase review dispatch                                              | open   | high     | task       | M        |
-| BL-260907-replace-the-default-project    | Replace the default project recap with a direct agent-authored visual flow                            | open   | high     | feature    | M        |
-| BL-260908-restore-recon-s-cheap-fan-out  | Restore recon's cheap-fan-out intent with per-wave routing under one approval envelope                | open   | high     | feature    | L        |
-| BL-260724-support-provider-directory     | Support provider directory symlinks as full collection sync                                           | open   | high     | feature    | M        |
-| BL-260820-track-pr-closeout-evidence     | Track PR-closeout evidence freshness against the current head                                         | open   | high     | feature    | L        |
-| BL-260901-add-corrective-revision        | Add corrective-revision transition after review exhaustion                                            | open   | medium   | feature    | M        |
-| BL-260718-add-generated-runbook          | Add generated-runbook verification command pass                                                       | open   | medium   | feature    | M        |
-| BL-260719-add-pinned-recon-agents        | Add pinned recon agents for reusable orchestration                                                    | open   | medium   | feature    | M        |
-| BL-260830-add-remote-review-respond      | Add remote review respond and summarize skill set                                                     | open   | medium   | feature    | L        |
-| BL-260830-add-strict-yaml-validation     | Add strict YAML validation to oat skill validation                                                    | open   | medium   | task       | S        |
-| BL-260902-append-only-lifecycle-history  | Append-only lifecycle history after completion                                                        | open   | medium   | feature    | M        |
-| BL-260830-cli-flag-help-p2-p3-cleanup    | CLI flag/help P2-P3 cleanup                                                                           | open   | medium   | task       | M        |
-| BL-260819-classify-canonical-skills-by   | Classify canonical skills by distribution, lifecycle, and tenant scope                                | open   | medium   | feature    | M        |
-| BL-260903-close-manual-only-agents-md    | Close manual-only AGENTS.md refresh loop                                                              | open   | medium   | task       | M        |
-| BL-260830-complete-control-plane-backed  | Complete control-plane-backed lifecycle reads                                                         | open   | medium   | initiative | M        |
-| BL-260817-decide-and-pin-the-system      | Decide and pin the system-Chromium requirement introduced by test:skills on the merge path            | open   | medium   | task       | S        |
-| BL-260830-decide-generic-oat-ownership   | Decide generic OAT ownership of Jira backlog refinement                                               | open   | medium   | idea       | L        |
-| BL-260902-decide-test-only-freshness     | Decide test-only freshness exception for the implement exit gate                                      | open   | medium   | idea       | S        |
-| BL-260818-distinguish-operator-directed  | Distinguish operator-directed review rounds from failed fix cycles in the review-cycle cap            | open   | medium   | task       | M        |
-| BL-260718-document-execution-program     | Document execution-program artifact as stable OAT contract                                            | open   | medium   | feature    | M        |
-| BL-260817-drop-explainer-kit-publish     | Drop explainer-kit publish-request/v1 in a future minor                                               | open   | medium   | task       | S        |
-| BL-260902-file-deferred-repository       | File deferred repository follow-ups from a passing receive                                            | open   | medium   | feature    | M        |
-| BL-260706-front-load-recurring-gate      | Front-load recurring gate-finding classes into implementer briefs                                     | open   | medium   | feature    | L        |
-| BL-260909-give-packages-control-plane    | Give packages/control-plane a check script so its formatting is CI-gated                              | open   | medium   | task       | XS       |
-| BL-260830-integrate-recon-across         | Integrate recon across analysis and research workflows                                                | open   | medium   | feature    | L        |
-| BL-260830-integrate-recon-with-oat       | Integrate recon with OAT discovery and quick start                                                    | open   | medium   | feature    | M        |
-| BL-260830-live-dogfood-oat-brainstorm    | Live dogfood oat-brainstorm destination and fold-back safety                                          | open   | medium   | task       | M        |
-| BL-260830-make-documentation-aware       | Make documentation-aware discovery prerequisites configurable                                         | open   | medium   | feature    | M        |
-| BL-260909-make-oat-sync-scope-all-report | Make oat sync --scope all report a sibling scope's failure in the plan body                           | open   | medium   | task       | S        |
-| BL-260904-make-quick-the-default-oat     | Make quick the default OAT workflow mode and spec-driven the explicit larger mode                     | open   | medium   | feature    | L        |
-| BL-260906-make-the-dispatch-stamp        | Make the dispatch-stamp contract helper reject bold-step boundaries and normal-path shim permissions  | open   | medium   | task       | S        |
-| BL-260830-persist-instruction-sync       | Persist instruction sync strategy in config and init                                                  | open   | medium   | feature    | M        |
-| BL-260830-re-evaluate-same-target-gate   | Re-evaluate same-target gate execution                                                                | open   | medium   | idea       | L        |
-| BL-260906-re-evaluate-universal-plan     | Re-evaluate universal plan proof strategy and test-first guidance                                     | open   | medium   | feature    | L        |
-| BL-260907-recognize-phase-level          | Recognize phase-level completion records so bullet-list revision phases do not read as incomplete     | open   | medium   | task       | S        |
-| BL-260907-record-absorbed-projects       | Record absorbed projects and backlog items for Lite consolidations                                    | open   | medium   | task       | S        |
-| BL-260827-refresh-provider-codex-md      | Refresh provider-codex.md for the ultra effort tier, the GPT-5.4 retirement, and per-subcommand flags | open   | medium   | task       | S        |
-| BL-260908-remove-the-top-level-skill     | Remove the top-level skill version read after the alias error has been quiet                          | open   | medium   | task       | S        |
-| BL-260909-repair-the-bare-fences-that    | Repair the bare fences that swallow headings outside .agents/skills                                   | open   | medium   | task       | S        |
-| BL-260909-restamp-a-stale-copy-strategy  | Restamp a stale copy-strategy contentHash on skip and retire the pre-framing digest bridge            | open   | medium   | task       | M        |
-| BL-260908-retire-the-top-level-skill     | Retire the top-level skill version alias on the recorded schedule                                     | open   | medium   | task       | S        |
-| BL-260718-rewrite-worktree-bootstrap     | Rewrite worktree bootstrap-group as tested TypeScript command                                         | open   | medium   | feature    | M        |
-| BL-260713-root-agent-judgment-logging    | Root-agent judgment logging responsibility for project log                                            | open   | medium   | feature    | S        |
-| BL-260817-run-the-rc-explainer-end       | Run the RC explainer end-to-end test in CI with a provisioned browser                                 | open   | medium   | task       | M        |
-| BL-260827-span-based-prose-guards        | Span-based prose guards, anchored probe records, and a shared probe runner for skill contract tests   | open   | medium   | task       | S        |
-| BL-260718-support-fumadocs-in-oat-docs   | Support Fumadocs in oat docs nav sync (currently MkDocs-only)                                         | open   | medium   | task       |          |
-| BL-260909-surface-config-warnings        | Surface config warnings on every reader path and document the warnings field                          | open   | medium   | task       | M        |
-| BL-260909-sweep-the-raw-main-module      | Sweep the raw main-module guard across the sibling skill scripts                                      | open   | medium   | task       | M        |
-| BL-260907-type-check-cli-test-files      | Type-check CLI test files with a test-scoped tsconfig gate                                            | open   | medium   | task       | M        |
-| BL-260726-validate-cursor-pin-effort     | Validate Cursor pin effort rungs at sync time                                                         | open   | medium   | task       | S        |
-| BL-260908-validate-the-catalog-refresh   | Validate the catalog-refresh policy state in normalizeSyncEvidence                                    | open   | medium   | task       | XS       |
-| BL-260708-verify-cursor-gpt-5-6-subagent | Verify Cursor GPT-5.6 subagent model slugs                                                            | open   | medium   | task       | S        |
-| BL-260817-verify-protected-mode-public   | Verify protected-mode public URLs with an authenticated end-to-end GET                                | open   | medium   | task       | M        |
-| BL-260830-wire-bounded-durable-reference | Wire bounded durable-reference reads into lifecycle skills                                            | open   | medium   | feature    | M        |
-| BL-260830-wire-provide-remote-skills     | Wire provide-remote skills to the review-remote helper CLI                                            | open   | medium   | feature    | L        |
-| BL-260909-add-a-grep-by-shape-control    | Add a grep-by-shape control for own-key sweeps keyed to variable names                                | open   | low      | task       | S        |
-| BL-260830-add-per-claude-md-adoption-opt | Add per-CLAUDE.md adoption opt-out for instruction sync                                               | open   | low      | feature    | M        |
-| BL-260728-additional-visual-workflows    | Additional visual workflows                                                                           | open   | low      | feature    | L        |
-| BL-260908-align-the-provider-view-json   | Align the provider-view JSON, evidence states, and docs with the human row                            | open   | low      | task       | XS       |
-| BL-260830-benchmark-listprojects-before  | Benchmark listProjects before approving a summary fast path                                           | open   | low      | idea       | M        |
-| BL-260725-classify-general-sync-owned    | Classify general sync-owned dirt in project-start preflight                                           | open   | low      | task       | M        |
-| BL-260903-close-claude-runtime-lineage   | Close Claude runtime lineage depth and unverified provider shapes                                     | open   | low      | task       | S        |
-| BL-260901-consolidate-terminal-remote    | Consolidate terminal remote-ref advertisement parsing                                                 | open   | low      | task       | M        |
-| BL-260908-date-decision-record-ids       | Date decision-record IDs in local time or document UTC                                                | open   | low      | task       | XS       |
-| BL-260830-decide-whether-oat-owns        | Decide whether OAT owns dependency intelligence                                                       | open   | low      | idea       | L        |
-| BL-260826-decide-whether-test-only-paths | Decide whether test-only paths under packages/cli/src count as publishable                            | open   | low      | task       | S        |
-| BL-260719-evaluate-broader-final-gate    | Evaluate broader final-gate freshness policy after narrow optimization                                | open   | low      | feature    | M        |
-| BL-260909-fix-the-agents-md-unsafe       | Fix the agents-md unsafe-directory test race under parallel turbo                                     | open   | low      | task       | XS       |
-| BL-260906-give-project-state-frontmatter | Give PROJECT_STATE_FRONTMATTER_FIELDS a production consumer or delete it                              | open   | low      | task       | S        |
-| BL-260907-ignore-backslash-escaped       | Ignore backslash-escaped emphasis in skill-script reference extraction                                | open   | low      | task       | XS       |
-| BL-260909-make-findsection-comment-aware | Make findSection comment-aware in the bundled-docs contract test                                      | open   | low      | task       | S        |
-| BL-260906-make-the-phase-implementer     | Make the phase-implementer sweep contract test negation-aware                                         | open   | low      | task       | S        |
-| BL-260830-memory-subsystem-ownership     | Memory subsystem ownership decision for OAT                                                           | open   | low      | idea       | XL       |
-| BL-260906-project-journal-reservation    | Project journal reservation state into the smoke evidence bundle                                      | open   | low      | task       | S        |
-| BL-260909-re-source-the-surviving-codex  | Re-source the surviving Codex provider claims and repair the dead provider-reference URLs             | open   | low      | task       | S        |
-| BL-260909-reject-malformed-nested-values | Reject malformed nested values in the strict pjm.remote shared reader                                 | open   | low      | task       | S        |
-| BL-260908-repair-or-exempt-archived      | Repair or exempt archived project ledgers that fail the pr-final path guard                           | open   | low      | task       | S        |
-| BL-260906-report-errno-for-asset-root    | Report errno for asset root stat failures and reset the statRedirects test seam                       | open   | low      | task       | XS       |
-| BL-260908-restructure-the-authoring      | Restructure the authoring skills for progressive disclosure and decide proactive invocation           | open   | low      | feature    | M        |
-| BL-260903-retire-deprecated-pack         | Retire deprecated pack placement and dead evidence diagnostics                                        | open   | low      | task       | M        |
-| BL-260909-rewrite-inbound-references     | Rewrite inbound references when oat backlog archive moves an item                                     | open   | low      | task       | S        |
-| BL-260907-route-quick-mode-discovery     | Route quick-mode discovery rows in oat-project-next and oat-project-progress straight to quick-start  | open   | low      | task       | XS       |
-| BL-260909-show-the-brainstorm-pack       | Show the brainstorm pack in the oat-doctor dashboard example and pack enumeration                     | open   | low      | task       | XS       |
-| BL-260904-stabilize-the-collection       | Stabilize the collection-detach engine integration test                                               | open   | low      | task       | S        |
-| BL-260908-tighten-the-pr-final-ledger    | Tighten the pr-final ledger guard's prose and escaped-pipe boundary                                   | open   | low      | task       | XS       |
-| BL-260909-use-handle-bound-traversal     | Use handle-bound traversal in the managed-copy and manifest filesystem readers                        | open   | low      | task       | M        |
-| BL-260903-verify-the-packs-inventory     | Verify the packs:inventory path-redaction claim in troubleshooting docs                               | open   | low      | task       | XS       |
-| BL-260909-wave-7-review-polish-leftovers | Wave-7 review polish leftovers                                                                        | open   | low      | task       | S        |
-| BL-260903-project-document-should-prompt | project-document should prompt a re-run when review fixes change a shipped contract                   | open   | low      | task       | S        |
-
+| ID | Title | Status | Priority | Scope | Estimate |
+| --- | --- | --- | --- | --- | --- |
+| BL-260711-skip-re-review-for-bookkeeping | Skip re-review for bookkeeping-only review findings | open | urgent | feature | L |
+| BL-260711-add-activity-aware-gate | Add activity-aware gate timeouts | open | high | feature | M |
+| BL-260718-add-oat-wave-lifecycle-cli | Add oat wave lifecycle CLI command family | open | high | feature | L |
+| BL-260720-add-oat-project-complete-auto | Add oat-project-complete-auto companion skill for autonomous closeouts | open | high | task | M |
+| BL-260711-add-root-owned-dispatch-broker | Add root-owned dispatch broker for exact OAT subagent launches | open | high | feature | M |
+| BL-260820-bind-each-gate-review | Bind each gate review disposition to its exact received ledger event | open | high | task | M |
+| BL-260820-emit-source-qualified | Emit source-qualified provenance envelopes for review and gate receipts | open | high | feature | M |
+| BL-260806-fail-closed-when-configured | Fail closed when configured closeout snapshot is absent | open | high | task | M |
+| BL-260909-give-the-dispatch-record | Give the dispatch record a consumer or remove it | open | high | task | S |
+| BL-260906-harden-dispatch-launch | Harden dispatch launch baselines and terminal reconciliation | open | high | feature | M |
+| BL-260718-harden-full-surface-gate | Harden full-surface gate reviews against budget and recursive dispatch | open | high | feature | M |
+| BL-260729-implement-reviewplan-first | Implement ReviewPlan-first reviewer workflow | open | high | feature | L |
+| BL-260727-make-explainer-run-durability | Make explainer run durability survive ephemeral environments | open | high | task | M |
+| BL-260911-make-oat-doctor | Make oat-doctor a collaborative router over config, PJM, agent instructions, and docs health | open | high | feature | M |
+| BL-260829-order-phase-bookkeeping-before | Order phase bookkeeping before per-phase review dispatch | open | high | task | M |
+| BL-260907-replace-the-default-project | Replace the default project recap with a direct agent-authored visual flow | open | high | feature | M |
+| BL-260908-restore-recon-s-cheap-fan-out | Restore recon's cheap-fan-out intent with per-wave routing under one approval envelope | open | high | feature | L |
+| BL-260724-support-provider-directory | Support provider directory symlinks as full collection sync | open | high | feature | M |
+| BL-260820-track-pr-closeout-evidence | Track PR-closeout evidence freshness against the current head | open | high | feature | L |
+| BL-260901-add-corrective-revision | Add corrective-revision transition after review exhaustion | open | medium | feature | M |
+| BL-260718-add-generated-runbook | Add generated-runbook verification command pass | open | medium | feature | M |
+| BL-260719-add-pinned-recon-agents | Add pinned recon agents for reusable orchestration | open | medium | feature | M |
+| BL-260830-add-remote-review-respond | Add remote review respond and summarize skill set | open | medium | feature | L |
+| BL-260830-add-strict-yaml-validation | Add strict YAML validation to oat skill validation | open | medium | task | S |
+| BL-260902-append-only-lifecycle-history | Append-only lifecycle history after completion | open | medium | feature | M |
+| BL-260830-cli-flag-help-p2-p3-cleanup | CLI flag/help P2-P3 cleanup | open | medium | task | M |
+| BL-260819-classify-canonical-skills-by | Classify canonical skills by distribution, lifecycle, and tenant scope | open | medium | feature | M |
+| BL-260903-close-manual-only-agents-md | Close manual-only AGENTS.md refresh loop | open | medium | task | M |
+| BL-260830-complete-control-plane-backed | Complete control-plane-backed lifecycle reads | open | medium | initiative | M |
+| BL-260817-decide-and-pin-the-system | Decide and pin the system-Chromium requirement introduced by test:skills on the merge path | open | medium | task | S |
+| BL-260830-decide-generic-oat-ownership | Decide generic OAT ownership of Jira backlog refinement | open | medium | idea | L |
+| BL-260902-decide-test-only-freshness | Decide test-only freshness exception for the implement exit gate | open | medium | idea | S |
+| BL-260818-distinguish-operator-directed | Distinguish operator-directed review rounds from failed fix cycles in the review-cycle cap | open | medium | task | M |
+| BL-260718-document-execution-program | Document execution-program artifact as stable OAT contract | open | medium | feature | M |
+| BL-260817-drop-explainer-kit-publish | Drop explainer-kit publish-request/v1 in a future minor | open | medium | task | S |
+| BL-260902-file-deferred-repository | File deferred repository follow-ups from a passing receive | open | medium | feature | M |
+| BL-260706-front-load-recurring-gate | Front-load recurring gate-finding classes into implementer briefs | open | medium | feature | L |
+| BL-260909-give-packages-control-plane | Give packages/control-plane a check script so its formatting is CI-gated | open | medium | task | XS |
+| BL-260830-integrate-recon-across | Integrate recon across analysis and research workflows | open | medium | feature | L |
+| BL-260830-integrate-recon-with-oat | Integrate recon with OAT discovery and quick start | open | medium | feature | M |
+| BL-260830-live-dogfood-oat-brainstorm | Live dogfood oat-brainstorm destination and fold-back safety | open | medium | task | M |
+| BL-260830-make-documentation-aware | Make documentation-aware discovery prerequisites configurable | open | medium | feature | M |
+| BL-260909-make-oat-sync-scope-all-report | Make oat sync --scope all report a sibling scope's failure in the plan body | open | medium | task | S |
+| BL-260904-make-quick-the-default-oat | Make quick the default OAT workflow mode and spec-driven the explicit larger mode | open | medium | feature | L |
+| BL-260906-make-the-dispatch-stamp | Make the dispatch-stamp contract helper reject bold-step boundaries and normal-path shim permissions | open | medium | task | S |
+| BL-260830-persist-instruction-sync | Persist instruction sync strategy in config and init | open | medium | feature | M |
+| BL-260830-re-evaluate-same-target-gate | Re-evaluate same-target gate execution | open | medium | idea | L |
+| BL-260906-re-evaluate-universal-plan | Re-evaluate universal plan proof strategy and test-first guidance | open | medium | feature | L |
+| BL-260907-recognize-phase-level | Recognize phase-level completion records so bullet-list revision phases do not read as incomplete | open | medium | task | S |
+| BL-260907-record-absorbed-projects | Record absorbed projects and backlog items for Lite consolidations | open | medium | task | S |
+| BL-260827-refresh-provider-codex-md | Refresh provider-codex.md for the ultra effort tier, the GPT-5.4 retirement, and per-subcommand flags | open | medium | task | S |
+| BL-260908-remove-the-top-level-skill | Remove the top-level skill version read after the alias error has been quiet | open | medium | task | S |
+| BL-260909-repair-the-bare-fences-that | Repair the bare fences that swallow headings outside .agents/skills | open | medium | task | S |
+| BL-260909-restamp-a-stale-copy-strategy | Restamp a stale copy-strategy contentHash on skip and retire the pre-framing digest bridge | open | medium | task | M |
+| BL-260908-retire-the-top-level-skill | Retire the top-level skill version alias on the recorded schedule | open | medium | task | S |
+| BL-260718-rewrite-worktree-bootstrap | Rewrite worktree bootstrap-group as tested TypeScript command | open | medium | feature | M |
+| BL-260713-root-agent-judgment-logging | Root-agent judgment logging responsibility for project log | open | medium | feature | S |
+| BL-260817-run-the-rc-explainer-end | Run the RC explainer end-to-end test in CI with a provisioned browser | open | medium | task | M |
+| BL-260827-span-based-prose-guards | Span-based prose guards, anchored probe records, and a shared probe runner for skill contract tests | open | medium | task | S |
+| BL-260718-support-fumadocs-in-oat-docs | Support Fumadocs in oat docs nav sync (currently MkDocs-only) | open | medium | task |  |
+| BL-260909-surface-config-warnings | Surface config warnings on every reader path and document the warnings field | open | medium | task | M |
+| BL-260909-sweep-the-raw-main-module | Sweep the raw main-module guard across the sibling skill scripts | open | medium | task | M |
+| BL-260907-type-check-cli-test-files | Type-check CLI test files with a test-scoped tsconfig gate | open | medium | task | M |
+| BL-260726-validate-cursor-pin-effort | Validate Cursor pin effort rungs at sync time | open | medium | task | S |
+| BL-260908-validate-the-catalog-refresh | Validate the catalog-refresh policy state in normalizeSyncEvidence | open | medium | task | XS |
+| BL-260708-verify-cursor-gpt-5-6-subagent | Verify Cursor GPT-5.6 subagent model slugs | open | medium | task | S |
+| BL-260817-verify-protected-mode-public | Verify protected-mode public URLs with an authenticated end-to-end GET | open | medium | task | M |
+| BL-260830-wire-bounded-durable-reference | Wire bounded durable-reference reads into lifecycle skills | open | medium | feature | M |
+| BL-260830-wire-provide-remote-skills | Wire provide-remote skills to the review-remote helper CLI | open | medium | feature | L |
+| BL-260909-add-a-grep-by-shape-control | Add a grep-by-shape control for own-key sweeps keyed to variable names | open | low | task | S |
+| BL-260830-add-per-claude-md-adoption-opt | Add per-CLAUDE.md adoption opt-out for instruction sync | open | low | feature | M |
+| BL-260728-additional-visual-workflows | Additional visual workflows | open | low | feature | L |
+| BL-260908-align-the-provider-view-json | Align the provider-view JSON, evidence states, and docs with the human row | open | low | task | XS |
+| BL-260830-benchmark-listprojects-before | Benchmark listProjects before approving a summary fast path | open | low | idea | M |
+| BL-260725-classify-general-sync-owned | Classify general sync-owned dirt in project-start preflight | open | low | task | M |
+| BL-260903-close-claude-runtime-lineage | Close Claude runtime lineage depth and unverified provider shapes | open | low | task | S |
+| BL-260901-consolidate-terminal-remote | Consolidate terminal remote-ref advertisement parsing | open | low | task | M |
+| BL-260908-date-decision-record-ids | Date decision-record IDs in local time or document UTC | open | low | task | XS |
+| BL-260830-decide-whether-oat-owns | Decide whether OAT owns dependency intelligence | open | low | idea | L |
+| BL-260826-decide-whether-test-only-paths | Decide whether test-only paths under packages/cli/src count as publishable | open | low | task | S |
+| BL-260719-evaluate-broader-final-gate | Evaluate broader final-gate freshness policy after narrow optimization | open | low | feature | M |
+| BL-260909-fix-the-agents-md-unsafe | Fix the agents-md unsafe-directory test race under parallel turbo | open | low | task | XS |
+| BL-260906-give-project-state-frontmatter | Give PROJECT_STATE_FRONTMATTER_FIELDS a production consumer or delete it | open | low | task | S |
+| BL-260907-ignore-backslash-escaped | Ignore backslash-escaped emphasis in skill-script reference extraction | open | low | task | XS |
+| BL-260909-make-findsection-comment-aware | Make findSection comment-aware in the bundled-docs contract test | open | low | task | S |
+| BL-260906-make-the-phase-implementer | Make the phase-implementer sweep contract test negation-aware | open | low | task | S |
+| BL-260830-memory-subsystem-ownership | Memory subsystem ownership decision for OAT | open | low | idea | XL |
+| BL-260906-project-journal-reservation | Project journal reservation state into the smoke evidence bundle | open | low | task | S |
+| BL-260909-re-source-the-surviving-codex | Re-source the surviving Codex provider claims and repair the dead provider-reference URLs | open | low | task | S |
+| BL-260909-reject-malformed-nested-values | Reject malformed nested values in the strict pjm.remote shared reader | open | low | task | S |
+| BL-260908-repair-or-exempt-archived | Repair or exempt archived project ledgers that fail the pr-final path guard | open | low | task | S |
+| BL-260906-report-errno-for-asset-root | Report errno for asset root stat failures and reset the statRedirects test seam | open | low | task | XS |
+| BL-260908-restructure-the-authoring | Restructure the authoring skills for progressive disclosure and decide proactive invocation | open | low | feature | M |
+| BL-260903-retire-deprecated-pack | Retire deprecated pack placement and dead evidence diagnostics | open | low | task | M |
+| BL-260909-rewrite-inbound-references | Rewrite inbound references when oat backlog archive moves an item | open | low | task | S |
+| BL-260907-route-quick-mode-discovery | Route quick-mode discovery rows in oat-project-next and oat-project-progress straight to quick-start | open | low | task | XS |
+| BL-260909-show-the-brainstorm-pack | Show the brainstorm pack in the oat-doctor dashboard example and pack enumeration | open | low | task | XS |
+| BL-260904-stabilize-the-collection | Stabilize the collection-detach engine integration test | open | low | task | S |
+| BL-260908-tighten-the-pr-final-ledger | Tighten the pr-final ledger guard's prose and escaped-pipe boundary | open | low | task | XS |
+| BL-260909-use-handle-bound-traversal | Use handle-bound traversal in the managed-copy and manifest filesystem readers | open | low | task | M |
+| BL-260903-verify-the-packs-inventory | Verify the packs:inventory path-redaction claim in troubleshooting docs | open | low | task | XS |
+| BL-260909-wave-7-review-polish-leftovers | Wave-7 review polish leftovers | open | low | task | S |
+| BL-260903-project-document-should-prompt | project-document should prompt a re-run when review fixes change a shipped contract | open | low | task | S |
 <!-- END OAT BACKLOG-INDEX -->
 
 ## Notes

--- a/.oat/repo/pjm/backlog/items/BL-260911-make-oat-doctor.md
+++ b/.oat/repo/pjm/backlog/items/BL-260911-make-oat-doctor.md
@@ -1,0 +1,62 @@
+---
+id: BL-260911-make-oat-doctor
+title: Make oat-doctor a collaborative router over config, PJM, agent
+  instructions, and docs health
+status: open
+priority: high
+scope: feature
+scope_estimate: M
+labels:
+  - doctor
+  - config
+  - pjm
+  - agent-instructions
+  - docs
+  - skills
+assignee: null
+created: 2026-09-11T23:34:16.344Z
+updated: 2026-09-11T23:34:16.344Z
+associated_issues: []
+external_plans: []
+---
+
+## Description
+
+Today oat-doctor (skill 1.2.4) is a tool-inventory check: installed packs, outdated skills, three stale-pointer config checks, and a --summary dashboard, with config-key explanations read from bundled docs and a hard-coded fallback list of eleven keys. The CLI already exposes richer, machine-readable health signals that nothing routes a person to: oat doctor --json (environment and setup), oat pjm doctor --json (adoption state plus twelve pjm:\* checks such as legacy_monoliths, loose_reference_files, backlog_invalid_status), oat config list / dump / describe (resolved values with source attribution and per-key descriptions across the five surfaces), oat config adopt (bundled recommendation templates), oat instructions validate (AGENTS.md / CLAUDE.md sync integrity), and the docs skills (oat-docs-analyze, oat-agent-instructions-analyze). The operator's ask (2026-09-11): one doctor that looks at everything, presents potential issues, and asks where to dive deeper, and in the config area teaches — not just flags: what a missing setting does, why you might or might not want it, how to set it, and what belongs at project versus user level. A person who has not initialized PJM, whose PJM tree drifted from the current structure, whose root agent instructions lack the OAT context sections, or whose config carries a legacy post-implement sequence value should learn that from one place.
+
+## Acceptance Criteria
+
+- {Outcome 1}
+- {Outcome 2}
+
+## Shape
+
+One skill, `oat-doctor`, rewritten as a collaborative router. It runs a read-only sweep across the areas below, presents the findings grouped by area with severity, and asks where to dive deeper; each dive is a conversation that ends in an offered fix, never an applied one. Unattended invocation (no user-response channel) reports the sweep and stops. No new CLI command: every signal the sweep needs already exists as `--json` output, and the areas that need an apply step route to the skill that owns it. The teaching material is the bundled docs (`cli-utilities/configuration.md`, `config-and-local-state.md`, `workflow-gates.md`, `bootstrap.md`, `backlog-lifecycle.md`) plus `oat config describe`; the skill does not carry a second copy of key descriptions (the current eleven-key fallback list is retired).
+
+## Areas (each a dive)
+
+- **Config** (`oat doctor --json`, `oat config dump`, `oat config describe`, `oat config adopt --help`). Findings: stale `activeProject` / `activeIdea` / `lastPausedProject` pointers; legacy values the CLI still accepts but no longer recommends (for example a string `workflow.postImplement` sequence from `VALID_POST_IMPLEMENT_LEGACY_SEQUENCES` where the structured steps exist; deprecated `explainers.defaults.palette` / `visualProfile` in favor of `style`); keys set at a surface the docs say is the wrong owner (secrets or machine paths in shared config, team policy in local); bundled recommendation templates not yet adopted. Teaching: for every documented key group that is unset, what it does, why one might or might not set it, the command to set it, and which surface (shared, local, user) it belongs on — answered from the docs, with the person's questions answered in the same turn. Fix path: `oat config set` / `unset` / `adopt`, offered with the exact command.
+- **PJM** (`oat pjm doctor --json`). Findings: adoption `absent` / `partial` (offer `oat pjm init`); the twelve `pjm:*` checks surfaced with the fix each implies (`legacy_monoliths`, `loose_reference_files`, `second_roadmap`, the four backlog integrity checks, `template_frontmatter`, `top_level_layout`). Fix path: `oat pjm init`, `oat backlog archive` / `regenerate-index`, `oat decision regenerate-index`, or a pointer to the migration prompt for structural drift.
+- **Agent instructions** (`oat instructions validate --json`, plus a read of the root `AGENTS.md` / `CLAUDE.md`). Findings: sync-strategy drift; missing OAT context sections that `oat tools install --project-guidance` and `oat pjm init` normally write (skills discovery, project management, decision records, the docs section when a docs surface exists); nested instruction files that contradict the root. Fix path: `oat instructions sync`, `oat tools install --project-guidance`, or route to `oat-agent-instructions-analyze` + `-apply` for content quality.
+- **Docs** (existing-docs detection as in `BL-260911-make-docs-bootstrap-a-front`). Findings: a docs surface with no `documentation` config, or docs package drift. Fix path: route to `oat-docs-bootstrap`'s front door; no docs logic lives in the doctor.
+- **Tools** (the existing Steps 1–2, kept): installed packs, outdated skills, sync status.
+
+## Acceptance Criteria
+
+- `oat-doctor` with no arguments runs the read-only sweep over all five areas and prints one grouped report (area, finding, severity, the command or skill that fixes it), then asks which area to dive into; `--summary` keeps today's dashboard.
+- A dive is a conversation: the skill explains each finding and each relevant unset key from the bundled docs (never from a hard-coded list), answers the person's questions, and offers the exact fix command or the owning skill; it applies nothing without explicit approval and never edits config, PJM, instructions, or docs itself except through the named CLI commands the person approves.
+- Every finding names its evidence (the CLI check id or the file:line) and its fix path; a finding with no fix path is reported as informational.
+- Under `OAT_NON_INTERACTIVE=1` or with no user-response channel the sweep report is the whole output.
+- The config dive distinguishes the five surfaces and says, per key group, which surface the docs recommend; a key set on a surface the docs mark as wrong is a finding.
+- The legacy-value list is sourced from the CLI (`config describe` and the config module's legacy tables), not maintained in the skill; a new legacy value in the CLI appears in the doctor without a skill edit, pinned by a contract test.
+- The eleven-key fallback description list in the current skill is removed; when bundled docs are missing the doctor says so and points at `oat tools install core`.
+- `oat-doctor` bumps; the `oat-docs` skill's config-question routing and the `cli-utilities/index.md` page mention the doctor as the place to start; `pnpm check`, `pnpm test:skills`, `pnpm lint`, `pnpm format` green.
+- Reference repos for validation: this repository (adoption `declared`, all `pjm:*` checks passing today), `~/code/vox/pntr` (no `documentation` config, PJM present), and one fresh scratch repo with no `.oat/` at all (every area should offer its bootstrap).
+
+## Out of scope
+
+- A separate `oat-doctor-config` / `oat-doctor-docs` skill family: one router with dives is the operator's preference ("maybe this should all just be one thing"); dives that grow their own apply machinery route to an owning skill instead.
+- New CLI diagnostics: file a follow-up if a dive needs a check the CLI cannot answer today.
+- Auto-fixing anything.
+
+Related: `BL-260911-make-docs-bootstrap-a-front` (the docs dive's target), `BL-260911-support-per-tool-scope`.


### PR DESCRIPTION
One backlog item, **BL-260911-make-oat-doctor** (high): rewrite oat-doctor as a collaborative router that sweeps config, PJM, agent instructions, docs, and tools read-only, presents grouped findings, and dives into an area on request — teaching from the bundled docs (what an unset key does, why you might set it, which surface owns it) and offering the exact fix command or owning skill, never applying anything. Built on the CLI signals that already exist (oat doctor / pjm doctor / config describe / instructions validate --json); no new CLI, no separate doctor-config or doctor-docs skills. Docs dive routes to BL-260911-make-docs-bootstrap-a-front.

https://claude.ai/code/session_01UoCrbPXKqdwb41cvzu86XZ